### PR TITLE
 fix: Update music section headers in translation files

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.31.1
+  version: 7.0.32.1
   kind: app
   description: |
     music for deepin os.

--- a/assets/deepin-music/music/en_US/music.md
+++ b/assets/deepin-music/music/en_US/music.md
@@ -1,4 +1,4 @@
-# Music | deepin-music
+# Music |deepin-music|
 
 ## Overview
 

--- a/assets/deepin-music/music/en_US/music.md
+++ b/assets/deepin-music/music/en_US/music.md
@@ -1,4 +1,4 @@
-# Music |deepin-music|
+# Music|deepin-music|
 
 ## Overview
 

--- a/assets/deepin-music/music/zh_HK/music.md
+++ b/assets/deepin-music/music/zh_HK/music.md
@@ -1,4 +1,4 @@
-# 音樂 | deepin-music
+# 音樂 |deepin-music|
 
 ## 概述
 

--- a/assets/deepin-music/music/zh_HK/music.md
+++ b/assets/deepin-music/music/zh_HK/music.md
@@ -1,4 +1,4 @@
-# 音樂 |deepin-music|
+# 音樂|deepin-music|
 
 ## 概述
 

--- a/assets/deepin-music/music/zh_TW/music.md
+++ b/assets/deepin-music/music/zh_TW/music.md
@@ -1,4 +1,4 @@
-# 音樂 | deepin-music
+# 音樂 |deepin-music|
 
 ## 概述
 

--- a/assets/deepin-music/music/zh_TW/music.md
+++ b/assets/deepin-music/music/zh_TW/music.md
@@ -1,4 +1,4 @@
-# 音樂 |deepin-music|
+# 音樂|deepin-music|
 
 ## 概述
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.32) unstable; urgency=medium
+
+  * fix: Update music section headers in translation files
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Tue, 24 Jun 2025 17:29:20 +0800
+
 deepin-music (7.0.31) unstable; urgency=medium
 
   * Update version to 7.0.31

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.31.1
+  version: 7.0.32.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.31.1
+  version: 7.0.32.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
fix: Update music section headers in translation files
   
   - Adjusted the formatting of section headers in English, Traditional Chinese, and Hong Kong Chinese music markdown files to remove extra spaces around "deepin-music".
   
   bug: https://pms.uniontech.com/bug-view-321609.html

## Summary by Sourcery

Fix formatting of music section headers in translation markdown files and bump deepin-music version to 7.0.32.1 in manifests

Bug Fixes:
- Remove extra spaces around "deepin-music" in music section headers across English, Traditional Chinese, and Hong Kong Chinese translation files.

Enhancements:
- Update deepin-music version from 7.0.31.1 to 7.0.32.1 in architecture-specific YAML manifests.