### PR TITLE
fix: 修复待机、休眠后继续音乐播放

### DIFF
--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -1055,15 +1055,8 @@ void Player::onSleepWhenTaking(bool sleep)
                 INT_LAST_PROGRESS_FLAG = 1;
                 m_ActiveMeta.offset = time;
                 m_basePlayer->stop();
+                emit signalPlaybackStatusChanged(Player::Paused);
             }
-        }
-    } else { //设置状态
-        if (m_Vlcstate == Vlc::Playing) {
-            //播放
-            QTimer::singleShot(2000, [ = ]() {
-                playMeta(m_ActiveMeta);
-            });
-            m_Vlcstate = -1;
         }
     }
 }


### PR DESCRIPTION
修复待机、休眠后继续音乐播放，放弃之前继续播放音乐逻辑

Bug: https://pms.uniontech.com/bug-view-277919.html
Log: 修复待机、休眠后继续音乐播放