### PR TITLE
fix: add QT_GSTREAMER_USE_PLAYBIN_VOLUME env var for low-latency volu…

### DIFF
--- a/src/music-player/core/qtplayer.cpp
+++ b/src/music-player/core/qtplayer.cpp
@@ -27,8 +27,8 @@ void QtPlayer::init()
 {
     //防止多次创建
     if (m_mediaPlayer == nullptr) {
+        qputenv("QT_GSTREAMER_USE_PLAYBIN_VOLUME", "1");
         m_mediaPlayer = new QMediaPlayer(this);
-
         connect(m_mediaPlayer, &QMediaPlayer::mediaStatusChanged, this, &QtPlayer::onMediaStatusChanged);
         connect(m_mediaPlayer, &QMediaPlayer::positionChanged, this, &QtPlayer::onPositionChanged);
         connect(m_mediaPlayer, &QMediaPlayer::stateChanged, this, [ = ](QMediaPlayer::State newState) {


### PR DESCRIPTION
…me control

log: Introduces environment variable to choose between playbin built-in volume control (lower latency) and separate volume element (more flexible). Built-in control eliminates buffering delays that caused 1-second volume change delays for certain audio formats like APE, matching VLC's instant response behavior.

Bug: https://pms.uniontech.com/bug-view-328001.html

## Summary by Sourcery

Enable instant volume control by setting QT_GSTREAMER_USE_PLAYBIN_VOLUME to use playbin’s built-in volume adjustment and eliminate buffering delays

Bug Fixes:
- Resolve 1-second delay in volume changes for certain audio formats (e.g., APE)

Enhancements:
- Add QT_GSTREAMER_USE_PLAYBIN_VOLUME environment variable to enable playbin’s built-in low-latency volume control