### PR TITLE
fix: add Ctrl+A shortcut for select all in music list

### DIFF
--- a/src/music-player/mainwindow/MainWindow.qml
+++ b/src/music-player/mainwindow/MainWindow.qml
@@ -71,12 +71,11 @@ ApplicationWindow {
         }
     }
 
-
-
     Shortcuts {
         id: shortcuts
         enabled: rootWindow.active
     }
+
     MusicContentWindow {
         id: contentWindow
         visible: !isLyricShow
@@ -402,11 +401,20 @@ ApplicationWindow {
         rootWindow.requestActivate()
     }
 
+    function onKeyFiltered(key, modifier) {
+        if (key === Qt.Key_A && modifier === Qt.ControlModifier) {
+            if (!isPlaylistShow && !isLyricShow) {
+                contentWindow.selectAll();
+            }
+        }
+    }
+
     Component.onCompleted: {
         Presenter.addOneMeta.connect(onAddOneMeta)
         Presenter.importFinished.connect(onImportFinished)
         Presenter.quitRequested.connect(onQuitRequested)
         Presenter.raiseRequested.connect(onRaiseRequested)
         globalVariant.devicePixelRatio = Screen.devicePixelRatio
+        EventsFilter.keyFiltered.connect(onKeyFiltered)
     }
 }

--- a/src/music-player/mainwindow/MusicContentWindow.qml
+++ b/src/music-player/mainwindow/MusicContentWindow.qml
@@ -25,7 +25,6 @@ Rectangle {
     color: "transparent"
     signal clickPlayAllBtn()
 
-
     MusicBaselistview {
         id: musicBaselist
         width: 220;
@@ -57,6 +56,13 @@ Rectangle {
         }
 
         listViewStackView.push(Qt.resolvedUrl("SearchResultWindow.qml"), {pattern:text, curIndex: type});
+    }
+
+    function selectAll() {
+        var item = listViewStackView.currentItem;
+        if (item && item.objectName !== "artist" && item.objectName !== "album") {
+            item.selectAll();
+        }
     }
 
     Connections {

--- a/src/music-player/musicList/AllMusicList.qml
+++ b/src/music-player/musicList/AllMusicList.qml
@@ -37,6 +37,7 @@ Rectangle {
             visible: (rootRectangle.mediaModels.count === 0) ? true : false
         }
         AllMusicListView {
+            id: musicListView
             width: rootRectangle.width
             height: rootRectangle.height - toolButtonItem.height/* - 70*/
             mediaModel: mediaModels
@@ -111,6 +112,12 @@ Rectangle {
             default:
                 toolButtonItem.sortType = -1
             }
+        }
+    }
+
+    function selectAll() {
+        if (musicListView && musicListView.visible) {
+            musicListView.selectAll();
         }
     }
 }

--- a/src/music-player/musicList/AllMusicListView.qml
+++ b/src/music-player/musicList/AllMusicListView.qml
@@ -56,6 +56,12 @@ Rectangle {
         }
     }
 
+    function selectAll() {
+        if (listview && listview.visible && mediaModel.count > 0) {
+            listview.selectAll();
+        }
+    }
+
     ListView {
         property var delegateModelGroup: new Array
         property var dragGroup: new Array
@@ -337,6 +343,16 @@ Rectangle {
         Connections {
             target: globalVariant
             onClearSelectGroup: {listview.removeModelGroup()}
+        }
+
+        function selectAll() {
+            listview.removeModelGroup();
+            for(var i = 0; i < mediaModel.count; i++) {
+                mediaModel.setProperty(i, "inMulitSelect", true);
+                listview.delegateModelGroup.push(i);
+                listview.dragGroup.push(mediaModel.get(i).coverUrl);
+            }
+            listview.lastIndex = mediaModel.count - 1;
         }
     }
 }

--- a/src/music-player/util/eventsfilter.cpp
+++ b/src/music-player/util/eventsfilter.cpp
@@ -15,6 +15,7 @@ public:
         : m_parent(parent)
     {
         m_keyStatus.insert(Qt::Key_Space, true);
+        m_keyStatus.insert(Qt::Key_A, true);
     }
 
 private:
@@ -43,9 +44,12 @@ bool EventsFilter::eventFilter(QObject *watched, QEvent *event)
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         if (m_data->m_filterFlag && m_data->m_keyStatus.contains(keyEvent->key())
                 && m_data->m_keyStatus[keyEvent->key()]) {
-            if (event->type() == QEvent::KeyPress)
+            if (event->type() == QEvent::KeyPress) {
                 emit keyFiltered(keyEvent->key(), static_cast<int>(keyEvent->modifiers()));
-            return true;
+                if (keyEvent->key() == Qt::Key_Space) {
+                    return true;
+                }
+            }
         }
     }
     break;


### PR DESCRIPTION
- Add Key_A to events filter
- Implement select all function in music list views
- Connect keyFiltered signal to handle Ctrl+A shortcut
- Only return true for space key to allow system shortcuts

Log: add Ctrl+A shortcut for select all in music list
Bug: https://pms.uniontech.com/bug-view-289885.htm