### PR TITLE
fix: 切换歌曲时未终止上一首歌曲

### DIFF
--- a/src/libdmusic/metadetector.cpp
+++ b/src/libdmusic/metadetector.cpp
@@ -360,15 +360,21 @@ void MetaDetector::getCoverData(const QString &path, const QString &tmpPath, con
 #else
             TagLib::MPEG::File f(path.toStdString().c_str());
 #endif
-            if (f.ID3v2Tag() != nullptr) {
-                TagLib::ID3v2::FrameList frameList = f.ID3v2Tag()->frameListMap()["APIC"];
-                if (!frameList.isEmpty()) {
-                    TagLib::ID3v2::AttachedPictureFrame *picFrame = static_cast<TagLib::ID3v2::AttachedPictureFrame *>(frameList.front());
-                    QBuffer buffer;
-                    buffer.setData(picFrame->picture().data(), static_cast<int>(picFrame->picture().size()));
-                    QImageReader imageReader(&buffer);
-                    image = imageReader.read();
+            // 检查音乐文件
+            if (f.isValid()) {
+                // 音乐文件不一定存在ID3v2Tag
+                if (f.ID3v2Tag() != nullptr) {
+                    TagLib::ID3v2::FrameList frameList = f.ID3v2Tag()->frameListMap()["APIC"];
+                    if (!frameList.isEmpty()) {
+                        TagLib::ID3v2::AttachedPictureFrame *picFrame = static_cast<TagLib::ID3v2::AttachedPictureFrame *>(frameList.front());
+                        QBuffer buffer;
+                        buffer.setData(picFrame->picture().data(), static_cast<int>(picFrame->picture().size()));
+                        QImageReader imageReader(&buffer);
+                        image = imageReader.read();
+                    }
                 }
+
+                f.clear();
             }
         }
 
@@ -418,21 +424,24 @@ QPixmap MetaDetector::getCoverDataPixmap(MediaMeta meta, int engineType)
 #else
         TagLib::MPEG::File f(meta.localPath.toStdString().c_str());
 #endif
-        // 音乐文件不一定存在ID3v2Tag
-        if (f.ID3v2Tag()) {
-            TagLib::ID3v2::FrameList frameList = f.ID3v2Tag()->frameListMap()["APIC"];
-            if (!frameList.isEmpty()) {
-                TagLib::ID3v2::AttachedPictureFrame *picFrame = static_cast<TagLib::ID3v2::AttachedPictureFrame *>(frameList.front());
-                QImage image;
-                QBuffer buffer;
-                buffer.setData(picFrame->picture().data(), static_cast<int>(picFrame->picture().size()));
-                QImageReader imageReader(&buffer);
-                image = imageReader.read();
-                pixmap = QPixmap::fromImage(image);
+        // 检查音乐文件
+        if (f.isValid()) {
+            // 音乐文件不一定存在ID3v2Tag
+            if (f.ID3v2Tag()) {
+                TagLib::ID3v2::FrameList frameList = f.ID3v2Tag()->frameListMap()["APIC"];
+                if (!frameList.isEmpty()) {
+                    TagLib::ID3v2::AttachedPictureFrame *picFrame = static_cast<TagLib::ID3v2::AttachedPictureFrame *>(frameList.front());
+                    QImage image;
+                    QBuffer buffer;
+                    buffer.setData(picFrame->picture().data(), static_cast<int>(picFrame->picture().size()));
+                    QImageReader imageReader(&buffer);
+                    image = imageReader.read();
+                    pixmap = QPixmap::fromImage(image);
+                }
             }
-        }
 
-        f.clear();
+            f.clear();
+        }
     }
 
     return pixmap;

--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -438,6 +438,7 @@ void Player::playNextMeta(bool isAuto)
                 break;
             }
         }
+
         if (index == -1 && !m_ActiveMeta.hash.isEmpty()) {
             for (int i = 0; i < m_MetaList.size(); i++) {
                 if (m_MetaList.at(i).hash == m_ActiveMeta.hash) {
@@ -447,7 +448,7 @@ void Player::playNextMeta(bool isAuto)
             }
             if (index != -1) {
                 for (int i = 0; i < curMetaList.size(); i++) {
-                    if (curMetaList.at(i).first > index && i > 0) {
+                    if (curMetaList.at(i).first > index && i >= 0) {
                         index = i - 1;
                         break;
                     }
@@ -509,7 +510,10 @@ void Player::playNextMeta(bool isAuto)
             break;
         }
         }
-        m_ActiveMeta = curMetaList.at(index == -1 ? 0 : index).second;
+
+        index = (index == -1 ? 0 : index);
+        index = (index >= curMetaList.size() ? 0 : index);
+        m_ActiveMeta = curMetaList.at(index).second;
         playMeta(m_ActiveMeta);
     } else {
         stop();

--- a/src/music-player/core/playerbase.h
+++ b/src/music-player/core/playerbase.h
@@ -74,7 +74,7 @@ public:
     virtual void loadFromPreset(uint index) {Q_UNUSED(index);}
     virtual void setPreamplification(float value) {Q_UNUSED(value);}
     virtual void setAmplificationForBandAt(float amp, uint bandIndex) {Q_UNUSED(amp); Q_UNUSED(bandIndex);}
-    virtual float amplificationForBandAt(uint bandIndex) {Q_UNUSED(bandIndex);}
+    virtual float amplificationForBandAt(uint bandIndex) {Q_UNUSED(bandIndex); return 1.0;}
     virtual float preamplification() {return 1.0;}
 
 signals:

--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -112,8 +112,12 @@ void QtPlayer::pause()
 
 void QtPlayer::stop()
 {
-    if (m_mediaPlayer != nullptr && m_mediaPlayer->state() == QMediaPlayer::PlayingState)
+    // 播放和状态状态都可以停止播放
+    if (m_mediaPlayer != nullptr && (m_mediaPlayer->state() == QMediaPlayer::State::PlayingState
+                                     || m_mediaPlayer->state() == QMediaPlayer::State::PausedState)) {
         m_mediaPlayer->stop();
+    }
+
 }
 
 int QtPlayer::length()

--- a/src/music-player/listView/musicInfoList/playlistview.cpp
+++ b/src/music-player/listView/musicInfoList/playlistview.cpp
@@ -581,10 +581,7 @@ void PlayListView::showErrorDlg()
     warnDlg.setTitle(tr("File is invalid or does not exist, load failed"));
     warnDlg.addButtons(QStringList() << tr("OK"));
     warnDlg.setDefaultButton(0);
-    if (0 == warnDlg.exec()) {
-        //播放下一首
-        Player::getInstance()->playNextMeta(true);
-    }
+    warnDlg.exec();
 }
 
 int PlayListView::getMusicCount()
@@ -694,8 +691,8 @@ void PlayListView::slotOnDoubleClicked(const QModelIndex &index)
     } else {
         if (!Player::getInstance()->supportedSuffixStrList().contains(fileSuffix.toLower()))
             emit CommonService::getInstance()->signalDecodingErrorMessage();
-        playMusic(itemMeta);
     }
+    playMusic(itemMeta);
 }
 
 void PlayListView::slotLoadData()


### PR DESCRIPTION
切换歌曲时终止上一首歌曲并重新计算下一首索引

Log: 切换歌曲正常
Bug: https://pms.uniontech.com/bug-view-122595.html,https://pms.uniontech.com/bug-view-122845.html,https://pms.uniontech.com/bug-view-122897.html,https://pms.uniontech.com/bug-view-122913.html
/review @lzwind