### PR TITLE
fix: 在文管中选中点击打开调起音乐后所有音乐界面展示歌曲数量错误

### DIFF
--- a/src/music-player/mainFrame/musiclistdatawidget.cpp
+++ b/src/music-player/mainFrame/musiclistdatawidget.cpp
@@ -80,6 +80,9 @@ MusicListDataWidget::MusicListDataWidget(QWidget *parent) :
     // 导入时刷新leble
     connect(m_musicListView, &PlayListView::signalRefreshInfoLabel, this, &MusicListDataWidget::refreshInfoLabel);
     connect(m_musicListView, &PlayListView::signalRefreshInfoLabel, this, &MusicListDataWidget::refreshSortAction);
+    connect(CommonService::getInstance(), &CommonService::loadData, this, [ = ]() {
+        refreshInfoLabel("all");
+    }, Qt::QueuedConnection);
 }
 
 MusicListDataWidget::~MusicListDataWidget()


### PR DESCRIPTION
延迟加载后重新刷新歌曲数目

Log: 外部打开音乐歌曲显示正常
Bug: https://pms.uniontech.com/bug-view-125431.html
/review @lzwind