### PR TITLE
fix: 窗口特效关闭后音乐的托盘按钮只有第一次能正常唤起音乐

### DIFF
--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -389,14 +389,18 @@ void MainFrame::initMenuAndShortcut()
     this, [ = ](QSystemTrayIcon::ActivationReason reason) {
         if (QSystemTrayIcon::Trigger == reason) {
             if (checkWindowVisible(Global::isWaylandMode())) {
+                m_preMaxFlag = isMaximized();
                 showMinimized();
             } else {
                 if (!isVisible()) {
                     restoreGeometry(m_geometryBa);
                 }
+                show();
+                // 特性关闭后需要使用showNormal/showMaximized
+                if (m_preMaxFlag) showMaximized();
+                else showNormal();
                 // 使用dbus显示窗口
                 this->titlebar()->setFocus();
-                show();
                 raise();
                 activateWindow();
             }
@@ -1146,6 +1150,7 @@ void MainFrame::closeEvent(QCloseEvent *event)
         qApp->aboutDialog()->hide();
     }
     this->setFocus();
+    m_preMaxFlag = isMaximized();
     DMainWindow::closeEvent(event);
 }
 

--- a/src/music-player/mainFrame/mainframe.h
+++ b/src/music-player/mainFrame/mainframe.h
@@ -160,8 +160,9 @@ private:
     QString             m_selectStr;
     QString             m_selectAllStr;
     QString             m_doneStr;
-    bool                m_contentUpByKeyBoard = false;
-    ComDeepinImInterface *m_comDeepinImInterface = nullptr;
+    bool                m_contentUpByKeyBoard     = false;
+    bool                m_preMaxFlag              = false;
+    ComDeepinImInterface *m_comDeepinImInterface  = nullptr;
 };
 
 //extern const QString s_PropertyViewname;


### PR DESCRIPTION
窗口特效关闭后需要使用showNormal/showMaximized

Log: 音乐的托盘唤醒正常
Bug: https://pms.uniontech.com/bug-view-127663.html
/review @lzwind 