### PR TITLE
fix: 在演唱者的平铺模式下放歌左侧音乐库的动画效果展示在专辑栏上

### DIFF
--- a/src/music-player/listView/singerList/singerdelegate.cpp
+++ b/src/music-player/listView/singerList/singerdelegate.cpp
@@ -657,7 +657,7 @@ void SingerDataDelegate::mouseClicked(const QStyleOptionViewItem &option, const 
         if (fillPolygon.containsPoint(pressPos, Qt::OddEvenFill)) {
             if (singertmp.musicinfos.values().size() > 0) {
                 emit CommonService::getInstance()->signalSetPlayModel(Player::RepeatAll);
-                Player::getInstance()->setCurrentPlayListHash("album", false);
+                Player::getInstance()->setCurrentPlayListHash("artist", false);
                 Player::getInstance()->setPlayList(singertmp.musicinfos.values());
                 Player::getInstance()->playMeta(singertmp.musicinfos.values().first());
                 emit Player::getInstance()->signalPlayListChanged();


### PR DESCRIPTION
平铺模式下放歌时设置当前播放列表为专辑

Log: 平铺模式下放歌正常
/review @lzwind