### PR TITLE
fix: 播放任意搜索的歌曲后，去专辑页面播放任意歌曲后，删除当前专辑中的歌曲，音乐没有继续播放下一首歌曲

### DIFF
--- a/src/music-player/listView/albumList/albumlistview.cpp
+++ b/src/music-player/listView/albumList/albumlistview.cpp
@@ -550,7 +550,7 @@ void AlbumListView::slotAddSingleSong(const QString &listHash, const MediaMeta &
 void AlbumListView::slotRemoveSelectedSongs(const QString &deleteHash, const QStringList &musicHashs, bool removeFromLocal)
 {
     Q_UNUSED(removeFromLocal)
-    if (deleteHash != "album" || Player::getInstance()->getCurrentPlayListHash() != "album") {
+    if (deleteHash != m_hash || Player::getInstance()->getCurrentPlayListHash() != m_hash) {
         return;
     }
     if (musicHashs.size() == 0 || Player::getInstance()->getPlayList()->isEmpty()) {

--- a/src/music-player/listView/albumList/albumlistview.h
+++ b/src/music-player/listView/albumList/albumlistview.h
@@ -113,7 +113,7 @@ private:
     MediaMeta                 hoverinMeta;
     QPixmap                 playingPix = QPixmap(":/texts/music_play1_20px.svg");
 //    MusicListDialog        *musciListDialog = nullptr;
-    QString                 m_hash;
+    QString                 m_hash; //用于区分当前列表是album列表还是搜索中的album列表
     QListView::ViewMode     m_viewModel = QListView::ListMode;
     QIcon                   m_defaultIcon = QIcon::fromTheme("cover_max");
 };

--- a/src/music-player/listView/singerList/singerlistview.cpp
+++ b/src/music-player/listView/singerList/singerlistview.cpp
@@ -674,7 +674,7 @@ void SingerListView::slotRemoveSelectedSongs(const QString &deleteHash, const QS
 {
     Q_UNUSED(removeFromLocal)
     QString curDeleteHash = deleteHash;
-    if (curDeleteHash != "artist" || Player::getInstance()->getCurrentPlayListHash() != "artist") {
+    if (curDeleteHash != m_hash || Player::getInstance()->getCurrentPlayListHash() != m_hash) {
         return;
     }
     if (musicHashs.size() == 0 || Player::getInstance()->getPlayList()->isEmpty()) {

--- a/src/music-player/listView/singerList/singerlistview.h
+++ b/src/music-player/listView/singerList/singerlistview.h
@@ -117,7 +117,7 @@ private:
     SingerDataDelegate      *signerDelegate = nullptr;
 //    MusicListDialog        *musicListDialog = nullptr;
     QPixmap                 playingPix = QPixmap(":/texts/music_play1_20px.svg");
-    QString                  m_hash;
+    QString                  m_hash; //用于区分当前列表是artist列表还是搜索中的artist列表
     QListView::ViewMode      m_viewModel = QListView::ListMode;
     QIcon                   m_defaultIcon = QIcon::fromTheme("cover_max");
 };


### PR DESCRIPTION
 播放任意搜索的歌曲后，去专辑页面播放任意歌曲后，删除当前专辑中的歌曲，音乐没有继续播放下一首歌曲

Log: 播放任意搜索的歌曲后，去专辑页面播放任意歌曲后，删除当前专辑中的歌曲，音乐没有继续播放下一首歌曲
Bug: https://pms.uniontech.com/bug-view-125751.html