### PR TITLE
fix: init music app connection after init player

### DIFF
--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -87,6 +87,24 @@ int main(int argc, char *argv[])
     app.setApplicationDisplayName(QObject::tr("Deepin Music"));
     app.setWindowIcon(QIcon(":/common/image/deepin-music.svg"));
 
+    MusicSettings::init();
+
+    // set theme
+    qDebug() << "TRACE:" << "set theme";
+    auto theme = MusicSettings::value("base.play.theme").toString();
+//    auto themePrefix = AppSettings::instance()->value("base.play.theme_prefix").toString();
+//    DThemeManager::instance()->setPrefix(themePrefix);
+    DThemeManager::instance()->setTheme(theme);
+
+    // DMainWindow must create on main function, so it can deconstruction before QApplication
+    MainFrame mainframe;
+    MusicApp *music = new MusicApp(&mainframe);
+    music->initUI();
+
+    Player::instance()->init();
+
+    music->initConnection();
+
     if (!app.setSingleInstance("deepinmusic")) {
         qDebug() << "another deepin music has started";
         if (!toOpenFile.isEmpty()) {
@@ -108,21 +126,6 @@ int main(int argc, char *argv[])
         exit(0);
     }
 
-    MusicSettings::init();
-
-    // set theme
-    qDebug() << "TRACE:" << "set theme";
-    auto theme = MusicSettings::value("base.play.theme").toString();
-//    auto themePrefix = AppSettings::instance()->value("base.play.theme_prefix").toString();
-//    DThemeManager::instance()->setPrefix(themePrefix);
-    DThemeManager::instance()->setTheme(theme);
-
-    // DMainWindow must create on main function, so it can deconstruction before QApplication
-    MainFrame mainframe;
-    MusicApp *music = new MusicApp(&mainframe);
-    music->init();
-
-    Player::instance()->init();
     if (!toOpenFile.isEmpty()) {
         auto fi = QFileInfo(toOpenFile);
         auto url = QUrl::fromLocalFile(fi.absoluteFilePath());

--- a/src/music-player/musicapp.cpp
+++ b/src/music-player/musicapp.cpp
@@ -243,7 +243,7 @@ void MusicApp::quit()
     qApp->quit();
 }
 
-void MusicApp::init()
+void MusicApp::initUI()
 {
     Q_D(MusicApp);
 
@@ -253,6 +253,11 @@ void MusicApp::init()
     qDebug() << "TRACE:" << "create MainFrame";
 //    d->playerFrame->initUI(0 != mediaCount);
     show();
+}
+
+void MusicApp::initConnection()
+{
+    Q_D(MusicApp);
 
     qDebug() << "TRACE:" << "create Presenter";
     d->presenter = new Presenter;

--- a/src/music-player/musicapp.h
+++ b/src/music-player/musicapp.h
@@ -35,7 +35,8 @@ public:
     MusicApp(MainFrame* frame, QObject *parent = nullptr);
     ~MusicApp();
 
-    void init();
+    void initUI();
+    void initConnection();
     void show();
     void quit();
 


### PR DESCRIPTION
上个提交调整顺序引入了双击播放文件无法正常播放的bug（初始化顺序导致的信号没连上），这个提交可以修复这个问题，并且应该可以再改善一点启动速度（