### PR TITLE
fix: When switching from the MP3 engine to the APE engine, the volume…

### DIFF
--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -154,8 +154,9 @@ void QtPlayer::setMediaMeta(MediaMeta meta)
 bool QtPlayer::getMute()
 {
     init();
-//    return m_mediaPlayer->isMuted();
-    return isDbusMuted();
+    return m_mediaPlayer->isMuted();
+    //setDbusMute函数会触发“滴”声，影响用户体验
+    //return isDbusMuted();
 }
 
 void QtPlayer::setFadeInOutFactor(double fadeInOutFactor)
@@ -178,8 +179,9 @@ int QtPlayer::getVolume()
 void QtPlayer::setMute(bool value)
 {
     init();
-//    m_mediaPlayer->setMuted(value);
-    setDbusMute(value);
+    m_mediaPlayer->setMuted(value);
+    //setDbusMute函数会触发“滴”声，影响用户体验
+    //setDbusMute(value);
 }
 
 void QtPlayer::onMediaStatusChanged(QMediaPlayer::MediaStatus status)

--- a/src/music-player/core/vlcplayer.cpp
+++ b/src/music-player/core/vlcplayer.cpp
@@ -265,7 +265,8 @@ void VlcPlayer::setMediaMeta(MediaMeta meta)
     if (engineChanged) {
         if (m_bApe) {
             m_qtPlayer->setMute(m_qvplayer->getMute());
-            // m_qtPlayer->setVolume(m_qvplayer->getVolume()); //Qt自带播放器播放APE格式视频时调节音量可能会导致音量异常
+            // 引擎切换时，需要同步音量值
+            m_qtPlayer->setVolume(m_qvplayer->getVolume()); //Qt自带播放器播放APE格式视频时调节音量可能会导致音量异常
         } else {
             m_qvplayer->setMute(m_qtPlayer->getMute());
             m_qtPlayer->setMute(false);


### PR DESCRIPTION
… value needs to be synchronized.

1. Synchronize the volume value when detecting an engine switch.

When detecting an engine switch, synchronize the volume value. Otherwise, when switching songs, the volume does not change synchronously, affecting the user experience.

fix: mp3引擎切换到ape引擎时，需要同步音量值

1. 监测到引擎切换时，同步音量值

监测到引擎切换时，同步音量值，不然当歌曲切换时，音量没有同步变化，影响用户体验。

Bug: https://pms.uniontech.com/bug-view-328003.html

## Summary by Sourcery

Bug Fixes:
- Synchronize volume value when switching between MP3 and APE engines to maintain consistent volume levels across format changes