### PR TITLE
fix: the base color of the applied control does not switch with the s…

### DIFF
--- a/src/music-player/mainwindow/Toolbar.qml
+++ b/src/music-player/mainwindow/Toolbar.qml
@@ -370,7 +370,7 @@ FloatingPanel {
                     width: 36
                     height: 36
                     anchors.verticalCenter: parent.verticalCenter
-                    icon.name: checked ? "toolbar_lrc_checked" : "toolbar_lrc"
+                    icon.name: "toolbar_lrc"
                     icon.width: 36
                     icon.height: 36
                     checkable: true
@@ -389,8 +389,8 @@ FloatingPanel {
                     width: 36
                     height: 36
                     anchors.verticalCenter: parent.verticalCenter
-                    icon.name: bMute ? (checked ? "toolbar_volume-_checked" : "toolbar_volume-")
-                                     : (checked ? "toolbar_volume+_checked" : "toolbar_volume+")
+                    icon.name: bMute ? ("toolbar_volume-")
+                                     : ("toolbar_volume+")
                     icon.width: 36
                     icon.height: 36
                     checkable: true
@@ -420,7 +420,7 @@ FloatingPanel {
                     width: 36
                     height: 36
                     anchors.verticalCenter: parent.verticalCenter
-                    icon.name: checked ? "toolbar_playlist_checked" : "toolbar_playlist"
+                    icon.name: "toolbar_playlist"
                     icon.width: 36
                     icon.height: 36
                     checkable: true


### PR DESCRIPTION
…ystem theme color

Replace the icon that is updated when the control is selected with a suitable icon, so that the color in the icon will not obscure the system color.

Log: the base color of the applied control does not switch with the system theme color
Bug: https://pms.uniontech.com/bug-view-248345.html