### PR TITLE
fix: 托盘音乐图标点击多次后无法唤起音乐窗口

### DIFF
--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -388,7 +388,7 @@ void MainFrame::initMenuAndShortcut()
     connect(m_sysTrayIcon, &QSystemTrayIcon::activated,
     this, [ = ](QSystemTrayIcon::ActivationReason reason) {
         if (QSystemTrayIcon::Trigger == reason) {
-            if (isVisible() && !isMinimized()) {
+            if (checkWindowVisible(Global::isWaylandMode())) {
                 showMinimized();
             } else {
                 if (!isVisible()) {
@@ -427,6 +427,35 @@ void MainFrame::initPadMenu()
     m_titlebar->setMenu(pTitleMenu);
 
     connect(pTitleMenu, SIGNAL(triggered(QAction *)), this, SLOT(slotMenuTriggered(QAction *)));
+}
+
+bool MainFrame::checkWindowVisible(bool waylandMode)
+{
+    if (waylandMode) {
+        QVariant v = DBusUtils::readDBusProperty("com.deepin.dde.daemon.Dock", "/com/deepin/dde/daemon/Dock",
+                                                 "com.deepin.dde.daemon.Dock", "Entries");
+
+        if (!v.isValid()) return false;
+
+        QList<QDBusObjectPath> allSinkInputsList = v.value<QList<QDBusObjectPath> >();
+
+        QString entryPath;
+        for (auto curPath : allSinkInputsList) {
+            QVariant nameV = DBusUtils::readDBusProperty("com.deepin.dde.daemon.Dock", curPath.path(),
+                                                         "com.deepin.dde.daemon.Dock.Entry", "Name");
+            if (!nameV.isValid() || nameV != Global::getAppName()) continue;
+
+            entryPath = curPath.path();
+            break;
+        }
+
+        QVariant isActive = DBusUtils::readDBusProperty("com.deepin.dde.daemon.Dock", entryPath,
+                                                        "com.deepin.dde.daemon.Dock.Entry", "IsActive");
+
+        return isActive.isValid() ? isActive.toBool() : false;
+    } else {
+        return (isVisible() && !isMinimized());
+    }
 }
 
 void MainFrame::autoStartToPlay()

--- a/src/music-player/mainFrame/mainframe.h
+++ b/src/music-player/mainFrame/mainframe.h
@@ -64,6 +64,8 @@ public:
     void initTabletSelectBtn();
     // 初始化平板菜单
     void initPadMenu();
+    // 检查窗口状态
+    bool checkWindowVisible(bool waylandMode);
 public slots:
     // 显示弹窗消息
     void showPopupMessage(const QString &songListName, int selectCount, int insertCount);

--- a/tests/testApplication.cpp
+++ b/tests/testApplication.cpp
@@ -2281,6 +2281,8 @@ TEST(Application, showHide)
     CommonService::getInstance()->setIsTabletEnvironment(true);
 
     MainFrame *w = Application::getInstance()->getMainWindow();
+    w->checkWindowVisible(false);
+    w->checkWindowVisible(true);
     w->showMinimized();
     QTest::qWait(500);
 


### PR DESCRIPTION
窗口显示状态错误

Log: 托盘正常唤起音乐
Bug: https://pms.uniontech.com/bug-view-124509.html
/review @lzwind