### PR TITLE
chore: Update version to 7.0.38 and package URLs in linglong.yaml fil…

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.37.1
+  version: 7.0.38.1
   kind: app
   description: |
     music for deepin os.
@@ -870,8 +870,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_arm64.deb
     digest: dead175491c1ee86faacf68a361f8acc700ff340d008c99ce51cf7737c1ae438
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/protobuf/libprotobuf-lite32_3.21.12-8deepin1+rb1_arm64.deb
-    digest: e2639478e140d50cfb505cfe313c01d89448618504499ac6ebe0efbe8b86569e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/protobuf/libprotobuf-lite32_3.21.12-8deepin2_arm64.deb
+    digest: a396580c8f1d14e41a4a003bd577be0bd0616dc6fe0ff2a90f90cfd937cc6bd3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb
     digest: c4961acabed64ea88a254ba89930110925ea89fb182f5d088e428503d9c531fe
@@ -1032,11 +1032,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_arm64.deb
     digest: 06467b3c81e07336f2e7381ebde3b511f8a1d1dfa5c6ef8c74504589445a86fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0-dev_0.2.2-1_arm64.deb
-    digest: ab3f731a5af6e5ac38350af354ff80b5acb03016b0dc16dad0b16092b75017cb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0-dev_0.2.2-4_arm64.deb
+    digest: d0b511236c320bc6e569eb56e698d94b1b4e05a38f0c79cb45b14da0d1904554
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_arm64.deb
-    digest: 84c039697e041663bd4b7de673b0755d8ea5375a7c026809a81d986c0a3f6683
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-4_arm64.deb
+    digest: 9103fc5202e468b8652f90a589d813aa4f2d1d50cddc6e4dd39ed7c74d14348c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_arm64.deb
     digest: 15b8585dbd98a84d43b18797fb0619363087f91bff7ca70f042a9d0a63c9060b

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-music (7.0.38) unstable; urgency=medium
+
+  * chore: Update version to 7.0.37
+  * resolve compile error
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 11 Jul 2025 09:48:53 +0800
+
 deepin-music (7.0.37) unstable; urgency=medium
 
   * chore: Update package URLs and digests in linglong.yaml files

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.37.1
+  version: 7.0.38.1
   kind: app
   description: |
     music for deepin os.
@@ -864,8 +864,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_amd64.deb
     digest: 6c5525e0cc7c8c9b719ad4ba0f4fad45e717029026fd6f8052990b8767a4695b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/protobuf/libprotobuf-lite32_3.21.12-8deepin1+rb1_amd64.deb
-    digest: 5e164ae64eca0438f4c1c01e7348f10943e85b354233ca06ea981b1cb72f0e64
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/protobuf/libprotobuf-lite32_3.21.12-8deepin2_amd64.deb
+    digest: 6534df1a0417ffc6a0dbf87cf0519a193aa87e10d49a82b794bfe55da89f1a4f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb
     digest: 4ad4360252e008b89ea7885a7c27e2df5af4a45e0aede319e08b17db3c3af932
@@ -1026,11 +1026,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_amd64.deb
     digest: 9743d579d479e0e2ef99f984986b2d9d40d7e0a43b6f0f74b935f3fd2d5b6caa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0-dev_0.2.2-1_amd64.deb
-    digest: b0f50dd7eb7bdb0ab997c7c149609bf78ac964804ed1552e5a228607e560af8b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0-dev_0.2.2-4_amd64.deb
+    digest: dde86dc32286de0a58930cdc9fb39d6d0b31af2befaf42615cfaf58984a0eb02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_amd64.deb
-    digest: 8ba9b50925d6722aad9a86f36483cc5cbf169c6199b21edd84f43bf142608cf5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-4_amd64.deb
+    digest: 50496e43facbda6b5c6a814a66adbbb2a42f8fb994cbf7a16d0bdb6b2aae648e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_amd64.deb
     digest: 9ff9bfa155660e99d78ab3501392fd17381adcb90bdf2457bac8c3af296b3815

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.37.1
+  version: 7.0.38.1
   kind: app
   description: |
     music for deepin os.
