### PR TITLE
fix: 在文官中打开歌曲后无法触发均衡器效果

### DIFF
--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -454,16 +454,16 @@ void MainFrame::autoStartToPlay()
     if (lastListPageSwitchType != AllSongListType)
         emit CommonService::getInstance()->signalSwitchToView(lastListPageSwitchType, lastplaypage);
     Player::getInstance()->reloadMetaList();
+    //读取均衡器使能开关配置
+    auto eqSwitch = MusicSettings::value("equalizer.all.switch").toBool();
+    if (eqSwitch) {
+        Player::getInstance()->initEqualizerCfg();
+    }
     if (!strOpenPath.isEmpty()) {
         //通知设置当前页面
         Player::getInstance()->setCurrentPlayListHash(lastplaypage, false);
         Player::getInstance()->init();
         return ;
-    }
-    //读取均衡器使能开关配置
-    auto eqSwitch = MusicSettings::value("equalizer.all.switch").toBool();
-    if (eqSwitch) {
-        Player::getInstance()->initEqualizerCfg();
     }
     auto lastMeta = MusicSettings::value("base.play.last_meta").toString();
     if (!lastMeta.isEmpty()) {


### PR DESCRIPTION
直接打开文件时未进行设置均衡器

Log: 均衡器效果正常
Bug: https://pms.uniontech.com/bug-view-124511.html
/review @lzwind