### PR TITLE
fix: 双击音频文件概率性无法自动播放、闪退问题

### DIFF
--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -234,8 +234,6 @@ void Player::playMeta(MediaMeta meta)
                 qDebug() << "seek last position:" << lastOffset;
                 m_basePlayer->setTime(lastOffset);
                 m_basePlayer->play();
-                if (Global::checkBoardVendorType())
-                    m_basePlayer->resume();
 
                 QTimer *muteTimer = new QTimer(this);
                 muteTimer->setInterval(200);


### PR DESCRIPTION
修复双击音频文件概率性无法自动播放、闪退问题

Log: 修复双击音频文件概率性无法自动播放、闪退问题

Bug: https://pms.uniontech.com/bug-view-232159.html