### PR TITLE
fix: resolve music player startup deadlock issue

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -1173,26 +1173,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_arm64.deb
     digest: 694573210aea6173c54cc5084a8c29aa2001200e0a1e2144d6338463050f3979
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-c-dev_2.0.2-2_arm64.deb
-    digest: 7afba4378d9fd3caf48d95f750035aab5b2a2181166537cd82262b93ed633489
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1-dev_1.12-1deepin0_arm64.deb
+    digest: 09f7860b7d5a1b2015828f0e541771f4fae109593fa5f5021908c6b6b8b044cb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-c2_2.0.2-2_arm64.deb
-    digest: 84b7d919019292c9a20738038a32399d42b369f22eb431ac22ca7213837ed671
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_arm64.deb
+    digest: 11a3b9c567f890b509d68c0c5ff52a87c5697d94eccb5ca45271eb2e1fa6b20d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-dev_2.0.2-2_arm64.deb
-    digest: e988b8b2da3710226a4b7b57935d3df96ad79b64a036986912b744295b344eac
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1-dev_2.0.2-2_arm64.deb
-    digest: 4fef240ed5f4929ed9dfcfc14ad5d12907f96392fc26fd05b2c25aba5f9c4f30
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_arm64.deb
-    digest: 287d31cf9321b19b5c7d104e8e1be43c0e6c4536cd64eab2b6c9813ebe1772b5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5_1.12-1deepin0_arm64.deb
-    digest: b39662c030536a2562c91ab82dbfb6c876062b277fb0a0bed667030e8b288872
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag2_2.0.2-2_arm64.deb
-    digest: 1594f7a4e760da7851069bc151a6021d42194f553bb6eea9da8c643fd194c0d3
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1v5_1.12-1deepin0_arm64.deb
+    digest: b60df9b4459c014d4294dd9203611fd45c99faa45daa09a6d46860957abbbebc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
     digest: a193d7e19d36227ab39cc199ed2601bd6bbb91baddaa26dad3a2530288a57cab

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1167,26 +1167,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_amd64.deb
     digest: 75f4b1c1d7e0caf4127313225fb3be35243b09df4cf93e0225f5fb27e6c4074d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-c-dev_2.0.2-2_amd64.deb
-    digest: 149f03b2a1315e50db88e17ae2736a751d745da2060cbc11f728133976b7540b
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1-dev_1.12-1deepin0_amd64.deb
+    digest: 2a88bac2c2e961ddb524b17bd62940438b99f734421956c5b171ef8b9376c766
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-c2_2.0.2-2_amd64.deb
-    digest: 8cecce4c82c39e2c48bfd9e63842fbb1b4005b840deae6a8b73c8b58a2f86ce6
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_amd64.deb
+    digest: 6212c1eb5ca1e4a9340e0c6737acde50c96b23095e0889b551bdd0a51b860696
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-dev_2.0.2-2_amd64.deb
-    digest: 806751c462a8f3b2fb91df809e9a754c6a954b370c8bcf5b57fff0a1c1fb3b23
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1-dev_2.0.2-2_amd64.deb
-    digest: d0c9b2f39daeadd9a9c36d4f15df8e99c90780725566822f684a24e39850bdd7
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_amd64.deb
-    digest: 4fdd6319d141f7950b7a0581b38a34f9a2e63f35a8ff38b2ed13a7a77e80e90e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5_1.12-1deepin0_amd64.deb
-    digest: 6981b6a6a11c8e04e81c0e149166261c159f4860055f0dd25e3ed3cdffd14fa7
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag2_2.0.2-2_amd64.deb
-    digest: ec6092e1dbe95f4a06954406151bf1e47c844baa83492ec0324c5ff21d44a49e
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1v5_1.12-1deepin0_amd64.deb
+    digest: f7e34270e50ce72e1b1358164901a7c9a06709cfb48b46a27bc7f84a78a68dd9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
     digest: 3f24f7a181f374bd6623bfdc7781e2cee5d948361a456d2f6216aa4ba5c44a2e

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -1155,26 +1155,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_loong64.deb
     digest: 2e66a084ee5197d6ca309c766a7fb0d9a4b397359e21a5b7a920dce4695cfcf4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-c-dev_2.0.2-2_loong64.deb
