### PR TITLE
fix: 播放音乐未播放最后两秒，直接切换到下一首

### DIFF
--- a/src/music-player/core/vlc/MediaPlayer.cpp
+++ b/src/music-player/core/vlc/MediaPlayer.cpp
@@ -18,6 +18,8 @@
 
 #include <QDebug>
 
+extern int g_playbackStatus;
+
 typedef libvlc_media_player_t *(*vlc_media_player_new_function)(libvlc_instance_t *);
 typedef libvlc_event_manager_t *(*vlc_media_player_event_manager_function)(libvlc_media_player_t *);
 typedef void (*vlc_media_player_release_function)(libvlc_media_player_t *);
@@ -365,7 +367,14 @@ void VlcMediaPlayer::libvlc_callback(const libvlc_event_t *event,
         emit core->backward();
         break;
     case libvlc_MediaPlayerEndReached:
-        emit core->end(); //play end
+        g_playbackStatus = 0;
+        if (core->_data.isEmpty()) {
+            emit core->end(); //play end
+        } else {
+            g_playbackStatus = 1;
+            // 设置当前进度时间、步进、总时间
+            emit core->endReached();
+        }
         break;
     case libvlc_MediaPlayerEncounteredError:
         emit core->error();

--- a/src/music-player/core/vlc/MediaPlayer.h
+++ b/src/music-player/core/vlc/MediaPlayer.h
@@ -287,6 +287,8 @@ signals:
     */
     void stateChanged();
 
+    void endReached();
+
 protected:
     static void libvlc_callback(const libvlc_event_t *event,
                                 void *data);
@@ -298,6 +300,8 @@ protected:
     libvlc_event_manager_t *_vlcEvents;
 
     VlcEqualizer *_vlcEqualizer;
+
+    QByteArray _data;
 };
 
 #endif // VLCQT_MEDIAPLAYER_H_

--- a/src/music-player/core/vlc/sdlplayer.cpp
+++ b/src/music-player/core/vlc/sdlplayer.cpp
@@ -142,6 +142,9 @@ SdlPlayer::SdlPlayer(VlcInstance *instance)
         m_pCheckDataThread = new CheckDataZeroThread(this);
         connect(m_pCheckDataThread, &CheckDataZeroThread::sigPlayNextSong, this, &SdlPlayer::checkDataZero, Qt::QueuedConnection);
         connect(m_pCheckDataThread, &CheckDataZeroThread::sigExtraTime, this, &VlcMediaPlayer::timeChanged, Qt::QueuedConnection);
+        connect(this, &SdlPlayer::endReached, this, [=](){
+            m_pCheckDataThread->initTimeParams();
+        });
     }
     //}
 

--- a/src/music-player/core/vlc/sdlplayer.h
+++ b/src/music-player/core/vlc/sdlplayer.h
@@ -146,7 +146,7 @@ private:
     SDL_AudioSpec obtainedAS;
     bool m_loadSdlLibrary;
 
-    QByteArray _data;
+//    QByteArray _data;
     int progressTag = 0;
     int m_volume = 50.0;
     bool m_mute = false;


### PR DESCRIPTION
修复播放音乐时未播放最后两秒，直接切换到下一首

Log: 修复播放音乐时未播放最后两秒，直接切换到下一首

Bug: https://pms.uniontech.com/bug-view-206605.html