### PR TITLE
fix: [volume] Fix volume synchronization issues when switching betwee…

### DIFF
--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -168,6 +168,12 @@ void QtPlayer::setVolume(int volume)
 {
     init();
     m_mediaPlayer->setVolume(volume);
+    m_mediaPlayer->setPosition(m_mediaPlayer->position() + 1); //微小跳转（触发解码器刷新） 1ms
+}
+
+int QtPlayer::getVolume()
+{
+    return m_mediaPlayer->volume();
 }
 
 void QtPlayer::setMute(bool value)
@@ -239,7 +245,6 @@ void QtPlayer::resetPlayInfo()
     readSinkInputPath();
 
     if (m_sinkInputPath.isEmpty()) return;
-
     QVariant volumeV = DBusUtils::readDBusProperty("com.deepin.daemon.Audio", m_sinkInputPath,
                                                    "com.deepin.daemon.Audio.SinkInput", "Volume");
 

--- a/src/music-player/core/qtplayer.h
+++ b/src/music-player/core/qtplayer.h
@@ -31,6 +31,7 @@ public:
     void setTime(qint64 time) override;
     qint64 time() override;
     void setVolume(int volume) override;
+    int getVolume();
     void setMute(bool value) override;
     void setMediaMeta(MediaMeta meta) override;
     bool getMute() override;


### PR DESCRIPTION
…n APE and non-APE audio formats

- Volume becomes unresponsive when switching from muted non-APE format to APE format
- Volume remains muted when switching from muted APE format to non-APE format until manual progress bar interaction
- Audio engine state desynchronization between QtPlayer and VlcPlayer

Log: Fixed volume and mute state synchronization problems when switching between different audio engines (QtPlayer for APE, VlcPlayer for others)

Bug:https://pms.uniontech.com/bug-view-319219.html

## Summary by Sourcery

Synchronize volume and mute state across QtPlayer and VlcPlayer when switching between APE and non-APE formats, and ensure volume updates take effect immediately.

Bug Fixes:
- Synchronize mute and volume states when switching audio engines between APE (QtPlayer) and non-APE (VlcPlayer).

Enhancements:
- Trigger a 1 ms position jump in QtPlayer after setting volume to refresh the decoder.
- Expose getVolume() in QtPlayer to support state synchronization.