-    digest: 185326269c038044d69e0f2258a95419e6e71f05617a402f2e21e9cc8f485fa6
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1-dev_1.12-1deepin0_loong64.deb
+    digest: 545f8f6f1dab3018ed6d9c73acc0be69384e94028604d7642e31ed31bccc5df3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-c2_2.0.2-2_loong64.deb
-    digest: 297fae7a69c118a170e6492e833e2c661c426ea6d4512f441d6191cb303f16eb
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_loong64.deb
+    digest: ec1e67ba619eb837e8bdc8703e0f7b6b1969f55750fa2bff9780afd53a6b3259
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag-dev_2.0.2-2_loong64.deb
-    digest: 6ae14752578a951892923afc2e75d2756c85d23ae7f5b55198010d01ce8f1145
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1-dev_2.0.2-2_loong64.deb
-    digest: af88066856da6a595d8aad0b1c9a6b739dc546b6da53b6fc914212aec3372561
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_loong64.deb
-    digest: d2688537a91f78d0b816045d583542bd5bb41bf4ef6e10d49672f4bbcf639997
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5_1.12-1deepin0_loong64.deb
-    digest: 68acfd7d231bdd51d3e2f0e37c54710572b6685e153f11434ab9024f20ae3492
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag2_2.0.2-2_loong64.deb
-    digest: 01a561f564be6c9b185d53e7a7e2241eadd85f37747a63fee4f906f91d64c9fb
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/t/taglib/libtag1v5_1.12-1deepin0_loong64.deb
+    digest: 0574efcb89436db156833fede60fb2793ea70bafe8db184f13cd21eec572322b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
     digest: 75dde4d8be25c4d18dcf4e27dffff588fabf9c2b365b3c22b2cbd12af97d90b3

--- a/src/music-player/toolbar/StripedRectangle.qml
+++ b/src/music-player/toolbar/StripedRectangle.qml
@@ -35,7 +35,7 @@ Rectangle {
             id: linerGra
             anchors.fill: parent
             start: Qt.point(0, 0)
-            end: Qt.point(curSecs * parent.width / totalSecs, 0)
+            end: Qt.point(totalSecs > 0 ? curSecs * parent.width / totalSecs : 0, 0)
             gradient: Gradient {
                 GradientStop { position: 0.0; color: startColor }
                 GradientStop { position: 1.0; color: endColor}

--- a/src/music-player/toolbar/WaveformItem.qml
+++ b/src/music-player/toolbar/WaveformItem.qml
@@ -63,7 +63,7 @@ Rectangle {
         Rectangle {
             x: 0
             y: 0
-            width: curSecs * parent.width / totalSecs
+            width: totalSecs > 0 ? curSecs * parent.width / totalSecs : 0
             height: 50
         }
     }

--- a/src/music-player/toolbar/WaveformRect.qml
+++ b/src/music-player/toolbar/WaveformRect.qml
@@ -93,7 +93,7 @@ Rectangle {
         }
         FastBlur {
             id: blur
-            width: curSecs * parent.width / totalSecs
+            width: totalSecs > 0 ? curSecs * parent.width / totalSecs : 0
             height: linearGradient.height
             anchors.left: linearGradient.left
             anchors.verticalCenter: linearGradient.verticalCenter


### PR DESCRIPTION
- Add totalSecs > 0 checks in WaveformItem.qml, StripedRectangle.qml, and WaveformRect.qml
- Prevent division by zero when totalSecs is 0 causing infinite width calculations
- Fix Qt Quick rendering engine deadlock when attempting to create infinite-sized textures
- Resolve application hanging at QWaitCondition::wait() during startup

log: resolve music player startup deadlock issue

## Summary by Sourcery

Fix division-by-zero errors in waveform rendering components to prevent infinite-sized texture creation and resolve music player startup deadlock

Bug Fixes:
- Guard against division by zero in StripedRectangle.qml, WaveformItem.qml, and WaveformRect.qml by adding totalSecs > 0 checks
- Prevent infinite width calculations to avoid creating infinite-sized textures that cause Qt Quick rendering engine deadlock