### PR TITLE
fix: simplify playPreMeta logic in playerengine

### DIFF
--- a/src/libdmusic/player/playerengine.cpp
+++ b/src/libdmusic/player/playerengine.cpp
@@ -443,10 +443,8 @@ void PlayerEngine::playPreMeta()
         }
 
         if (preIndex != -1) {
-            DmGlobal::PlaybackStatus prePlaybackStatus = playbackStatus();
             setMediaMeta(allMetas.at(preIndex));
-            if (prePlaybackStatus == DmGlobal::Playing)
-                play();
+            play();
         } else {
             stop();
         }


### PR DESCRIPTION
Remove redundant playback status check before playing previous track

Log: simplify playPreMeta logic in playerengine
Bug: https://pms.uniontech.com/bug-view-290013.html