### PR TITLE
chore: update version 7.0.30

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.29.1
+  version: 7.0.30.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.30) unstable; urgency=medium
+
+  * fix debug log
+
+ -- liuzheng <liuzheng@uniontech.com>  Sun, 22 Jun 2025 00:35:05 +0800
+
 deepin-music (7.0.29) unstable; urgency=medium
 
   * chore: Update dman's resources

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.29.1
+  version: 7.0.30.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.29.1
+  version: 7.0.30.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
update version 7.0.30

Log: update version 7.0.30

## Summary by Sourcery

Bump deepin-music package version to 7.0.30.1 across packaging manifests and changelog

Chores:
- Update version in ARM64, x86_64, and Loong64 linglong.yaml manifests to 7.0.30.1
- Update Debian changelog for version 7.0.30