### PR TITLE
fix: 双击音乐文件冷启动,显示播放，实际无音频输出

### DIFF
--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -228,7 +228,7 @@ void Player::playMeta(MediaMeta meta)
             QTimer::singleShot(100, this, [ = ]() {
                 setDbusMuted();
             });
-            m_basePlayer->pause();
+            m_basePlayer->pauseNew(); //此处只暂停，不关闭音频设备，防止后面打开失败
             qint64 lastOffset = m_ActiveMeta.offset;
             QTimer::singleShot(150, this, [ = ]() {//为了记录进度条生效，在加载的时候让音乐播放150ms
                 qDebug() << "seek last position:" << lastOffset;

--- a/src/music-player/core/playerbase.h
+++ b/src/music-player/core/playerbase.h
@@ -44,6 +44,7 @@ public:
     virtual PlayState state() = 0;
     virtual void play() = 0;
     virtual void pause() = 0;
+    virtual void pauseNew() = 0;
     virtual void resume() = 0;
     virtual void stop() = 0;
     virtual int length() = 0;

--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -95,6 +95,12 @@ void QtPlayer::pause()
     if (m_mediaPlayer != nullptr && m_mediaPlayer->state() == QMediaPlayer::PlayingState)
         m_mediaPlayer->pause();
 }
+
+void QtPlayer::pauseNew()
+{
+
+}
+
 void QtPlayer::resume()
 {
 

--- a/src/music-player/core/qtplayer.h
+++ b/src/music-player/core/qtplayer.h
@@ -24,6 +24,7 @@ public:
     PlayerBase::PlayState state() override;
     void play() override;
     void pause() override;
+    void pauseNew() override;
     void resume() override;
     void stop() override;
     int length() override; //播放总时长

--- a/src/music-player/core/vlc/MediaPlayer.cpp
+++ b/src/music-player/core/vlc/MediaPlayer.cpp
@@ -240,6 +240,18 @@ void VlcMediaPlayer::pause()
     VlcError::showErrmsg();
 }
 
+void VlcMediaPlayer::pauseNew()
+{
+    if (!_vlcMediaPlayer)
+        return;
+    vlc_media_player_can_pause_function vlc_media_player_can_pause = (vlc_media_player_can_pause_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSymbol("libvlc_media_player_can_pause");
+    vlc_media_player_set_pause_function vlc_media_player_set_pause = (vlc_media_player_set_pause_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSymbol("libvlc_media_player_set_pause");
+    if (vlc_media_player_can_pause(_vlcMediaPlayer))
+        vlc_media_player_set_pause(_vlcMediaPlayer, true);
+
+    VlcError::showErrmsg();
+}
+
 void VlcMediaPlayer::resume()
 {
     if (!_vlcMediaPlayer)

--- a/src/music-player/core/vlc/MediaPlayer.h
+++ b/src/music-player/core/vlc/MediaPlayer.h
@@ -161,6 +161,11 @@ public slots:
     virtual void pause();
 
     /*!
+        \brief Pauses the playback of current media if possible
+    */
+    virtual void pauseNew();
+
+    /*!
         \brief Resumes the playback of current media if possible
     */
     virtual void resume();

--- a/src/music-player/core/vlc/sdlplayer.cpp
+++ b/src/music-player/core/vlc/sdlplayer.cpp
@@ -100,7 +100,7 @@ typedef av_const int (*av_log2_function)(unsigned v);
 **/
 void SDL_LogOutputFunction_Err_Write(void *userdata, int category, SDL_LogPriority priority, const char *message)
 {
-    qDebug() << __FUNCTION__ << message;
+    qDebug() << __FUNCTION__ << "category: " << category << "priority: " << priority << "   " << message;
     SDL_GetAudioStatus_function GetAudioStatus = (SDL_GetAudioStatus_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_GetAudioStatus");
     QString strmsg = message;
     if (strmsg == SDL_AUDIO_ERR_MSG && category == SDL_LOG_CATEGORY_AUDIO && priority == SDL_LOG_PRIORITY_ERROR) {
@@ -131,6 +131,7 @@ SdlPlayer::SdlPlayer(VlcInstance *instance)
         SDL_LogSetPriority_function LogSetPriority = (SDL_LogSetPriority_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_LogSetPriority");
         SDL_LogSetOutputFunction_function LogSetOutputFunction = (SDL_LogSetOutputFunction_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_LogSetOutputFunction");
         Init(SDL_INIT_AUDIO);
+
         vlc_audio_set_callbacks(_vlcMediaPlayer, libvlc_audio_play_cb, libvlc_audio_pause_cb, libvlc_audio_resume_cb, libvlc_audio_flush_cb, nullptr, this);
         vlc_audio_set_format_callbacks(_vlcMediaPlayer, libvlc_audio_setup_cb, nullptr);
 
@@ -194,6 +195,7 @@ void SdlPlayer::open(VlcMedia *media)
         SDL_UnlockAudio_function UnlockAudio = (SDL_UnlockAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_UnlockAudio");
         SDL_Delay_function Delay = (SDL_Delay_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_Delay");
         SDL_CloseAudio_function CloseAudio = (SDL_CloseAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_CloseAudio");
+
         if (GetAudioStatus() != SDL_AUDIO_PLAYING)
             PauseAudio(1);
         cleanMemCache();
@@ -217,6 +219,7 @@ void SdlPlayer::open(VlcMedia *media)
 
 void SdlPlayer::play()
 {
+    qDebug() << "SdlPlayer play.";
     if (!_vlcMediaPlayer)
         return;
 
@@ -230,6 +233,7 @@ void SdlPlayer::play()
 
 void SdlPlayer::pause()
 {
+    qDebug() << "SdlPlayer pause.";
     if (!_vlcMediaPlayer)
         return;
     setProgressTag(0); //first start
@@ -243,6 +247,7 @@ void SdlPlayer::pause()
         SDL_UnlockAudio_function UnlockAudio = (SDL_UnlockAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_UnlockAudio");
         SDL_Delay_function Delay = (SDL_Delay_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_Delay");
         SDL_CloseAudio_function CloseAudio = (SDL_CloseAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_CloseAudio");
+
         if (GetAudioStatus() != SDL_AUDIO_PAUSED && GetAudioStatus() != SDL_AUDIO_STOPPED)
             PauseAudio(1);
 
@@ -254,6 +259,24 @@ void SdlPlayer::pause()
             UnlockAudio();
             CloseAudio();
         }
+    }
+
+    VlcMediaPlayer::pause();
+}
+
+void SdlPlayer::pauseNew()
+{
+    qDebug() << __func__;
+    if (!_vlcMediaPlayer)
+        return;
+    setProgressTag(0);
+
+    if (m_loadSdlLibrary) {
+        SDL_GetAudioStatus_function GetAudioStatus = (SDL_GetAudioStatus_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_GetAudioStatus");
+        SDL_PauseAudio_function PauseAudio = (SDL_PauseAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_PauseAudio");
+
+        if (GetAudioStatus() != SDL_AUDIO_PAUSED && GetAudioStatus() != SDL_AUDIO_STOPPED)
+            PauseAudio(1);
     }
 
     VlcMediaPlayer::pause();
@@ -408,6 +431,7 @@ void SdlPlayer::libvlc_audio_resume_cb(void *data, int64_t pts)
 
 int SdlPlayer::libvlc_audio_setup_cb(void **data, char *format, unsigned *rate, unsigned *channels)
 {
+    qDebug() << __func__ ;
     SDL_PauseAudio_function PauseAudio = (SDL_PauseAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_PauseAudio");
     SDL_Delay_function Delay = (SDL_Delay_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_Delay");
     SDL_OpenAudio_function OpenAudio = (SDL_OpenAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_OpenAudio");

--- a/src/music-player/core/vlc/sdlplayer.h
+++ b/src/music-player/core/vlc/sdlplayer.h
@@ -48,6 +48,11 @@ public:
     void pause();
 
     /*!
+        \brief Pauses the playback of current media if possible
+    */
+    void pauseNew();
+
+    /*!
         \brief Resumes the playback of current media if possible
     */
     void resume();

--- a/src/music-player/core/vlcplayer.cpp
+++ b/src/music-player/core/vlcplayer.cpp
@@ -134,6 +134,14 @@ void VlcPlayer::pause()
         m_qvplayer->pause();
     }
 }
+
+void VlcPlayer::pauseNew()
+{
+    if (m_qvplayer) {
+        m_qvplayer->pauseNew();
+    }
+}
+
 void VlcPlayer::resume()
 {
     if (m_qvplayer) {

--- a/src/music-player/core/vlcplayer.h
+++ b/src/music-player/core/vlcplayer.h
@@ -32,6 +32,7 @@ public:
 public:
     void play() override;
     void pause() override;
+    void pauseNew() override;
     void resume() override;
     PlayerBase::PlayState state() override;
     void stop() override;


### PR DESCRIPTION
修复双击音乐文件冷启动,显示播放，实际无音频输出问题

Log: 修复双击音乐文件冷启动,显示播放，实际无音频输出问题

Bug: https://pms.uniontech.com/bug-view-234211.html