### PR TITLE
Fix build on x86_64: add fPIC option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
+set(CMAKE_C_FLAGS "-fPIC")
+set(CMAKE_CXX_FLAGS "-fPIC")
 
 option(USE_DXCB "integration with dxcb platform plugin" OFF)
 option(DMR_DEBUG "turn on debug output" off)


### PR DESCRIPTION
Fix https://github.com/linuxdeepin/developer-center/issues/2232