### PR TITLE
fix: 语音控制-切换播放模式后tooltip内容与按钮不一致

### DIFF
--- a/assets/deepin-music.json
+++ b/assets/deepin-music.json
@@ -48,35 +48,25 @@
         },
         {
             "name": "playControl",
-            "description": "播放控制",
+            "description": "状态控制",
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "play": {
+                    "control": {
                         "type": "string",
-                        "description": "继续播放"
-                    },
-                    "pause": {
-                        "type": "string",
-                        "description": "暂停"
-                    },
-                    "stop": {
-                        "type": "string",
-                        "description": "停止播放"
-                    },
-                    "previous": {
-                        "type": "string",
-                        "description": "上一首"
-                    },
-                    "next": {
-                        "type": "string",
-                        "description": "下一首"
-                    },
-                    "playMode": {
-                        "type": "string",
-                        "description": "切换播放模式，例如：列表循环，单曲循环，随机播放"
-                    },
-                    "seek": {
+                        "description": "Play继续播放,Pause暂停,Stop停止播放,Previous上一首,Next下一首,ListLoop列表循环,SingleLoop单曲循环,Shuffle随机播放",
+                        "enum": ["Play", "Pause", "Stop", "Previous", "Next", "ListLoop", "SingleLoop", "Shuffle"]
+                    }
+                }
+            }
+        },
+        {
+            "name": "seek",
+            "description": "快进/快退",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "position": {
                         "type": "string",
                         "description": "快进、快退到.."
                     }
@@ -100,13 +90,13 @@
                 }
             }
         },
-{
+        {
             "name": "playMyFavorite",
             "description": "播放我收藏的音乐",
             "parameters": {
                 "type": "object",
-            "properties": {
-            }
+                "properties": {
+                }
             }
         }
     ]

