### PR TITLE
[FEATURE] Add MPRIS Artwork handling

### DIFF
--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -728,8 +728,6 @@ void Player::setMuted(bool mute)
     MusicSettings::setOption("base.play.mute", mute);
 }
 
-#include <iostream>
-
 void Player::setActiveMeta(const MediaMeta &meta)
 {
     m_ActiveMeta = meta;

--- a/src/music-player/core/util/global.cpp
+++ b/src/music-player/core/util/global.cpp
@@ -24,12 +24,18 @@
 #include <QCoreApplication>
 #include <DStandardPaths>
 
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <iostream>
+
 DCORE_USE_NAMESPACE;
 QString appName;
+static QString imagePushFilePath = "/tmp/deepin-music/cover.jpg";
+
 QString Global::configPath()
 {
-    auto userConfigPath = DStandardPaths::standardLocations(QStandardPaths::AppConfigLocation).value(0);
-    return userConfigPath;
+    return DStandardPaths::standardLocations(QStandardPaths::AppConfigLocation).value(0);
 }
 
 QString Global::cacheDir()
@@ -48,3 +54,60 @@ QString Global::getAppName()
     return appName;
 }
 
+#define RECURSION_LIMIT 5
+
+static int recursion = 0;
+static bool firstTime = true;
+bool isPending = false; //Used in slotMediaMetaChanged(...) signal
+
+QString Global::imagePushed(QFile &src)
+{
+    QFileInfo info(imagePushFilePath);
+    if ((!info.exists() | !info.isWritable()) && firstTime == false && recursion<RECURSION_LIMIT) {
+        QString path = imagePushFilePath.remove(info.fileName());
+        path.chop(1);
+        path += "_/cover.jpg";
+        imagePushFilePath = path;
+        QDir().mkdir(path);
+        recursion++;
+        return imagePushed(src);
+    } else {
+        if (firstTime) {
+            firstTime = false;
+            //So create the dir first.
+            if (!QDir().mkdir("/tmp/deepin-music")) {
+                return imagePushed(src);
+            }
+        }
+        QFile f(imagePushFilePath);
+        if (f.open(QIODevice::OpenModeFlag::Truncate | QIODevice::OpenModeFlag::WriteOnly)) {
+            //SRC file checks, else abort OP
+            if (!src.isOpen()) {
+                if (!src.open(QIODevice::OpenModeFlag::ReadOnly)) {
+                    return "";
+                }
+            }
+            if (src.isReadable()) {
+                f.write(src.readAll(), src.size());
+                f.flush();
+                f.close();
+                recursion = 0;
+                std::cout << "File saved." << std::endl;
+                return imagePushFilePath;
+            }
+            return "";
+        } else if (recursion<RECURSION_LIMIT) {//We can remove it as at a time it'll for sure find a good path to use
+            //Maybe an error we haven't caught.
+            QString path = imagePushFilePath.remove(info.fileName());
+            path.chop(1);
+            path += "_/cover.jpg";
+            imagePushFilePath = path;
+            QDir().mkdir(path);
+            recursion++;
+            return imagePushed(src);
+        } else {
+            recursion = 0;
+            return "";
+        }
+    }
+}

--- a/src/music-player/core/util/global.cpp
+++ b/src/music-player/core/util/global.cpp
@@ -27,15 +27,20 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <iostream>
+
+#define RECURSION_LIMIT 5
 
 DCORE_USE_NAMESPACE;
 QString appName;
+
+static int recursion = 0;
+static bool firstTime = true;
 static QString imagePushFilePath = "/tmp/deepin-music/cover.jpg";
 
 QString Global::configPath()
 {
-    return DStandardPaths::standardLocations(QStandardPaths::AppConfigLocation).value(0);
+    auto userConfigPath = DStandardPaths::standardLocations(QStandardPaths::AppConfigLocation).value(0);
+    return userConfigPath;
 }
 
 QString Global::cacheDir()
@@ -53,12 +58,6 @@ QString Global::getAppName()
 {
     return appName;
 }
-
-#define RECURSION_LIMIT 5
-
-static int recursion = 0;
-static bool firstTime = true;
-bool isPending = false; //Used in slotMediaMetaChanged(...) signal
 
 QString Global::imagePushed(QFile &src)
 {
@@ -92,7 +91,6 @@ QString Global::imagePushed(QFile &src)
                 f.flush();
                 f.close();
                 recursion = 0;
-                std::cout << "File saved." << std::endl;
                 return imagePushFilePath;
             }
             return "";

--- a/src/music-player/core/util/global.h
+++ b/src/music-player/core/util/global.h
@@ -23,6 +23,8 @@
 
 #include <QString>
 
+class QFile;
+
 class Global
 {
 public:
@@ -30,4 +32,11 @@ public:
     static QString cacheDir();
     static void setAppName(QString name);
     static QString getAppName();
+
+    /**
+     * @brief Saves src file to a local file with automatic FP resolution to ensure we can read and write on it. Use it for artworks.
+     * @param src
+     * @return
+     */
+    static QString imagePushed(QFile &src);
 };


### PR DESCRIPTION
I seen while using the DMPRISControl, the artwork was not loaded. After few researches, I added support for artwork in Deepin Music.
Here are the steps:
1. Get a valid file path for the artwork, a local file
2. Copy the artwork data to the file
3. Set the mpris:artUrl field to our filepath in the metadata that is pushed to the MPRIS DBus interface

Player::playMeta(MediaMeta meta) function have been modified to enable artwork URL handling when user select a new sound. The old version was not able to do such due to my implementation but the function call Global::imagePushed(QFile &src) can be moved to have less changes.

