### PR TITLE
fix: 终端使用deepin-music加歌曲后，音乐不会播放加的歌曲

### DIFF
--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -120,11 +120,13 @@ int main(int argc, char *argv[])
     if (!OpenFilePaths.isEmpty()) {
         QStringList strList;
         for (QString str : OpenFilePaths) {
-            QUrl url = QUrl(str);
-            if (url.toLocalFile().isEmpty()) {
-                strList.append(str);
-            } else {
-                strList.append(url.toLocalFile());
+            if (QFile::exists(str)) {
+                QUrl url = QUrl::fromLocalFile(QDir::current().absoluteFilePath(str));
+                if (url.toLocalFile().isEmpty()) {
+                    strList.append(str);
+                } else {
+                    strList.append(url.toLocalFile());
+                }
             }
         }
         // 添加应用唯一性判断


### PR DESCRIPTION
 终端使用deepin-music加歌曲后，音乐不会播放加的歌曲

Log: 终端使用deepin-music加歌曲后，音乐不会播放加的歌曲
Bug: https://pms.uniontech.com/bug-view-127339.html