### PR TITLE
fix: setting dialogs and tray icon

### DIFF
--- a/src/music-player/dialogs/SettingsDialog.qml
+++ b/src/music-player/dialogs/SettingsDialog.qml
@@ -437,8 +437,8 @@ Settings.SettingsDialog {
     property var duplicatDlg :DialogWindow {
         property int curId: 0
         property int duplicatId: 0
-        property string newValue: null
-        property string oldValue: null
+        property string newValue: ""
+        property string oldValue: ""
         property bool replaceFlag: false
 
         id: dialog

--- a/src/music-player/mainwindow/MainWindow.qml
+++ b/src/music-player/mainwindow/MainWindow.qml
@@ -183,7 +183,9 @@ ApplicationWindow {
     SystemTrayIcon{
         id: systemTray
         visible: true
+        // TODO: temporar setting, wait dtk fix IconEngine. icon.name is fallback
         icon.name: "deepin-music"
+        icon.source: "qrc:/dsg/img/deepin-music.svg"
         tooltip: qsTr("Music")
 
         onActivated: {


### PR DESCRIPTION
[fix: can not open settings dialog](https://github.com/linuxdeepin/deepin-music/commit/5358cf925805b94169e2e452e93403d73c1e7865) 

As title, the string value can not access when set null.

Log: Fix can not open settings dialog.
Bug: https://pms.uniontech.com/bug-view-289833.html
Influence: UI

[fix: tray icon incorrect](https://github.com/linuxdeepin/deepin-music/commit/33f4a2711629d16f8800d7cbeb65e0ab37d6d9ca) 

the QIcon::fromTheme("", fallback) return fallback
if QIcon.availableSizes() is empty().
- DDciIconEngine not impl availableSizes()
We temporarily use icon.source, wait dtk fix it.

Log: fix tray icon.
Bug: https://pms.uniontech.com/bug-view-290021.html