### PR TITLE
chore: update version to 7.0.25

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.24.1
+  version: 7.0.25.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.25) unstable; urgency=medium
+
+  * chore: New version 7.0.25
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 16 Apr 2025 16:19:17 +0800
+
 deepin-music (7.0.24) unstable; urgency=medium
 
   * chore: New version 7.0.24 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.24.1
+  version: 7.0.25.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.24.1
+  version: 7.0.25.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
Update the version of deepin-music to 7.0.25 in all relevant files, including linglong.yaml for arm64 and loong64 architectures, and reflect the change in the debian changelog.

## Summary by Sourcery

Chores:
- Bump application version from 7.0.24.1 to 7.0.25.1 in linglong.yaml files for multiple architectures