### PR TITLE
chore: Update version to 7.0.40

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.39.1
+  version: 7.0.40.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.40) unstable; urgency=medium
+
+  * chore: Update deepin-manual resources
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 16 Jul 2025 09:27:08 +0800
+
 deepin-music (7.0.39) unstable; urgency=medium
 
   * fix: music player crash issue

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.39.1
+  version: 7.0.40.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.39.1
+  version: 7.0.40.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- update version to 7.0.40

 log: update version to 7.0.40

## Summary by Sourcery

Bump Deepin Music package version to 7.0.40.1 in manifest files

Chores:
- Update version number from 7.0.39.1 to 7.0.40.1 across ARM64, generic, and Loong64 YAML manifests
- Refresh debian/changelog to reflect new version