### PR TITLE
fix: 遇到歌曲本身有问题的歌曲音乐不会自动跳过

### DIFF
--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -182,7 +182,8 @@ void QtPlayer::setMute(bool value)
 
 void QtPlayer::onMediaStatusChanged(QMediaPlayer::MediaStatus status)
 {
-    if (status == QMediaPlayer::MediaStatus::EndOfMedia) {
+    // 过滤无效音乐文件
+    if (status == QMediaPlayer::MediaStatus::EndOfMedia || status == QMediaPlayer::MediaStatus::InvalidMedia) {
         emit end();
     }
 }


### PR DESCRIPTION
跳过播放无效音乐文件

Log: 正常跳过无效音乐文件
Bug: https://pms.uniontech.com/bug-view-122845.html
/review @lzwind