### PR TITLE
fix: high memory usage in music player

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.27.1
+  version: 7.0.28.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.28) unstable; urgency=medium
+
+  * Update version to 7.0.28 
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 22 May 2025 16:05:38 +0800
+
 deepin-music (7.0.27) unstable; urgency=medium
 
   * Update version to 7.0.27

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.27.1
+  version: 7.0.28.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.27.1
+  version: 7.0.28.1
   kind: app
   description: |
     music for deepin os.

--- a/src/libdmusic/player/vlcplayer.cpp
+++ b/src/libdmusic/player/vlcplayer.cpp
@@ -9,6 +9,7 @@
 
 #include <QDBusObjectPath>
 #include <QDBusInterface>
+#include <malloc.h>
 
 #include "vlc/Error.h"
 #include "vlc/Common.h"
@@ -203,6 +204,7 @@ void VlcPlayer::setMediaMeta(MediaMeta meta)
     m_qvplayer->open(m_qvmedia);
     m_qvplayer->setCurMeta(meta);
     emit metaChanged();
+    malloc_trim(0);
 }
 
 void VlcPlayer::setFadeInOutFactor(double fadeInOutFactor)

--- a/src/music-player/mainwindow/Toolbar.qml
+++ b/src/music-player/mainwindow/Toolbar.qml
@@ -540,9 +540,11 @@ FloatingPanel {
     }
     function audioBufferChange(buffer,hash) {
         //console.log("toolbar audioBufferChange:...........")
+        pointList = null;
         pointList = []
         pointList = buffer
         waveform.onAudioDataChanged()
+        gc();
     }
     function onDeleteOneMeta(playlistHashs, hash) {
         for (var i = 0; i < playlistHashs.length; i++){

--- a/src/music-player/toolbar/WaveformRect.qml
+++ b/src/music-player/toolbar/WaveformRect.qml
@@ -93,6 +93,7 @@ Rectangle {
             source: linearGradient
             radius: 48
             transparentBorder: true
+            cached: true
         }
     }
 
@@ -172,6 +173,14 @@ Rectangle {
     }
 
     function onAudioDataChanged() {
+        // 将原有的pathelement手动清理一下
+        for (var i = 0; i < maskPath.pathElements.length; i++) {
+            var item = maskPath.pathElements[i];
+            if (item) {
+                item.destroy();
+            }
+        }
+        gc();
         maskPath.pathElements = []
         var pointCount = shapeMask.width / waveItem.sampleRectWidth / magnification
         var step = Math.floor(pointList.length / pointCount)


### PR DESCRIPTION
- Add preventive measures to reduce memory growth

bug: https://pms.uniontech.com/bug-view-311021.html

## Summary by Sourcery

Fix high memory usage in the music player by implementing explicit cleanup of QML elements, enabling item caching, triggering garbage collection on waveform updates, and trimming the C++ heap after metadata changes.

Bug Fixes:
- Destroy previous waveform path elements and invoke QML garbage collection on audio data changes to prevent memory growth
- Enable caching for waveform rectangles to reduce render overhead
- Trim C++ heap after media metadata updates via malloc_trim to release unused memory
- Reset audio buffer list and trigger garbage collection upon toolbar audio buffer updates