### PR TITLE
fix: do init MPRIS first

### DIFF
--- a/src/music-player/musicapp.cpp
+++ b/src/music-player/musicapp.cpp
@@ -124,9 +124,9 @@ void MusicAppPrivate::onDataPrepared()
         this->triggerShortcutAction(optKey);
     });
 
-    presenter->postAction();
-
     initMpris("DeepinMusic");
+
+    presenter->postAction();
 }
 
 void MusicAppPrivate::onQuit()


### PR DESCRIPTION
修复自动播放打开时，启动播放器，播放音乐正常但 MPRIS 信息未能成功初始化的问题。

原因是自动播放是先进行的， MPRIS 是在其后进行的初始化（并连接了相应信号和槽），于是播放时的信号没能成功与槽关联导致没有初始化 MPRIS 数据。

https://tower.im/teams/9487/todos/232998/