### PR TITLE
chore: [log] Format log output.

### DIFF
--- a/src/libdmusic/player/vlc/MediaPlayer.cpp
+++ b/src/libdmusic/player/vlc/MediaPlayer.cpp
@@ -13,6 +13,7 @@
 #include "Media.h"
 #include "MediaPlayer.h"
 #include "Equalizer.h"
+#include "util/log.h"
 
 #include "dynamiclibraries.h"
 
@@ -83,6 +84,7 @@ VlcMediaPlayer::VlcMediaPlayer(VlcInstance *instance)
     _vlcEqualizer = new VlcEqualizer(this);
 
     //屏蔽视频功能,只支持音频
+    qCDebug(dmMusic) << "Configuring media player - disabling video, enabling CD audio";
     config_PutInt_fc((vlc_object_t *)_vlcMediaPlayer, "video", 0); //0=disable
     //cdda plugin使能
     config_PutInt_fc((vlc_object_t *)_vlcMediaPlayer, "cd-audio", 1);
@@ -99,17 +101,20 @@ VlcMediaPlayer::VlcMediaPlayer(VlcInstance *instance)
 
 VlcMediaPlayer::~VlcMediaPlayer()
 {
+    qCDebug(dmMusic) << "Destroying VLC media player instance";
     removeCoreConnections();
     //释放均衡器
     if (_vlcEqualizer) {
         delete _vlcEqualizer;
         _vlcEqualizer = nullptr;
+        qCDebug(dmMusic) << "Equalizer released";
     }
     vlc_media_player_release_function vlc_media_player_release = (vlc_media_player_release_function)DynamicLibraries::instance()->resolve("libvlc_media_player_release");
     //释放播放器
     if (_vlcMediaPlayer) {
         vlc_media_player_release(_vlcMediaPlayer);
         _vlcEqualizer = nullptr;
+        qCDebug(dmMusic) << "Media player released";
     }
 }
 
@@ -125,6 +130,7 @@ VlcEqualizer *VlcMediaPlayer::equalizer() const
 
 void VlcMediaPlayer::createCoreConnections()
 {
+    qCDebug(dmMusic) << "Creating core media player connections";
     QList<libvlc_event_e> list;
     list << libvlc_MediaPlayerMediaChanged
          << libvlc_MediaPlayerNothingSpecial
@@ -154,6 +160,7 @@ void VlcMediaPlayer::createCoreConnections()
 
 void VlcMediaPlayer::removeCoreConnections()
 {
+    qCDebug(dmMusic) << "Removing core media player connections";
     QList<libvlc_event_e> list;
     list << libvlc_MediaPlayerMediaChanged
          << libvlc_MediaPlayerNothingSpecial
@@ -179,6 +186,7 @@ void VlcMediaPlayer::removeCoreConnections()
     foreach (const libvlc_event_e &event, list) {
         vlc_event_detach(_vlcEvents, event, libvlc_callback, this);
     }
+    qCDebug(dmMusic) << "Core media player connections removed successfully";
 }
 
 int VlcMediaPlayer::length() const
@@ -193,33 +201,43 @@ int VlcMediaPlayer::length() const
 
 void VlcMediaPlayer::open(VlcMedia *media)
 {
+    qCDebug(dmMusic) << "Opening media";
     //防止没打开文件
-    if (media->core() == nullptr)
+    if (media->core() == nullptr) {
+        qCWarning(dmMusic) << "Cannot open media: media core is null";
         return;
+    }
     vlc_media_player_set_media_function vlc_media_player_set_media = (vlc_media_player_set_media_function)DynamicLibraries::instance()->resolve("libvlc_media_player_set_media");
     config_PutInt_func config_PutInt_fc = (config_PutInt_func)DynamicLibraries::instance()->resolve("config_PutInt");
     int track = media->getCdaTrack();
     vlc_media_player_set_media(_vlcMediaPlayer, media->core());
     if (track >= 0) {
+        qCDebug(dmMusic) << "Setting CDA track to:" << track;
         config_PutInt_fc((vlc_object_t *)_vlcMediaPlayer, "cdda-track", track);
     }
 
     VlcError::showErrmsg();
+    qCDebug(dmMusic) << "Media opened successfully";
 }
 
 void VlcMediaPlayer::initCddaTrack()
 {
+    qCDebug(dmMusic) << "Initializing CDDA track";
     /**
      * important:do not modify it,it will open stream failed if does not set cdda-track to zero!
      **/
     config_PutInt_func config_PutInt_fc = (config_PutInt_func)DynamicLibraries::instance()->resolve("config_PutInt");
     config_PutInt_fc((vlc_object_t *)_vlcMediaPlayer, "cdda-track", 0);
+    qCDebug(dmMusic) << "CDDA track initialized to 0";
 }
 
 void VlcMediaPlayer::play()
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot play: media player is null";
         return;
+    }
+    qCDebug(dmMusic) << "Starting playback";
     vlc_media_player_play_function vlc_media_player_play = (vlc_media_player_play_function)DynamicLibraries::instance()->resolve("libvlc_media_player_play");
     vlc_media_player_play(_vlcMediaPlayer);
 
