### PR TITLE
fix: add empty URL check for importMetas

### DIFF
--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -566,6 +566,10 @@ QString Presenter::getCurrentPlayList()
 void Presenter::importMetas(const QStringList &urls, const QString &playlistHash, const bool &playFalg)
 {
     qDebug() << __func__;
+    if (urls.isEmpty()) {
+        qInfo() << "importMetas urls is empty";
+        return;
+    }
     m_data->m_dataManager->importMetas(urls, playlistHash, playFalg);
 }
 


### PR DESCRIPTION
Add validation to prevent processing empty URL lists when importing media files.

Log: add empty URL check for importMetas