### PR TITLE
fix: Fix progress bar initialization in music player

### DIFF
--- a/src/music-player/mainFrame/footerwidget.h
+++ b/src/music-player/mainFrame/footerwidget.h
@@ -159,5 +159,7 @@ private:
     quint32             m_lastCookie          = 0;
 
     QTimer             *m_limitRepeatClick    = nullptr;
+    // 优化：添加进度条初始化状态跟踪
+    bool                m_progressBarInitialized = false;
 };
 


### PR DESCRIPTION
Resolved an issue where the progress bar in deepin-music would: 
1.Turn gray upon clicking play
2.Jump to position 0
3.Then return to the previous playback position

Log: Correct progress bar initialization behavior
Bug: https://pms.uniontech.com/bug-view-325223.html