### PR TITLE
fix: no longer build netease meta search plugin

### DIFF
--- a/src/plugin/plugin.pro
+++ b/src/plugin/plugin.pro
@@ -1,2 +1,2 @@
 TEMPLATE    = subdirs
-SUBDIRS     += netease-meta-search
+#SUBDIRS     += netease-meta-search


### PR DESCRIPTION
这个其实还不如拆单独插件的包...