### PR TITLE
try to import discid if DiscID not exist

### DIFF
--- a/src/source/audiocd.py
+++ b/src/source/audiocd.py
@@ -31,7 +31,10 @@ from helper import Dispatcher
 from player import Player
 from song import Song
 
-import DiscID
+try:
+    import DiscID
+except:
+    import discid as DiscID
 
 
 class CDDBInfo(object):


### PR DESCRIPTION
As in fedora 20 it seems that the module name is discid rather than DiscID
