### PR TITLE
fix: 专辑和演唱者列表不支持自定义排序但又支持多选容易让用户疑惑

### DIFF
--- a/src/music-player/listView/albumList/albumlistview.cpp
+++ b/src/music-player/listView/albumList/albumlistview.cpp
@@ -132,7 +132,7 @@ AlbumListView::AlbumListView(const QString &hash, QWidget *parent)
 // 双击逻辑位置移动
 //    connect(this, &AlbumListView::doubleClicked, this, &AlbumListView::onDoubleClicked);
 
-    setSelectionMode(QListView::ExtendedSelection);
+    setSelectionMode(QListView::SingleSelection);
     setSelectionBehavior(QAbstractItemView::SelectRows);
 
     connect(DataBaseService::getInstance(), &DataBaseService::signalCoverUpdate,

--- a/src/music-player/listView/singerList/singerlistview.cpp
+++ b/src/music-player/listView/singerList/singerlistview.cpp
@@ -134,7 +134,7 @@ SingerListView::SingerListView(const QString &hash, QWidget *parent)
 // 双击逻辑位置移动
 //    connect(this, &SingerListView::doubleClicked, this, &SingerListView::onDoubleClicked);
 
-    setSelectionMode(QListView::ExtendedSelection);
+    setSelectionMode(QListView::SingleSelection);
     setSelectionBehavior(QAbstractItemView::SelectRows);
 
     connect(DataBaseService::getInstance(), &DataBaseService::signalCoverUpdate,


### PR DESCRIPTION
设置专辑、演唱者一级列表只能单选

Log: 取消专辑、演唱者一级列表的多选能力
Bug: https://pms.uniontech.com/bug-view-112583.html
/review @lzwind