@@ -855,8 +855,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_loong64.deb
     digest: 6300c6ae6f8bcd6d0bef4a0d2007561ee359c7c23f9867a9cbfbcdb3a09c0292
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/protobuf/libprotobuf-lite32_3.21.12-8deepin1+rb1_loong64.deb
-    digest: a8b4e3b895ef204d27a2a743429f88f50e9eff02d373af73852281be95c4b62e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/protobuf/libprotobuf-lite32_3.21.12-8deepin2_loong64.deb
+    digest: 7054b0662f5a7c7d5ebf5f1d12f5a1d1f6b8f1bb54fe185b1d467e54a65bca12
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_loong64.deb
     digest: 450c63cece1053b61ad1db303e20cf3008cd130f59907df2610dee985a1ac250
@@ -1017,11 +1017,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_loong64.deb
     digest: 8809a7bd4cd047bccc1e7198bfb8e154716a647cc619ac7d49cbde13b7ebcb1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0-dev_0.2.2-1_loong64.deb
-    digest: cdb0eb729d111dc04c15171ab67538a80a0ce106d6c86a6335b1f15bf701a99b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0-dev_0.2.2-4_loong64.deb
+    digest: 7a06fe6c970752c28e1925a99bf13f2c159e924ede5fa9ef3052d2de216b072a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_loong64.deb
-    digest: 923a9d2f3cf3cbd71aa95c2451e47021ba3c4b93789a8128b93b8df4f8090d82
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-4_loong64.deb
+    digest: c7e17646918c98cbb93f359684ccdb448ab4e3959bc343330d0369c49b29f9e8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_loong64.deb
     digest: 330cc540349e985f4837e68c0c021dede1939f25516cbbb1dc7016ca0595ce4f

--- a/src/libdmusic/core/audioanalysis.cpp
+++ b/src/libdmusic/core/audioanalysis.cpp
@@ -202,13 +202,13 @@ bool AudioAnalysis::parseFileTagCodec(DMusic::MediaMeta &meta)
         meta.localPath.clear();
         return false;
     }
-    meta.length = t_audioProperties->length() * 1000;
+    meta.length = t_audioProperties->lengthInSeconds() * 1000;
     qCDebug(dmMusic) << "Audio length detected:" << meta.length << "ms for file:" << meta.localPath;
 
     bool encode = true;
-    encode &= tag->title().isNull() ? true : tag->title().isLatin1();
-    encode &= tag->artist().isNull() ? true : tag->artist().isLatin1();
-    encode &= tag->album().isNull() ? true : tag->album().isLatin1();
+    encode &= tag->title().isEmpty() ? true : tag->title().isLatin1();
+    encode &= tag->artist().isEmpty() ? true : tag->artist().isLatin1();
+    encode &= tag->album().isEmpty() ? true : tag->album().isLatin1();
     if (encode) {
         qCDebug(dmMusic) << "Tag contains Latin1 encoded data, detecting encoding for file:" << meta.localPath;
         if (detectCodec.isEmpty()) {


### PR DESCRIPTION
…es & resolve compile error

- resolve compile error in linglong
- Updated version to 7.0.38 across all architectures.
- Modified package URLs and digests for protobuf and libsamplerate in linglong.yaml files.

Log: Update version to 7.0.38 and package URLs in linglong.yaml files.

## Summary by Sourcery

Bump deepin-music to version 7.0.38.1 across all architectures, update protobuf and libsamplerate package URLs and digests in linglong.yaml, and resolve compile errors in AudioAnalysis code.

Bug Fixes:
- Replace deprecated AudioProperties::length() with lengthInSeconds() and switch null checks to isEmpty() in audioanalysis.cpp to fix compilation.

Enhancements:
- Update deepin-music version to 7.0.38.1 in all linglong.yaml files.
- Refresh protobuf and libsamplerate package URLs and digests for arm64, amd64, and loong64 architectures.