### PR TITLE
fix: 添加不支持的歌曲时提示框弹出时间较长

### DIFF
--- a/src/music-player/core/vlc/Instance.cpp
+++ b/src/music-player/core/vlc/Instance.cpp
@@ -121,6 +121,10 @@ VlcInstance::~VlcInstance()
     if (_vlcInstance) {
         vlc_release_function vlc_release = (vlc_release_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSymbol("libvlc_release");
         vlc_release(_vlcInstance);
+
+        vlc_release_function vlc_free = (vlc_release_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSymbol("libvlc_free");
+        vlc_free(_vlcInstance);
+        _vlcInstance = nullptr;
     }
 }
 

--- a/src/music-player/core/vlcplayer.cpp
+++ b/src/music-player/core/vlcplayer.cpp
@@ -103,6 +103,10 @@ void VlcPlayer::releasePlayer()
         delete m_qvplayer;
         m_qvplayer = nullptr;
     }
+    if (m_qvinstance) {
+        delete m_qvinstance;
+        m_qvinstance = nullptr;
+    }
 }
 
 void VlcPlayer::release()

--- a/src/music-player/presenter/dboperate.cpp
+++ b/src/music-player/presenter/dboperate.cpp
@@ -207,10 +207,11 @@ void DBOperate::slotCreatCoverImg(const QList<MediaMeta> &metas)
             m_needSleep = false;
         }
         //没有加载过的文件才去解析数据
-
         QFileInfo coverInfo(Global::cacheDir() + "/images/" + meta.hash + ".jpg");
         if (!coverInfo.exists()) {
-            meta.getCoverData(Global::cacheDir(), Global::playbackEngineType());
+            //taglib无法解析mp3格式之外的音频封面，所以需要在这里进行选择性过滤
+            if (Global::playbackEngineType() == 1 || QFileInfo(meta.localPath).suffix().contains("mp3", Qt::CaseInsensitive))
+                meta.getCoverData(Global::cacheDir(), Global::playbackEngineType());
         }
         emit sigCreatOneCoverImg(meta);
     }

--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -2,6 +2,7 @@
 export QT_QPA_PLATFORM='offscreen'
 QTEST_FUNCTION_TIMEOUT='800000'
 rm -rf ${HOME}/.cache/deepin/deepin-music/*
+rm -rf ${HOME}/.config/deepin/deepin-music/*
 rm -rf build
 mkdir build
 cd build


### PR DESCRIPTION
 添加不支持的歌曲时提示框弹出时间较长

Log: 添加不支持的歌曲时提示框弹出时间较长
Bug: https://pms.uniontech.com/bug-view-122953.html
     https://pms.uniontech.com/bug-view-123071.html