@@ -228,24 +246,38 @@ void VlcMediaPlayer::play()
 
 void VlcMediaPlayer::pause()
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot pause: media player is null";
         return;
+    }
+    qCDebug(dmMusic) << "Attempting to pause playback";
     vlc_media_player_can_pause_function vlc_media_player_can_pause = (vlc_media_player_can_pause_function)DynamicLibraries::instance()->resolve("libvlc_media_player_can_pause");
     vlc_media_player_set_pause_function vlc_media_player_set_pause = (vlc_media_player_set_pause_function)DynamicLibraries::instance()->resolve("libvlc_media_player_set_pause");
-    if (vlc_media_player_can_pause(_vlcMediaPlayer))
+    if (vlc_media_player_can_pause(_vlcMediaPlayer)) {
         vlc_media_player_set_pause(_vlcMediaPlayer, true);
+        qCDebug(dmMusic) << "Playback paused";
+    } else {
+        qCWarning(dmMusic) << "Media cannot be paused";
+    }
 
     VlcError::showErrmsg();
 }
 
 void VlcMediaPlayer::resume()
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot resume: media player is null";
         return;
+    }
+    qCDebug(dmMusic) << "Attempting to resume playback";
     vlc_media_player_can_pause_function vlc_media_player_can_pause = (vlc_media_player_can_pause_function)DynamicLibraries::instance()->resolve("libvlc_media_player_can_pause");
     vlc_media_player_set_pause_function vlc_media_player_set_pause = (vlc_media_player_set_pause_function)DynamicLibraries::instance()->resolve("libvlc_media_player_set_pause");
-    if (vlc_media_player_can_pause(_vlcMediaPlayer))
+    if (vlc_media_player_can_pause(_vlcMediaPlayer)) {
         vlc_media_player_set_pause(_vlcMediaPlayer, false);
+        qCDebug(dmMusic) << "Playback resumed";
+    } else {
+        qCWarning(dmMusic) << "Media cannot be resumed";
+    }
 
     VlcError::showErrmsg();
 }
@@ -259,14 +291,19 @@ void VlcMediaPlayer::setTime(qint64 time)
     if (!(state() == Vlc::Buffering
             || state() == Vlc::Playing
             || state() == Vlc::Paused
-            ||  state() == Vlc::Opening))
+            ||  state() == Vlc::Opening)) {
+        qCWarning(dmMusic) << "Cannot set time: invalid state" << state();
         return;
+    }
 #else
     if (!(state() == Vlc::Buffering
             || state() == Vlc::Playing
-            || state() == Vlc::Paused))
+            || state() == Vlc::Paused)) {
+        qCWarning(dmMusic) << "Cannot set time: invalid state" << state();
         return;
+    }
 #endif
+    qCDebug(dmMusic) << "Setting time to:" << time;
     vlc_media_player_set_time_function vlc_media_player_set_time = (vlc_media_player_set_time_function)DynamicLibraries::instance()->resolve("libvlc_media_player_set_time");
     vlc_media_player_set_time(_vlcMediaPlayer, time);
 
@@ -278,8 +315,11 @@ void VlcMediaPlayer::setTime(qint64 time)
 
 void VlcMediaPlayer::setVolume(int volume)
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot set volume: media player is null";
         return;
+    }
+    qCDebug(dmMusic) << "Setting volume to:" << volume;
     vlc_audio_set_volume_function vlc_audio_set_volume = (vlc_audio_set_volume_function)DynamicLibraries::instance()->resolve("libvlc_audio_set_volume");
     vlc_audio_set_volume(_vlcMediaPlayer, volume);
 
@@ -288,8 +328,11 @@ void VlcMediaPlayer::setVolume(int volume)
 
 void VlcMediaPlayer::setMute(bool mute)
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot set mute: media player is null";
         return;
