### PR TITLE
fix: 双击播放歌曲，工具栏无法展示歌曲图片

### DIFF
--- a/src/music-player/listView/musicInfoList/playlistview.cpp
+++ b/src/music-player/listView/musicInfoList/playlistview.cpp
@@ -1431,8 +1431,8 @@ QPixmap PlayListView::dragItemsPixmap()
     qreal scale = devicePixelRatio();
     QModelIndexList modelIndexList = allSelectedIndexes();
 
-    int leftBorder = m_dragFlag ? 0 : DRAGICON_LEFTBORDER;
-    int topBorder = m_dragFlag ? 0 : DRAGICON_TOPBORDER;
+    int leftBorder = DRAGICON_LEFTBORDER;
+    int topBorder = DRAGICON_TOPBORDER;
     QFont font;
     font.setPixelSize(10);
     QFontMetrics fontMetrics(font);

--- a/src/music-player/mainFrame/footerwidget.cpp
+++ b/src/music-player/mainFrame/footerwidget.cpp
@@ -382,6 +382,7 @@ void FooterWidget::initShortcut()
     connect(nextShortcut, &QShortcut::activated, this, &FooterWidget::slotShortCutTriggered);
     connect(previousShortcut, &QShortcut::activated, this, &FooterWidget::slotShortCutTriggered);
     connect(muteShortcut, &QShortcut::activated, this, &FooterWidget::slotShortCutTriggered);
+    connect(DataBaseService::getInstance(), &DataBaseService::signalCoverUpdate, this, &FooterWidget::slotCoverUpdate);
 }
 
 void FooterWidget::updateShortcut()
@@ -771,6 +772,23 @@ void FooterWidget::slotShortCutTriggered()
         bool mute = Player::getInstance()->getMuted();
         Player::getInstance()->setMuted(!mute);
         m_volSlider->flushVolumeIcon();
+    }
+}
+
+void FooterWidget::slotCoverUpdate(const MediaMeta &meta)
+{
+    MediaMeta curMeta = Player::getInstance()->getActiveMeta();
+    if (curMeta.hash != meta.hash)
+        return;
+
+    QString imagesDirPath = Global::cacheDir() + "/images/" + curMeta.hash + ".jpg";
+    QFileInfo file(imagesDirPath);
+    QIcon icon;
+    if (file.exists()) {
+        icon = QIcon(imagesDirPath);
+        m_btCover->setIcon(icon);
+    } else {
+        m_btCover->setIcon(QIcon::fromTheme("info_cover"));
     }
 }
 

--- a/src/music-player/mainFrame/footerwidget.h
+++ b/src/music-player/mainFrame/footerwidget.h
@@ -109,6 +109,7 @@ public slots:
     //void slotDelayAutoHide();
     // 快捷键响应
     void slotShortCutTriggered();
+    void slotCoverUpdate(const MediaMeta &meta);
 protected:
     virtual void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
 private:


### PR DESCRIPTION
修复双击播放歌曲工具栏无法展示歌曲图片，拖拽显示问题

Log: 修复双击播放歌曲工具栏无法展示歌曲图片，拖拽显示问题

Bug: https://pms.uniontech.com/bug-view-173653.html
     https://pms.uniontech.com/bug-view-155789.html