### PR TITLE
fix: select item no background color

### DIFF
--- a/src/libdmusic/global.h
+++ b/src/libdmusic/global.h
@@ -157,6 +157,9 @@ struct MediaMeta {
     bool    toDelete    = false;
 
     QString codec;              //save codec
+
+    bool inMuiltSelect = false; // runtime properties
+    bool dragFlag = false;
 };
 
 struct PlaylistInfo {

--- a/src/libdmusic/util/utils.cpp
+++ b/src/libdmusic/util/utils.cpp
@@ -237,6 +237,10 @@ QVariantMap Utils::metaToVariantMap(const DMusic::MediaMeta &meta)
     metaMap.insert("toDelete", meta.toDelete);
     metaMap.insert("codec", meta.codec);
 
+    // qml runtime properties
+    metaMap.insert("inMulitSelect", meta.inMuiltSelect);
+    metaMap.insert("dragFlag", meta.dragFlag);
+
     return metaMap;
 }
 

--- a/src/music-player/mainwindow/Toolbar.qml
+++ b/src/music-player/mainwindow/Toolbar.qml
@@ -483,7 +483,7 @@ FloatingPanel {
 
     onPlayModeChanged: {
         globalVariant.curPlayMode = playMode
-        if (mediaData.hash == null)
+        if (mediaData.hash == "")
             return
 
         updatePlayControlBtnStatus()

--- a/src/music-player/musicList/AllMusicListView.qml
+++ b/src/music-player/musicList/AllMusicListView.qml
@@ -78,7 +78,8 @@ Rectangle {
             autoExclusive: false
             width: listview.width - 40
             height: 56
-            backgroundVisible: index % 2 === 0
+            backgroundVisible: true
+            normalBackgroundVisible: index % 2 === 0
             delegateListHash: viewListHash
         }
 

--- a/src/music-player/musicmousemenu/ImportMenu.qml
+++ b/src/music-player/musicmousemenu/ImportMenu.qml
@@ -31,7 +31,7 @@ Menu {
     }
 
     MenuSeparator {
-        height: visible ? 12 : 0
+        height: visible ? implicitHeight : 0
         visible: ("play" === pageHash) ? false : true
     }
 
@@ -59,7 +59,7 @@ Menu {
     MenuSeparator {
         id: menuSeparator
 
-        height: visible ? 12 : 0
+        height: visible ? implicitHeight : 0
         visible: (globalVariant.globalCustomPlaylistModel.tmpModel.count === 0) ? false : true
     }
 

--- a/src/music-player/playlist/CurrentPlayList.qml
+++ b/src/music-player/playlist/CurrentPlayList.qml
@@ -164,7 +164,8 @@ CurrentFloatingPanel {
                 height: 56
                 anchors.left: parent.left
                 anchors.leftMargin: 10
-                backgroundVisible: index % 2 === 0
+                backgroundVisible: true
+                normalBackgroundVisible: index % 2 === 0
                 autoExclusive: false
             }
 


### PR DESCRIPTION
The select flag property can no longer be dynamiclly insert into the model item, we add it manually.
DTK api update, adjust background color.

Log: Fix select item no background color.
Bug: https://pms.uniontech.com/bug-view-290079.html
Influence: UI