--- a/src/music-player/ai/ai.cpp
+++ b/src/music-player/ai/ai.cpp
@@ -191,27 +191,45 @@ void UosAIInterface::handleAICall(QString &funcName, QMap<QString, QString> &arg
             break;
 
         case 1: {
-            if (keys[0] == "play") {
-                QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "resume", "");
-            } else if (keys[0] == "pause") {
-                QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "pause", "");
-            } else if (keys[0] == "stop") {
-                QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "stop", "");
-            }  else if (keys[0] == "previous") {
-                QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "pre", "");
-            } else if (keys[0] == "next") {
-                QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "next", "");
-            } else if (keys[0] == "playMode") {
+            if (keys[0] == "control") {
                 QString playMode;
-                if (arguments[keys[0]].contains("列表循环"))
-                    playMode = "0";
-                else if (arguments[keys[0]].contains("单曲循环"))
-                    playMode = "1";
-                else if (arguments[keys[0]].contains("随机"))
-                    playMode = "2";
 
-                QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "setMode", QString(playMode));
-            } else if (keys[0] == "seek") {
+                if (arguments[keys[0]] == "Play") {
+                    QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "resume", "");
+                } else if (arguments[keys[0]] == "Pause") {
+                    QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "pause", "");
+                } else if (arguments[keys[0]] == "Stop") {
+                    QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "stop", "");
+                } else if (arguments[keys[0]] == "Previous") {
+                    QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "pre", "");
+                } else if (arguments[keys[0]] == "Next") {
+                    QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "next", "");
+                } else if (arguments[keys[0]].contains("ListLoop")) {
+                    playMode = "0";
+                } else if (arguments[keys[0]].contains("SingleLoop")) {
+                    playMode = "1";
+                } else if (arguments[keys[0]].contains("Shuffle")) {
+                    playMode = "2";
+                }
+
+                if (!playMode.isEmpty()) {
+                    QDBusReply<QVariant> msg  = speechbus.call(QString("invoke"), "setMode", QString(playMode));
+                }
+            }
+
+            break;
+        }
+
+        default:
+            break;
+        }
+    } else if (funcName == "seek") {
+        switch (keys.size()) {
+        case 0:
+            break;
+
+        case 1: {
+            if (keys[0] == "position") {
                 QRegExp rx("(\\d+)");
                 int pos = 0;
                 QStringList times;
@@ -235,6 +253,7 @@ void UosAIInterface::handleAICall(QString &funcName, QMap<QString, QString> &arg
         default:
             break;
         }
+
     } else if (funcName == "addRemoveFavorite") {
         switch (keys.size()) {
         case 0:

--- a/src/music-player/mainFrame/footerwidget.cpp
+++ b/src/music-player/mainFrame/footerwidget.cpp
@@ -95,7 +95,9 @@ FooterWidget::FooterWidget(QWidget *parent) :
             this, &FooterWidget::slotMediaMetaChanged);
 
     connect(CommonService::getInstance(), &CommonService::signalFluashFavoriteBtnIcon, this, &FooterWidget::fluashFavoriteBtnIcon);
-    connect(CommonService::getInstance(), &CommonService::signalSetPlayModel, this, &FooterWidget::setPlayModel);
+    connect(CommonService::getInstance(), &CommonService::signalSetPlayModel, this, /*&FooterWidget::setPlayModel*/[=](Player::PlaybackMode playModel){
+        setPlayModel(playModel, true);
+    });
     connect(CommonService::getInstance(), &CommonService::signalPlayQueueClosed, this, &FooterWidget::slotFlushBackground);
     // dbus
     connect(Player::getInstance()->getMpris(), &MprisPlayer::volumeRequested, this, &FooterWidget::slotDbusVolumeChanged);
@@ -506,16 +508,6 @@ void FooterWidget::slotPlayModeClick(bool click)
         playModel = 0;
 
     setPlayModel(static_cast<Player::PlaybackMode>(playModel));
-    //更换提示框
-    auto hintWidget = m_btPlayMode->property("HintWidget").value<QWidget *>();
-    m_hintFilter->showHitsFor(m_btPlayMode, hintWidget);
-
-    if (hintWidget != nullptr) {
-        auto hintToolTips = static_cast<ToolTips *>(hintWidget);
-        if (hintToolTips != nullptr) {
-            hintToolTips->setText(playModeStr(playModel));
-        }
-    }
 }
 
 void FooterWidget::slotCoverClick(bool click)
@@ -658,7 +650,7 @@ void FooterWidget::slotMediaMetaChanged(MediaMeta activeMeta)
     }
 }
 
-void FooterWidget::setPlayModel(Player::PlaybackMode playModel)
+void FooterWidget::setPlayModel(Player::PlaybackMode playModel, bool isSignal)
 {
     switch (playModel) {
     case 0:
@@ -672,6 +664,18 @@ void FooterWidget::setPlayModel(Player::PlaybackMode playModel)
         break;
     default:
         break;
+    }
+
+    //更换提示框
+    auto hintWidget = m_btPlayMode->property("HintWidget").value<QWidget *>();
+    if (!isSignal)
+        m_hintFilter->showHitsFor(m_btPlayMode, hintWidget);
+
+    if (hintWidget != nullptr) {
+        auto hintToolTips = static_cast<ToolTips *>(hintWidget);
+        if (hintToolTips != nullptr) {
+            hintToolTips->setText(playModeStr(playModel));
+        }
     }
 
     m_btPlayMode->setProperty("playModel", QVariant(playModel));

--- a/src/music-player/mainFrame/footerwidget.h
+++ b/src/music-player/mainFrame/footerwidget.h
@@ -106,7 +106,7 @@ public slots:
     void slotPlaybackStatusChanged(Player::PlaybackStatus statue);
     void slotMediaMetaChanged(MediaMeta activeMeta);
 
-    void setPlayModel(Player::PlaybackMode playModel);
+    void setPlayModel(Player::PlaybackMode playModel, bool isSignal = false);
 
     // Dbug音量变化通知
     void slotDbusVolumeChanged(double volume);


### PR DESCRIPTION
修复语音控制切换播放模式后tooltip内容与按钮不一致问题；修改配置文件播放控制参数为枚举

Log: 修复语音控制切换播放模式后tooltip内容与按钮不一致问题；

Bug: https://pms.uniontech.com/bug-view-232285.html