### PR TITLE
fix: limit equalizer preset dropdown items to 9

### DIFF
--- a/src/music-player/dialogs/EqualizerDialog.qml
+++ b/src/music-player/dialogs/EqualizerDialog.qml
@@ -144,6 +144,7 @@ DialogWindow {
                         id: selectComBox
                         width: parent.width
                         height: parent.height
+                        maxVisibleItems: 9
 
                         textRole: "text"
                         iconNameRole: "icon"


### PR DESCRIPTION
Add maxVisibleItems property to improve ComboBox display in equalizer dialog

Log: limit equalizer preset dropdown items to 9
Bug: https://pms.uniontech.com/bug-view-300595.html