### PR TITLE
fix: update sidebar menu play button state

### DIFF
--- a/src/music-player/musicbaseandsonglist/MusicBaselistview.qml
+++ b/src/music-player/musicbaseandsonglist/MusicBaselistview.qml
@@ -96,6 +96,7 @@ Rectangle {
                     sidebarMenuLoader.setSource("../musicmousemenu/SidebarMenu.qml")
                 if (sidebarMenuLoader.status === Loader.Ready ) {
                     sidebarMenuLoader.item.pageHash = key;
+                    sidebarMenuLoader.item.updateMenuState();
                     sidebarMenuLoader.item.popup();
                 }
             }

--- a/src/music-player/musicmousemenu/SidebarMenu.qml
+++ b/src/music-player/musicmousemenu/SidebarMenu.qml
@@ -12,7 +12,13 @@ Menu{
 
     id: playlistMenu
     width: 200
+
+    function updateMenuState() {
+        playMenuItem.enabled = Presenter.playlistMetaCount(playlistMenu.pageHash) > 0
+    }
+
     MenuItem {
+        id: playMenuItem
         text: qsTr("Play")
         onTriggered: {
             Presenter.playPlaylist(playlistMenu.pageHash);


### PR DESCRIPTION
Update play menu item state based on playlist count to disable when empty

Log: update sidebar menu play button state
Bug: https://pms.uniontech.com/bug-view-290063.htm