### PR TITLE
fix: 通过快捷键“.”将歌曲添加到“我喜欢的歌曲”，但歌单中未显示且喜欢图标未被标记

### DIFF
--- a/src/music-player/allItems/Shortcuts.qml
+++ b/src/music-player/allItems/Shortcuts.qml
@@ -104,6 +104,9 @@ Item {
         id: favorite_song  //快捷键 我的喜欢
         sequence: { return Presenter.valueFromSettings("shortcuts.all.favorite_song");}
         onActivated: {
+            if (!globalVariant.currentMediaMeta.title)
+                return
+
             if(globalVariant.currentMediaMeta.favourite){
                 Presenter.removeFromPlayList(globalVariant.currentMediaMeta.hash, "fav");
                 globalVariant.currentMediaMeta.favourite = false;


### PR DESCRIPTION
当前播放歌曲为空时,禁用添加到喜欢的快捷键

Log: 当前播放歌曲为空时,禁用添加到喜欢的快捷键

Bug: https://pms.uniontech.com/bug-view-205103.html