### PR TITLE
chore: update linglong version to 7.0.22

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.21.1
+  version: 7.0.22.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.22) unstable; urgency=medium
+
+  * chore: New version 7.0.22.
+
+ -- Wang Yu <wangyu@uniontch.com>  Thu, 20 Mar 2025 18:48:26 +0800
+
 deepin-music (7.0.21) unstable; urgency=medium
 
   * chore: New version 7.0.21.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.21.1
+  version: 7.0.22.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.21.1
+  version: 7.0.22.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
update linglong version to 7.0.22

Log: update linglong version to 7.0.22

## Summary by Sourcery

Update linglong package version to 7.0.22.1 across multiple architectures.