### PR TITLE
fix: 标题栏退出菜单无法直接退出

### DIFF
--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -88,8 +88,8 @@ TitleBar {
                 license: qsTr("%1 is released under %2").arg("Music").arg("GPLV3")
             }
         }
-        //QuitAction {}
-        MenuItem {
+        QuitAction {}
+        /*MenuItem {
             id: quitControl
             text: qsTr("Quit")
             onTriggered: {
@@ -117,7 +117,7 @@ TitleBar {
                     }
                 }
             }
-        }
+        }*/
     }
     content: titleBarContent
 


### PR DESCRIPTION
标题栏退出菜单改为直接退出，不进行二次询问

Log: 标题栏退出菜单改为直接退出，不进行二次询问