### PR TITLE
Multiple fixes

### DIFF
--- a/src/libdmusic/CMakeLists.txt
+++ b/src/libdmusic/CMakeLists.txt
@@ -43,10 +43,11 @@ set_target_properties(dmusic PROPERTIES VERSION 1.0.0 SOVERSION 1.0)
 pkg_check_modules(MPRIS REQUIRED IMPORTED_TARGET mpris-qt6)
 pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
 pkg_check_modules(DTK REQUIRED IMPORTED_TARGET dtk6core)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavcodec libavformat)
 # pkg_check_modules(udisks2 REQUIRED IMPORTED_TARGET udisks2-qt5)
 
 set(TARGET_LIBS PkgConfig::TAGLIB PkgConfig::DTK)
-target_link_libraries(${CMD_NAME} ${TARGET_LIBS} PkgConfig::MPRIS PkgConfig::TAGLIB PkgConfig::DTK ICU::i18n)
+target_link_libraries(${CMD_NAME} ${TARGET_LIBS} PkgConfig::MPRIS PkgConfig::TAGLIB PkgConfig::DTK ICU::i18n PkgConfig::FFMPEG)
 target_link_libraries(${CMD_NAME} Qt6::Core Qt6::Multimedia Qt6::DBus Qt6::Sql Qt6::Core5Compat)
 
 # qt5_use_modules(${CMD_NAME} )

--- a/src/libdmusic/core/audioanalysis.cpp
+++ b/src/libdmusic/core/audioanalysis.cpp
@@ -480,7 +480,11 @@ void AudioAnalysis::parseMetaCover(DMusic::MediaMeta &meta)
             format_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr);
 
             if (pFormatCtx) {
+#if LIBAVFORMAT_VERSION_MAJOR < 61
                 if (pFormatCtx->iformat != nullptr && pFormatCtx->iformat->read_header(pFormatCtx) >= 0) {
+#else
+                if (avformat_find_stream_info(pFormatCtx, nullptr) >= 0) {
+#endif
                     for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
                         if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
                             AVPacket pkt = pFormatCtx->streams[i]->attached_pic;
@@ -581,7 +585,11 @@ QImage AudioAnalysis::getMetaCoverImage(DMusic::MediaMeta meta)
                 return image;
             }
 
+#if LIBAVFORMAT_VERSION_MAJOR < 61
             if (pFormatCtx->iformat != nullptr && pFormatCtx->iformat->read_header(pFormatCtx) >= 0) {
+#else
+            if (avformat_find_stream_info(pFormatCtx, nullptr) >= 0) {
+#endif
                 for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
                     if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
                         AVPacket pkt = pFormatCtx->streams[i]->attached_pic;

--- a/src/libdmusic/core/audioanalysis.cpp
+++ b/src/libdmusic/core/audioanalysis.cpp
@@ -206,9 +206,15 @@ bool AudioAnalysis::parseFileTagCodec(DMusic::MediaMeta &meta)
     qCDebug(dmMusic) << "Audio length detected:" << meta.length << "ms for file:" << meta.localPath;
 
     bool encode = true;
+#if TAGLIB_MAJOR_VERSION > 1 || (TAGLIB_MAJOR_VERSION == 1 && TAGLIB_MINOR_VERSION >= 11)
     encode &= tag->title().isEmpty() ? true : tag->title().isLatin1();
     encode &= tag->artist().isEmpty() ? true : tag->artist().isLatin1();
     encode &= tag->album().isEmpty() ? true : tag->album().isLatin1();
+#else
+    encode &= tag->title().isNull() ? true : tag->title().isLatin1();
+    encode &= tag->artist().isNull() ? true : tag->artist().isLatin1();
+    encode &= tag->album().isNull() ? true : tag->album().isLatin1();
+#endif
     if (encode) {
         qCDebug(dmMusic) << "Tag contains Latin1 encoded data, detecting encoding for file:" << meta.localPath;
         if (detectCodec.isEmpty()) {


### PR DESCRIPTION
- fix: Link against FFmpeg libraries via pkg-config
- fix: Support libavformat >= 61 (FFmpeg 7)
- chore: Fix tag encoding detection for older TagLib versions
