### PR TITLE
fix: 暂停歌曲后继续播放歌曲会从头开始播放

### DIFF
--- a/src/music-player/core/vlc/Media.cpp
+++ b/src/music-player/core/vlc/Media.cpp
@@ -81,13 +81,13 @@ void VlcMedia::initMedia(const QString &location,
                          bool localFile,
                          VlcInstance *instance, int track)
 {
+    releaseMedia();
+
     _currentLocation = location;
     m_cdaTrackId = track;
     QString path = location;
     if (localFile)
         path = QDir::toNativeSeparators(path);
-
-    releaseMedia();
 
     // Create a new libvlc media descriptor from location
     vlc_media_new_path_function vlc_media_new_path = (vlc_media_new_path_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSymbol("libvlc_media_new_path");


### PR DESCRIPTION
初始化音乐时将当前路径置为空了

Log: 正常播放暂停音乐
Bug: https://pms.uniontech.com/bug-view-129681.html
/review @lzwind 