### PR TITLE
chore: update version to 7.0.27

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.26.1
+  version: 7.0.27.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.27) unstable; urgency=medium
+
+  * Update version to 7.0.27
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 14 May 2025 11:17:13 +0800
+
 deepin-music (7.0.26) unstable; urgency=medium
 
   * New version 7.0.26 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.26.1
+  version: 7.0.27.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.26.1
+  version: 7.0.27.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- Update the version of deepin-music to 7.0.27

log: update version to 7.0.27

## Summary by Sourcery

Bump the deepin-music package version to 7.0.27.1 across all packaging specifications

Chores:
- Update deepin-music version from 7.0.26.1 to 7.0.27.1 in arm64, loong64, and generic linglong.yaml files
- Revise debian/changelog to reflect the new version