### PR TITLE
fix: add playPlaylistRequested signal for empty playlist

### DIFF
--- a/src/libdmusic/player/playerengine.cpp
+++ b/src/libdmusic/player/playerengine.cpp
@@ -218,14 +218,18 @@ void PlayerEngine::setMprisPlayer(const QString &serviceName, const QString &des
     connect(m_data->m_mprisPlayer, &MprisPlayer::playRequested,
     this, [ = ]() {
         // dbus暂停立即执行
-        if (playbackStatus() == DmGlobal::Paused) {
-            resume();
+        if (isEmpty()) {
+            Q_EMIT playPlaylistRequested("all");
         } else {
-            if (playbackStatus() != DmGlobal::Playing) {
-                //播放列表为空时也应考虑，不然会出现dbus调用无效的情况
-                playNextMeta(false);
+            if (playbackStatus() == DmGlobal::Paused) {
+                resume();
             } else {
-                pauseNow();
+                if (playbackStatus() != DmGlobal::Playing) {
+                    //播放列表为空时也应考虑，不然会出现dbus调用无效的情况
+                    playNextMeta(false);
+                } else {
+                    pauseNow();
+                }
             }
         }
     });

--- a/src/libdmusic/player/playerengine.h
+++ b/src/libdmusic/player/playerengine.h
@@ -77,6 +77,7 @@ signals:
     void sendCdaStatus(int state);
     void quitRequested();
     void raiseRequested();
+    void playPlaylistRequested(const QString &playlistHash);
 
 private:
     void playNextMeta(const DMusic::MediaMeta &meta, bool isAuto, bool playFlag = true);

--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -97,6 +97,9 @@ Presenter::Presenter(const QString &unknownAlbumStr, const QString &unknownArtis
             emit updateCDStatus(state);
         }
     });
+    connect(m_data->m_playerEngine, &PlayerEngine::playPlaylistRequested, this, [this](const QString &playlistHash){
+        playPlaylist(playlistHash);
+    });
     connect(m_data->m_playerEngine, &PlayerEngine::quitRequested, this, &Presenter::quitRequested);
     connect(m_data->m_playerEngine, &PlayerEngine::raiseRequested, this, &Presenter::raiseRequested);
 


### PR DESCRIPTION
When playlist is empty, emit playPlaylistRequested signal to play all songs via MPRIS dbus interface.

Log: add playPlaylistRequested signal for empty playlist
Bug: https://pms.uniontech.com/bug-view-300607.html