### PR TITLE
fix: 歌单重命名时使用delete键不是删除文字是删除歌单

### DIFF
--- a/src/music-player/listView/musicBaseAndSongList/musicsonglistview.cpp
+++ b/src/music-player/listView/musicBaseAndSongList/musicsonglistview.cpp
@@ -647,7 +647,8 @@ void MusicSongListView::resizeEvent(QResizeEvent *event)
 
 void MusicSongListView::keyReleaseEvent(QKeyEvent *event)
 {
-    if (event->key() == Qt::Key_Delete) {
+    // 重命名时不删除操作
+    if (event->key() == Qt::Key_Delete && (m_renameLineEdit == nullptr || !m_renameLineEdit->isVisible())) {
         rmvSongList();
     }
     DListView::keyReleaseEvent(event);


### PR DESCRIPTION
添加重命名不删除操作

Log: 重命名不删除歌单
Bug: https://pms.uniontech.com/bug-view-137279.html
/review @pengfeixx 