### PR TITLE
fix: 使用ffmpeg解码库的时从文管直接双击打开歌曲会使音乐中部分已有的歌曲无法播放

### DIFF
--- a/src/music-player/core/metabufferdetector.cpp
+++ b/src/music-player/core/metabufferdetector.cpp
@@ -250,6 +250,7 @@ void MetaBufferDetector::resample(const QVector<float> &buffer, const QString &h
 
     if (!t_buffer.isEmpty()) {
         auto max = *(std::max_element(std::begin(t_buffer), std::end(t_buffer)));
+        if (max < 1) max = 1.0;
         for (int i = 0; i < t_buffer.size(); ++i) {
             float ft = t_buffer[i] / max;
             ft *= 1000;

--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -112,6 +112,7 @@ int main(int argc, char *argv[])
     }
 
     app->loadTranslator();
+    Global::initPlaybackEngineType();
     MusicSettings::init();
 //    VlcDynamicInstance::VlcFunctionInstance();
 //    Player::getInstance();
@@ -160,7 +161,6 @@ int main(int argc, char *argv[])
     }
 
     DApplicationSettings saveTheme;
-    Global::initPlaybackEngineType();
     Global::checkBoardVendorType();
     /*---Player instance init---*/
     MainFrame mainframe;


### PR DESCRIPTION
双击打开时导入数据时未进行播放器判断

Log: 正常播放歌曲
Bug: https://pms.uniontech.com/bug-view-132843.html
/review @lzwind