### PR TITLE
fix: 【AMD, ARM】音乐关闭主窗口时，选择退出，不再询问后，再次退出仍弹窗询问

### DIFF
--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -117,7 +117,6 @@ void QtPlayer::stop()
                                      || m_mediaPlayer->state() == QMediaPlayer::State::PausedState)) {
         m_mediaPlayer->stop();
     }
-
 }
 
 int QtPlayer::length()
@@ -193,6 +192,9 @@ void QtPlayer::onMediaStatusChanged(QMediaPlayer::MediaStatus status)
 void QtPlayer::onPositionChanged(qint64 position)
 {
     init();
+    // 停止播放时，不设置进度
+    if (m_mediaPlayer->duration() <= 0 || m_mediaPlayer->state() != QMediaPlayer::State::PlayingState)
+        return;
     m_currPositionChanged = position;
     float value = static_cast<float>(position) / m_mediaPlayer->duration();
 //    qDebug() << "position" << position << "value" << value;

--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -1138,7 +1138,7 @@ void MainFrame::closeEvent(QCloseEvent *event)
     case 1: {
         MusicSettings::setOption("base.play.state", int(windowState()));
         MusicSettings::setOption("base.close.is_close", true);
-        MusicSettings::release();
+//        MusicSettings::release();
         //退出时,stop当前音乐
         Player::getInstance()->stop(false);
         qApp->processEvents();
@@ -1161,7 +1161,7 @@ void MainFrame::closeEvent(QCloseEvent *event)
         }
         if (ccd.closeAction() == 1) {
             MusicSettings::setOption("base.close.is_close", true);
-            MusicSettings::release();
+//            MusicSettings::release();
             //退出时,stop当前音乐
             Player::getInstance()->stop(false);
             qApp->processEvents();


### PR DESCRIPTION
 【AMD, ARM】音乐关闭主窗口时，选择退出，不再询问后，再次退出仍弹窗询问

Log: 【AMD, ARM】音乐关闭主窗口时，选择退出，不再询问后，再次退出仍弹窗询问
Bug: https://pms.uniontech.com/bug-view-129637.html