+    }
+    qCDebug(dmMusic) << "Setting mute to:" << mute;
     vlc_audio_set_mute_function vlc_audio_set_mute = (vlc_audio_set_mute_function)DynamicLibraries::instance()->resolve("libvlc_audio_set_mute");
     vlc_audio_set_mute(_vlcMediaPlayer, mute ? 1 : 0);
 
@@ -298,22 +341,30 @@ void VlcMediaPlayer::setMute(bool mute)
 
 Vlc::State VlcMediaPlayer::state() const
 {
+    qCDebug(dmMusic) << "Getting player state";
     // It's possible that the vlc doesn't play anything
     // so check before
     vlc_media_player_get_media_function vlc_media_player_get_media = (vlc_media_player_get_media_function)DynamicLibraries::instance()->resolve("libvlc_media_player_get_media");
-    if (!vlc_media_player_get_media(_vlcMediaPlayer))
+    if (!vlc_media_player_get_media(_vlcMediaPlayer)) {
+        qCDebug(dmMusic) << "No media loaded, returning Idle state";
         return Vlc::Idle;
+    }
 
     libvlc_state_t state;
     vlc_media_player_get_state_function vlc_media_player_get_state = (vlc_media_player_get_state_function)DynamicLibraries::instance()->resolve("libvlc_media_player_get_state");
     state = vlc_media_player_get_state(_vlcMediaPlayer);
+    qCDebug(dmMusic) << "Current player state:" << state;
 
     return Vlc::State(state);
 }
+
 void VlcMediaPlayer::stop()
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot stop: media player is null";
         return;
+    }
+    qCDebug(dmMusic) << "Stopping playback";
     vlc_media_player_stop_function vlc_media_player_stop = (vlc_media_player_stop_function)DynamicLibraries::instance()->resolve("libvlc_media_player_stop");
     vlc_media_player_stop(_vlcMediaPlayer);
 
@@ -322,11 +373,12 @@ void VlcMediaPlayer::stop()
 
 int VlcMediaPlayer::time() const
 {
+    qCDebug(dmMusic) << "Getting current time";
     vlc_media_player_get_time_function vlc_media_player_get_time = (vlc_media_player_get_time_function)DynamicLibraries::instance()->resolve("libvlc_media_player_get_time");
     libvlc_time_t time = vlc_media_player_get_time(_vlcMediaPlayer);
 
     VlcError::showErrmsg();
-
+    qCDebug(dmMusic) << "Current time:" << time;
     return time;
 }
 
