### PR TITLE
perf: launch speed under loongson

### DIFF
--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -122,7 +122,12 @@ int main(int argc, char *argv[])
     MusicApp *music = new MusicApp(&mainframe);
     music->init();
 
-    Player::instance()->init();
+    // blumia: init player *after* window shows up. It's vary dirty but can make deepin-music
+    //         launch time 100% faster on loongson.
+    QTimer::singleShot(10, [](){
+        Player::instance()->init();
+    });
+
     if (!toOpenFile.isEmpty()) {
         auto fi = QFileInfo(toOpenFile);
         auto url = QUrl::fromLocalFile(fi.absoluteFilePath());


### PR DESCRIPTION
龙芯（+ssd）上启动从四秒到两秒左右，把player的初始化放到窗口显示之后来做了，不过显示之后依然会做这个加载，用户实际交互依然是大概自运行起四秒左右，只是窗口能更快的显示出来了。