### PR TITLE
fix: 专辑或演唱者详情里面的播放所有与其他地方的播放所有表现不一致

### DIFF
--- a/src/music-player/mainFrame/subsonglistwidget.cpp
+++ b/src/music-player/mainFrame/subsonglistwidget.cpp
@@ -328,6 +328,8 @@ void SubSonglistWidget::slotPlayAllClicked()
 {
     QList<MediaMeta> musicList = m_musicListInfoView->getMusicListData();
     if (musicList.size() > 0) {
+        // 清空播放队列
+        Player::getInstance()->clearPlayList();
         Player::getInstance()->setCurrentPlayListHash(m_hash, false);
         Player::getInstance()->setPlayList(musicList);
         Player::getInstance()->playMeta(musicList.first());


### PR DESCRIPTION
 专辑或演唱者详情里面的播放所有与其他地方的播放所有表现不一致

Log: 专辑或演唱者详情里面的播放所有与其他地方的播放所有表现不一致
Bug: https://pms.uniontech.com/bug-view-127313.html