### PR TITLE
fix: 音乐每次启动的时候所有音乐均显示为15首歌曲

### DIFF
--- a/src/music-player/mainFrame/musiclistdatawidget.cpp
+++ b/src/music-player/mainFrame/musiclistdatawidget.cpp
@@ -119,6 +119,7 @@ void MusicListDataWidget::initInfoLabel(QString hash)
             countStr = QString("   ") + MusicListDataWidget::tr("%1 songs").arg(songCount);
         }
     }
+    m_countStr = countStr;
     m_infoLabel->setText(countStr);
 }
 
@@ -514,7 +515,12 @@ void MusicListDataWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
     m_lableWidget->setGeometry(m_actionBar->geometry());
-    refreshInfoLabel(m_currentHash);
+
+    QFontMetrics m_titleLabelFontMetrics(m_titleLabel->font());
+    int width = m_actionBar->width() / 2 - 20 - m_btPlayAll->width() - m_titleLabelFontMetrics.width(m_titleLabel->text()) / 2;
+    QFontMetrics font(m_infoLabel->font());
+    QString countStr = font.elidedText(m_countStr, Qt::ElideRight, width);
+    m_infoLabel->setText(countStr);
 }
 
 // 大标题跟随size变化
@@ -1096,6 +1102,7 @@ void MusicListDataWidget::refreshInfoLabel(QString hash)
         }
     }
 
+    m_countStr = countStr;
     // 文本太长显示...
     QFontMetrics m_titleLabelFontMetrics(m_titleLabel->font());
     int width = m_actionBar->width() / 2 - 20 - m_btPlayAll->width() - m_titleLabelFontMetrics.width(m_titleLabel->text()) / 2;

--- a/src/music-player/mainFrame/musiclistdatawidget.h
+++ b/src/music-player/mainFrame/musiclistdatawidget.h
@@ -126,6 +126,7 @@ private:
     QString             m_currentHash;
     ListPageSwitchType  m_preSwitchtype            = AllSongListType;
     QString             m_preHash                  = "all";//记录前一次显示，当清除搜索时回到上一页面
+    QString             m_countStr;
 };
 
 class ActionBar : public DWidget


### PR DESCRIPTION
启动延迟未刷新歌曲数目

Log: 音乐每次启动歌曲数目正常
Bug: https://pms.uniontech.com/bug-view-123073.html
/review @lzwind