### PR TITLE
chore: update linglong version to 7.0.21

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.20.1
+  version: 7.0.21.1
   kind: app
   description: |
     music for deepin os.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.20.1
+  version: 7.0.21.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.20.1
+  version: 7.0.21.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
update linglong version to 7.0.21

Log: update linglong version to 7.0.21

## Summary by Sourcery

Update linglong package version to 7.0.21.1 across multiple architectures.