### PR TITLE
fix: 休眠唤醒后进度条停滞，音乐无声音输出

### DIFF
--- a/src/music-player/core/vlc/sdlplayer.cpp
+++ b/src/music-player/core/vlc/sdlplayer.cpp
@@ -272,7 +272,7 @@ void SdlPlayer::resume()
         SDL_Delay_function Delay = (SDL_Delay_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_Delay");
         if (GetAudioStatus() == SDL_AUDIO_STOPPED) {
             if (OpenAudio(&obtainedAS, nullptr) < 0) {
-                qWarning() << __func__ << "SDL OpenAudio failed.";
+                qCritical() << __func__ << "  SDL OpenAudio failed.";
                 pause();
                 return;
             }
@@ -441,9 +441,7 @@ int SdlPlayer::libvlc_audio_setup_cb(void **data, char *format, unsigned *rate, 
 
     if (is_pa_connected) { //pa连接成功才进行播放，否则会造成崩溃
         if (OpenAudio(&desiredAS, &sdlMediaPlayer->obtainedAS) < 0) {
-            qWarning() << __func__ << "SDL OpenAudio failed.";
-            sdlMediaPlayer->pause();
-            return 0;
+            qCritical() << __func__ << " SDL OpenAudio failed.";
         }
 
         Delay(40);


### PR DESCRIPTION
修复休眠唤醒后进度条停滞，音乐无声音输出

Log: 修复休眠唤醒后进度条停滞，音乐无声音输出

Bug: https://pms.uniontech.com/bug-view-216759.html