### PR TITLE
fix: [ape] 修复两个播放APE格式音频时出现的异常

### DIFF
--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -217,7 +217,8 @@ bool QtPlayer::setDbusMute(bool value)
         if (!ainterface.isValid()) {
             return false;
         }
-        ainterface.call(QLatin1String("SetMute"), value);
+        if (isDbusMuted() != value)
+            ainterface.call(QLatin1String("SetMute"), value);
         return true;
     }
     return false;

--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -168,7 +168,6 @@ void QtPlayer::setVolume(int volume)
 {
     init();
     m_mediaPlayer->setVolume(volume);
-    m_mediaPlayer->setPosition(m_mediaPlayer->position() + 1); //微小跳转（触发解码器刷新） 1ms
 }
 
 int QtPlayer::getVolume()


### PR DESCRIPTION
1. 调整音量时出现提示音
反复调用setMute接口，该接口会由DTK触发提示音，减少setMute接口的无效调用。

2. 播放ape格式时，调整音量卡顿。
之前发现ape格式在播放时，因为ape格式解码较慢，调整音量会不及时，造成延迟。 所以添加了setPosition来重置解码器，但是
该行为会造成部分机器上卡顿，且可能影响其他格式音乐在QMdiapleayer的播放，暂时取消该改动。后续再评测是否应该修改。

## Summary by Sourcery

Prevent redundant mute commands and remove micro-seeking on volume changes to fix notification beeps and APE playback stutter.

Bug Fixes:
- Only invoke D-Bus SetMute when the mute state actually changes to suppress repeating notification sounds
- Remove the 1ms position jump in setVolume to eliminate playback stutter when adjusting volume on APE format audio