### PR TITLE
fix: add force play for empty metaHash in musicResult playlist

### DIFF
--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -539,7 +539,11 @@ void Presenter::playPlaylist(const QString &playlistHash, const QString &metaHas
         m_data->m_playerEngine->setMediaMeta(metaHash);
     }
     m_data->m_playerEngine->setCurrentPlayList(playlistHash);
-    m_data->m_playerEngine->play();
+    if (playlistHash == "musicResult" && metaHash.isEmpty()) {
+        m_data->m_playerEngine->forcePlay();
+    } else {
+        m_data->m_playerEngine->play();
+    }
 
     m_data->m_dataManager->setCurrentPlayliHash(playlistHash);
     m_data->m_dataManager->clearPlayList("play", false);


### PR DESCRIPTION
When playing musicResult playlist with empty metaHash, use forcePlay instead of normal play

Log: add force play for empty metaHash in musicResult playlist
Bug: https://pms.uniontech.com/bug-view-289787.html

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where playing a musicResult playlist with an empty metaHash would fail by using `forcePlay` instead of `play` in this specific scenario.