### PR TITLE
使用正则重写lrc解析，更正拼写错误

### DIFF
--- a/src/music-player/core/util/musiclyric.h
+++ b/src/music-player/core/util/musiclyric.h
@@ -28,18 +28,19 @@ class MusicLyric
 {
 public:
     MusicLyric();
+    void parseLyric(const QString& str);
     void getFromFile(QString dir);
     //void getFromFileOld(QString dir);
     QString getLineAt(int index);
     int getCount() const;
     int getIndex(qint64 pos);
-    qint64 getPostion(int index);
+    qint64 getPosition(int index);
     //bool getHeadFromFile(QString dir);
 
 private:
     QString filedir;
     double offset;
-    QVector<qint64> postion;
+    QVector<qint64> position;
     QVector<QString> line;
 };
 

--- a/src/music-player/widget/lrc/lyriclabel.cpp
+++ b/src/music-player/widget/lrc/lyriclabel.cpp
@@ -200,7 +200,7 @@ void LyricLabel::setThemeType(int type)
 
 void LyricLabel::changeToEvent(int index)
 {
-    emit changeTo(lyric.getPostion(index));
+    emit changeTo(lyric.getPosition(index));
 }
 
 //void LyricLabel::changeFont()


### PR DESCRIPTION
看到注释部分要用正则重写lrc文件解析，按要求写了。
抽象出parseLyric方法以方便网络下载等来源的歌词解析使用。
更正position拼写错误（强迫症）。
望采纳