@@ -337,99 +389,135 @@ void VlcMediaPlayer::libvlc_callback(const libvlc_event_t *event,
     VlcMediaPlayer *core = static_cast<VlcMediaPlayer *>(data);
     switch (event->type) {
     case libvlc_MediaPlayerMediaChanged:
+        qCDebug(dmMusic) << "Media player event: Media changed";
         emit core->mediaChanged(event->u.media_player_media_changed.new_media);
         break;
     case libvlc_MediaPlayerNothingSpecial:
+        qCDebug(dmMusic) << "Media player event: Nothing special";
         emit core->nothingSpecial();
         break;
     case libvlc_MediaPlayerOpening:
+        qCDebug(dmMusic) << "Media player event: Opening";
         emit core->opening();
         break;
     case libvlc_MediaPlayerBuffering:
+        qCDebug(dmMusic) << "Media player event: Buffering" << event->u.media_player_buffering.new_cache << "%";
         emit core->buffering(event->u.media_player_buffering.new_cache);
         emit core->buffering(qRound(event->u.media_player_buffering.new_cache));
         break;
     case libvlc_MediaPlayerPlaying:
+        qCDebug(dmMusic) << "Media player event: Playing";
         emit core->playing();
         break;
     case libvlc_MediaPlayerPaused:
+        qCDebug(dmMusic) << "Media player event: Paused";
         emit core->paused();
         break;
     case libvlc_MediaPlayerStopped:
+        qCDebug(dmMusic) << "Media player event: Stopped";
         emit core->stopped();
         break;
     case libvlc_MediaPlayerForward:
+        qCDebug(dmMusic) << "Media player event: Forward";
         emit core->forward();
         break;
     case libvlc_MediaPlayerBackward:
+        qCDebug(dmMusic) << "Media player event: Backward";
         emit core->backward();
         break;
     case libvlc_MediaPlayerEndReached:
+        qCDebug(dmMusic) << "Media player event: End reached";
         emit core->end(); //play end
         break;
     case libvlc_MediaPlayerEncounteredError:
+        qCCritical(dmMusic) << "Media player event: Error encountered";
         emit core->error();
         break;
 //    case libvlc_MediaPlayerTimeChanged:
 //        emit core->timeChanged(event->u.media_player_time_changed.new_time);
 //        break;
     case libvlc_MediaPlayerPositionChanged:
+        qCDebug(dmMusic) << "Media player event: Position changed to" << event->u.media_player_position_changed.new_position;
         emit core->positionChanged(event->u.media_player_position_changed.new_position);
         break;
     case libvlc_MediaPlayerSeekableChanged:
+        qCDebug(dmMusic) << "Media player event: Seekable changed to" << event->u.media_player_seekable_changed.new_seekable;
         emit core->seekableChanged(event->u.media_player_seekable_changed.new_seekable);
         break;
     case libvlc_MediaPlayerPausableChanged:
+        qCDebug(dmMusic) << "Media player event: Pausable changed to" << event->u.media_player_pausable_changed.new_pausable;
         emit core->pausableChanged(event->u.media_player_pausable_changed.new_pausable);
         break;
     case libvlc_MediaPlayerTitleChanged:
+        qCDebug(dmMusic) << "Media player event: Title changed to" << event->u.media_player_title_changed.new_title;
         emit core->titleChanged(event->u.media_player_title_changed.new_title);
         break;
     case libvlc_MediaPlayerSnapshotTaken:
+        qCDebug(dmMusic) << "Media player event: Snapshot taken" << event->u.media_player_snapshot_taken.psz_filename;
         emit core->snapshotTaken(event->u.media_player_snapshot_taken.psz_filename);
         break;
     case libvlc_MediaPlayerLengthChanged:
+        qCDebug(dmMusic) << "Media player event: Length changed to" << event->u.media_player_length_changed.new_length;
         emit core->lengthChanged(event->u.media_player_length_changed.new_length);
         break;
     case libvlc_MediaPlayerVout:
+        qCDebug(dmMusic) << "Media player event: Video output count changed to" << event->u.media_player_vout.new_count;
         emit core->vout(event->u.media_player_vout.new_count);
         break;
     default:
+        qCDebug(dmMusic) << "Media player event: Unknown event type" << event->type;
         break;
     }
 
     if (event->type >= libvlc_MediaPlayerNothingSpecial
             && event->type <= libvlc_MediaPlayerEncounteredError) {
+        qCDebug(dmMusic) << "Media player state changed";
         emit core->stateChanged();
     }
 }
 
 float VlcMediaPlayer::position()
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot get position: media player is null";
         return -1;
+    }
+    qCDebug(dmMusic) << "Getting playback position";
     vlc_media_player_get_position_function vlc_media_player_get_position = (vlc_media_player_get_position_function)DynamicLibraries::instance()->resolve("libvlc_media_player_get_position");
-    return vlc_media_player_get_position(_vlcMediaPlayer);
+    float pos = vlc_media_player_get_position(_vlcMediaPlayer);
+    qCDebug(dmMusic) << "Current position:" << pos;
+    return pos;
 }
 
 int VlcMediaPlayer::getVolume()
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot get volume: media player is null";
         return -1;
+    }
+    qCDebug(dmMusic) << "Getting volume";
     vlc_audio_get_volume_function vlc_audio_get_volume = (vlc_audio_get_volume_function)DynamicLibraries::instance()->resolve("libvlc_audio_get_volume");
