### PR TITLE
fix: 删除所有歌曲时，右键点击左侧音乐库任意项时，删除的滚动效果就消失了

### DIFF
--- a/src/music-player/presenter/databaseservice.cpp
+++ b/src/music-player/presenter/databaseservice.cpp
@@ -204,7 +204,7 @@ QList<MediaMeta> DataBaseService::getMusicInfosBySortAndCount(int count)
 QList<MediaMeta> DataBaseService::allMusicInfos(bool refresh)
 {
     // 防止重复查询数据库
-    if (!refresh || m_AllMediaMeta.size() == allDBMusicInfosCount()) {
+    if (!refresh || m_deleting || m_AllMediaMeta.size() == allDBMusicInfosCount()) {
         return m_AllMediaMeta;
     } else {
         m_AllMediaMeta.clear();


### PR DESCRIPTION
 删除所有歌曲时，右键点击左侧音乐库任意项时，删除的滚动效果就消失了

Log: 删除所有歌曲时，右键点击左侧音乐库任意项时，删除的滚动效果就消失了
Bug: https://pms.uniontech.com/bug-view-122967.html