### PR TITLE
fix: custom playlist order is incorrect

### DIFF
--- a/src/music-player/musicmousemenu/ImportMenu.qml
+++ b/src/music-player/musicmousemenu/ImportMenu.qml
@@ -63,12 +63,17 @@ Menu {
         visible: (globalVariant.globalCustomPlaylistModel.tmpModel.count === 0) ? false : true
     }
 
-    Repeater {
-        id: repeater
+    Instantiator {
+        id: customInstantiator
 
+        // new append menu item need add to the end
+        property int previousMenuItemCount: 5
         model: globalVariant.globalCustomPlaylistModel.tmpModel
 
-        MenuItem {
+        onObjectAdded: (index, object) => importMenu.insertItem(index + previousMenuItemCount, object)
+        onObjectRemoved: (index, object) => importMenu.removeItem(object)
+
+        delegate: MenuItem {
             height: visible ? 30 : 0
             text: model.displayName.replace(/</g, "&lt;")
             visible: (model.uuid === pageHash) ? false : true


### PR DESCRIPTION
Use Instantiator replace Repeater, can manager
the order of MenuItems.

Log: Fix custom playlist order incorrect.
Bug: https://pms.uniontech.com/bug-view-292029.html
Influence: UI