### PR TITLE
fix: 使用ffmpeg解码库播放CD，音乐也会显示不支持此编码的提示语

### DIFF
--- a/src/music-player/listView/musicInfoList/playlistview.cpp
+++ b/src/music-player/listView/musicInfoList/playlistview.cpp
@@ -689,7 +689,7 @@ void PlayListView::slotOnDoubleClicked(const QModelIndex &index)
         //弹出提示框
         showErrorDlg();
     } else {
-        if (!Player::getInstance()->supportedSuffixStrList().contains(fileSuffix.toLower()))
+        if ((itemMeta.mmType != MIMETYPE_CDA) && (!Player::getInstance()->supportedSuffixStrList().contains(fileSuffix.toLower())))
             emit CommonService::getInstance()->signalDecodingErrorMessage();
     }
     playMusic(itemMeta);


### PR DESCRIPTION
 使用ffmpeg解码库播放CD，音乐也会显示不支持此编码的提示语

Log: 使用ffmpeg解码库播放CD，音乐也会显示不支持此编码的提示语
Bug: https://pms.uniontech.com/bug-view-125879.html