### PR TITLE
chore: Update version to 7.0.39

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.38.1
+  version: 7.0.39.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.39) unstable; urgency=medium
+
+  * fix: music player crash issue
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Tue, 15 Jul 2025 10:24:15 +0800
+
 deepin-music (7.0.38) unstable; urgency=medium
 
   * chore: Update version to 7.0.37

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.38.1
+  version: 7.0.39.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.38.1
+  version: 7.0.39.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- update version to 7.0.39

 log: update version to 7.0.39

## Summary by Sourcery

Bump deepin-music package version to 7.0.39.1 across all manifests and update the changelog

Build:
- Update version field in arm64/linglong.yaml, linglong.yaml, and loong64/linglong.yaml to 7.0.39.1
- Revise debian/changelog to reflect version 7.0.39