### PR TITLE
fix: enhance sidebar menu with right-click actions

### DIFF
--- a/src/music-player/musicbaseandsonglist/MusicBaselistview.qml
+++ b/src/music-player/musicbaseandsonglist/MusicBaselistview.qml
@@ -83,6 +83,16 @@ Rectangle {
             onItemClicked: {
                 musicBaselistChanged(key, text);
             }
+            onItemRightClicked: {
+                if (sidebarMenuLoader.status === Loader.Null) {
+                    sidebarMenuLoader.setSource("../musicmousemenu/SidebarMenu.qml")
+                }
+                if (sidebarMenuLoader.status === Loader.Ready) {
+                    sidebarMenuLoader.item.pageHash = key;
+                    sidebarMenuLoader.item.updateMenuState();
+                    sidebarMenuLoader.item.popup();
+                }
+            }
         }
         Connections {
             target: musicSonglist

--- a/src/music-player/musicmousemenu/SidebarMenu.qml
+++ b/src/music-player/musicmousemenu/SidebarMenu.qml
@@ -14,7 +14,11 @@ Menu{
     width: 200
 
     function updateMenuState() {
-        playMenuItem.enabled = Presenter.playlistMetaCount(playlistMenu.pageHash) > 0
+        if (["album", "artist"].includes(playlistMenu.pageHash)) {
+            playMenuItem.enabled = Presenter.isExistMeta()
+        } else {
+            playMenuItem.enabled = Presenter.playlistMetaCount(playlistMenu.pageHash) > 0
+        }
     }
 
     MenuItem {
@@ -33,7 +37,7 @@ Menu{
         }
     }
     MenuItem {
-        visible: (pageHash === "fav") ? false : true
+        visible: !["fav", "all", "album", "artist"].includes(pageHash)
         height: visible ? 36: 0
         text: qsTr("Rename")
         onTriggered: {
@@ -47,7 +51,7 @@ Menu{
     }
     MenuItem {
         id: deletePlaylist
-        visible: (pageHash === "fav") ? false : true
+        visible: !["fav", "all", "album", "artist"].includes(pageHash)
         height: visible ? 36: 0
         text: qsTr("Delete");
         onTriggered: {


### PR DESCRIPTION
- Add right-click menu support for sidebar items
- Update menu item visibility rules for special playlists
- Improve play button state handling for album and artist views

Log: enhance sidebar menu with right-click support and menu visibility logic
Bug: https://pms.uniontech.com/bug-view-290003.html

## Summary by Sourcery

Implements a context menu on sidebar items via right-click. Updates the visibility rules for menu items, especially for special playlists like 'favorites', 'all songs', 'album', and 'artist'.

Enhancements:
- Adds right-click menu support to sidebar items.
- Updates menu item visibility rules for special playlists.
- Improves play button state handling for album and artist views.