### PR TITLE
fix: 演唱者或专辑页面详情页面播放任意歌曲后暂停然后删除歌曲后继续播放的歌曲为删除掉的歌曲

### DIFF
--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -280,6 +280,11 @@ void Player::resume()
         Player::getInstance()->forcePlayMeta();//播放列表第一首歌
         return;
     }
+    // 播放歌曲与当前歌曲不一致
+    if (m_basePlayer->getMediaMeta().hash != m_ActiveMeta.hash) {
+        playMeta(m_ActiveMeta);
+        return;
+    }
 
     bool empty = QFileInfo(m_ActiveMeta.localPath).dir().path().isEmpty();
     if (empty && m_ActiveMeta.mmType != MIMETYPE_CDA) {//光盘弹出时，有可能歌曲路径还在，不需要再播放。

--- a/src/music-player/core/playerbase.h
+++ b/src/music-player/core/playerbase.h
@@ -52,6 +52,7 @@ public:
     virtual void release() = 0;
 
 public:
+    MediaMeta getMediaMeta() {return m_activeMeta;}
     virtual void initCddaTrack() {}
     virtual QList<MediaMeta> getCdaMetaInfo() {return QList<MediaMeta>();}
 


### PR DESCRIPTION
暂停时未将歌曲设置到播放器

Log: 播放演唱者或专辑歌曲正常
Bug: https://pms.uniontech.com/bug-view-123303.html
/review @lzwind