-    return vlc_audio_get_volume(_vlcMediaPlayer);
+    int vol = vlc_audio_get_volume(_vlcMediaPlayer);
+    qCDebug(dmMusic) << "Current volume:" << vol;
+    return vol;
 }
 
 bool VlcMediaPlayer::getMute()
 {
-    if (!_vlcMediaPlayer)
+    if (!_vlcMediaPlayer) {
+        qCWarning(dmMusic) << "Cannot get mute state: media player is null";
         return -1;
+    }
+    qCDebug(dmMusic) << "Getting mute state";
     vlc_audio_get_mute_function vlc_audio_get_mute = (vlc_audio_get_mute_function)DynamicLibraries::instance()->resolve("libvlc_audio_get_mute");
-    return vlc_audio_get_mute(_vlcMediaPlayer) > 0 ? true : false;
+    bool muted = vlc_audio_get_mute(_vlcMediaPlayer) > 0;
+    qCDebug(dmMusic) << "Current mute state:" << muted;
+    return muted;
 }
 
 void VlcMediaPlayer::setPosition(float pos)
 {
+    qCDebug(dmMusic) << "Setting position to:" << pos;
     vlc_media_player_set_position_function vlc_media_player_set_position = (vlc_media_player_set_position_function)DynamicLibraries::instance()->resolve("libvlc_media_player_set_position");
     vlc_media_player_set_position(_vlcMediaPlayer, pos);
 

--- a/src/libdmusic/player/vlc/checkdatazerothread.cpp
+++ b/src/libdmusic/player/vlc/checkdatazerothread.cpp
@@ -7,6 +7,7 @@
 
 #include "playerengine.h"
 #include <QDebug>
+#include "util/log.h"
 
 extern int g_playbackStatus;
 
@@ -21,17 +22,24 @@ CheckDataZeroThread::CheckDataZeroThread(QObject *parent, SdlPlayer *player)
 
 void CheckDataZeroThread::initTimeParams()
 {
-    if (m_player->getCurMeta().localPath.isEmpty())
+    qCDebug(dmMusic) << "Initializing time parameters";
+    if (m_player->getCurMeta().localPath.isEmpty()) {
+        qCWarning(dmMusic) << "Current meta local path is empty, skipping time params initialization";
         return;
+    }
     m_currentTime = static_cast<qint64>(m_player->position() * m_player->length());
     m_duration = m_player->length();
     m_step = (m_duration - m_currentTime) / POSITION_STEP_COUNT;
+    qCDebug(dmMusic) << "Time params initialized - Current time:" << m_currentTime 
+                     << "Duration:" << m_duration << "Step:" << m_step;
 }
 
 void CheckDataZeroThread::run()
 {
+    qCDebug(dmMusic) << "Starting CheckDataZeroThread run loop";
     while (!m_bExit) {
         if (g_playbackStatus == 2) {
+            qCDebug(dmMusic) << "Playback status is 2, sending final time data";
             // 发送最后一秒的数据，保证进度能显示到最后一秒
             if (m_currentTime > 0)
                 emit sigExtraTime(m_duration);
@@ -43,6 +51,7 @@ void CheckDataZeroThread::run()
 
         if (g_playbackStatus == 1 && m_currentTime > 0) {
             if (m_player->getCurMeta().localPath.isEmpty()) {
+                qCWarning(dmMusic) << "Current meta local path is empty during playback, resetting parameters";
                 resetParam();
                 continue;
             }
@@ -54,10 +63,13 @@ void CheckDataZeroThread::run()
         }
         msleep(300);
     }
+    qCDebug(dmMusic) << "CheckDataZeroThread run loop ended";
 }
 
 void CheckDataZeroThread::resetParam()
 {
+    qCDebug(dmMusic) << "Resetting parameters - Current values - Time:" << m_currentTime 
+                     << "Step:" << m_step << "Duration:" << m_duration;
     m_currentTime = 0;
     m_step = 0;
     m_duration = 0;

--- a/src/libdmusic/util/log.cpp
+++ b/src/libdmusic/util/log.cpp
@@ -1,0 +1,3 @@
+#include "log.h"
+
+Q_LOGGING_CATEGORY(dmMusic, "deepin.music") 

--- a/src/libdmusic/util/log.h
+++ b/src/libdmusic/util/log.h
@@ -1,0 +1,8 @@
+#ifndef UTIL_LOG_H
+#define UTIL_LOG_H
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(dmMusic)
+
+#endif // UTIL_LOG_H 


### PR DESCRIPTION
Format the log output.

Log: Format the log output.

## Summary by Sourcery

Standardize and enhance logging across the codebase by introducing a dedicated logging category and replacing ad hoc debug prints with structured qCInfo, qCDebug, qCWarning, and qCCritical calls.

Enhancements:
- Add util/log.h and declare the dmMusic logging category
- Replace raw qDebug/qWarning/qCritical calls with category-based qCXX(dmMusic) logging
- Augment DataManager with detailed log statements for playlist, meta, and database operations
- Improve logging in SDL and Qt players, VLC media/player classes, and PlayerEngine for playback events and state changes
- Add contextual debug/info/warning/critical messages in AudioAnalysis, LyricAnalysis, CdaThread, DynamicLibraries, Global, Presenter, and Utils modules to include key variable values