### PR TITLE
fix: replace Text with Label component

### DIFF
--- a/src/music-player/dialogs/EqualizerDialog.qml
+++ b/src/music-player/dialogs/EqualizerDialog.qml
@@ -100,7 +100,7 @@ DialogWindow {
                     Row {
                         anchors.verticalCenter: parent.verticalCenter
 
-                        Text {
+                        Label {
                             width: contentWidth < 55 ? 55 : contentWidth
                             anchors.verticalCenter: parent.verticalCenter
                             text: qsTr("Equalizer")


### PR DESCRIPTION
- Change Text to Label in equalizer title for better UI consistency

Log: replace Text with Label component
Bug: https://pms.uniontech.com/bug-view-301041.html

## Summary by Sourcery

Bug Fixes:
- Fixed UI component inconsistency by replacing Text with Label in the Equalizer title