### PR TITLE
fix: 在文管中双击打开歌曲后音乐中显示歌曲增加2

### DIFF
--- a/src/music-player/listView/musicInfoList/playlistview.cpp
+++ b/src/music-player/listView/musicInfoList/playlistview.cpp
@@ -702,6 +702,11 @@ void PlayListView::slotLoadData()
     // 排序
     sortList(mediaMetas, sortType);
 
+    // 直接打开重复添加歌曲
+    for (int i = FirstLoadCount; i < m_model->rowCount(); ++i) {
+        m_model->removeRow(i);
+    }
+
     QList<MediaMeta> preMediaMetas = DataBaseService::getInstance()->getMusicInfosBySortAndCount(FirstLoadCount);
     for (int i = 0; i < mediaMetas.size(); i++) {
         //防止重复添加


### PR DESCRIPTION
延迟加载时取消重复加载相同歌曲

Log: 文官打开歌曲显示歌曲数目正常
Bug: https://pms.uniontech.com/bug-view-135241.html
/review @pengfeixx 