### PR TITLE
fix: 双击文件播放音乐不会置顶

### DIFF
--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -160,8 +160,8 @@ MainFrame::MainFrame()
         // 使用dbus显示窗口
         this->titlebar()->setFocus();
         show();
-//        raise();
-//        activateWindow();
+        raise();
+        activateWindow();
         this->setWindowState((this->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
     });
 


### PR DESCRIPTION
修复双击文件播放歌曲音乐不会置顶问题

Log: 修复双击文件播放歌曲音乐不会置顶问题

Bug: https://pms.uniontech.com/bug-view-206193.html