### PR TITLE
Included artist name in search box results

### DIFF
--- a/music-player/view/widget/searchedit.cpp
+++ b/music-player/view/widget/searchedit.cpp
@@ -121,7 +121,16 @@ void SearchEdit::onTextChanged()
         QStringList hashList;
 
         for (auto &meta : resultList) {
-            titleList << meta->title;
+            QString artist = meta->artist.trimmed();
+            if ( !artist.isEmpty() )
+            {
+                titleList << QString("%0 - %1").arg(artist).arg(meta->title);
+            }
+            else
+            {
+                titleList << meta->title;
+            }
+
             hashList << meta->hash;
         }
 


### PR DESCRIPTION
I noticed when using the player that the search results didn't include the artist of the song being searched for, which made it difficult to determine which track to choose when there were multiple with the same name.

In this commit I've added the artist to the beginning of the search result, if the concerned track has one. A fancier way might perhaps be to change the search results item model to support more than one column per result, but I thought the simpler way would be better for now.