### PR TITLE
fix: 拔出耳机后，点击播放无响应

### DIFF
--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -743,7 +743,7 @@ Player::PlaybackStatus Player::status()
         return PlaybackStatus::Playing;
     } else if (status == PlayerBase::Paused) {
         return PlaybackStatus::Paused;
-    } else if (status == PlayerBase::Stopped || status == PlayerBase::Idle) {
+    } else if (status == PlayerBase::Stopped || status == PlayerBase::Idle || status == PlayerBase::Ended) {
         return PlaybackStatus::Stopped;
     } else {
         return PlaybackStatus::InvalidPlaybackStatus;


### PR DESCRIPTION
问题出现于音频恰好播放结束时拔出耳机孔，
此时界面处于暂停状态，但播放状态置为Eneded
此状被处理为 Invalid 状态，后续无法进入
播放流程。
修改将 Ended 也视为 Stopped 状态。

Log: 修复界面响应问题
Bug: https://pms.uniontech.com/bug-view-248763.html