### PR TITLE
fix: 语音控制导致卡死/崩溃问题

### DIFF
--- a/src/music-player/ai/ai.cpp
+++ b/src/music-player/ai/ai.cpp
@@ -147,7 +147,7 @@ void UosAIInterface::handleAICall(QString &funcName, QMap<QString, QString> &arg
                     index = rx.cap(1);
                     pos += rx.matchedLength();
                 }
-                if (!index.isEmpty())
+                if (!index.isEmpty() && index.toInt() > 0)
                     QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "playIndex", index);
             }
             break;

--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -204,7 +204,8 @@ void Player::playMeta(MediaMeta meta)
                 //文件不存在提示
                 emit signalPlaybackStatusChanged(Player::Paused);
                 m_ActiveMeta = meta;
-                playNextMeta(false);
+                if (m_MetaList.size() > 1)
+                    playNextMeta(false);
                 INT_LAST_PROGRESS_FLAG = 0;
                 return;
             }


### PR DESCRIPTION
修复播放第一首歌曲导致崩溃问题；
修复播放权限为000文件卡死问题。

Log: 修复语音控制导致卡死/崩溃问题

Bug: https://pms.uniontech.com/bug-view-232273.html
     https://pms.uniontech.com/bug-view-232289.html