### PR TITLE
chore: update version 7.0.23

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.22.1
+  version: 7.0.23.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.23) unstable; urgency=medium
+
+  * chore: New version 7.0.23. 
+
+ -- Liu zheng <liuzheng@uniontech.com>  Thu, 27 Mar 2025 20:21:49 +0800
+
 deepin-music (7.0.22) unstable; urgency=medium
 
   * chore: New version 7.0.22.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.22.1
+  version: 7.0.23.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.22.1
+  version: 7.0.23.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
update version 7.0.23

Log: update version 7.0.23

## Summary by Sourcery

Chores:
- Bump application version from 7.0.22.1 to 7.0.23.1 in linglong configuration files for different architectures