### PR TITLE
fix: Probabilistic crash issue in music application

### DIFF
--- a/src/libdmusic/ffmpegdynamicinstance.cpp
+++ b/src/libdmusic/ffmpegdynamicinstance.cpp
@@ -32,6 +32,9 @@ FfmpegDynamicInstance *FfmpegDynamicInstance::VlcFunctionInstance()
 
 QFunctionPointer FfmpegDynamicInstance::resolveSymbol(const char *symbol, bool bffmpeg)
 {
+    qDebug() << __func__ << symbol << bffmpeg;
+    // m_funMap是非线程安全的，对读写操作进行加锁
+    QMutexLocker locker(&m_funMapMutex);  // 自动加锁解锁
     if (m_funMap.contains(symbol)) {
         return m_funMap[symbol];
     }
@@ -43,7 +46,7 @@ QFunctionPointer FfmpegDynamicInstance::resolveSymbol(const char *symbol, bool b
 
     if (!fgp) {
         //never get here if obey the rule
-        qDebug() << "[FfmpegDynamicInstance::resolveSymbol] resolve function:" << symbol;
+        qCritical() << "[FfmpegDynamicInstance::resolveSymbol] resolve function:" << symbol << "FAILED";
         return fgp;
     } else {
         //cache fuctionpointer for next visiting

--- a/src/libdmusic/ffmpegdynamicinstance.h
+++ b/src/libdmusic/ffmpegdynamicinstance.h
@@ -9,6 +9,7 @@
 #include <QObject>
 #include <QLibrary>
 #include <QMap>
+#include <QMutex>
 
 class FfmpegDynamicInstance : public QObject
 {
@@ -34,6 +35,7 @@ private:
     QLibrary libddformate;
 
     QMap<QString, QFunctionPointer> m_funMap;
+    QMutex m_funMapMutex;  // 添加互斥锁
 };
 
 #endif // FFMPEGDYNAMICINSTANCE_H


### PR DESCRIPTION
The `m_funMap` is not thread-safe and requires locking before read and write operations to avoid crash issues caused by thread contention.

fix: 音乐应用概率性崩溃问题

m_funMap不是线程安全的，需要在读写操作前加锁，避免线程竞争导致的崩溃问题。

Bug: https://pms.uniontech.com/bug-view-332355.html

## Summary by Sourcery

Add mutex locking around FfmpegDynamicInstance's m_funMap accesses to prevent race condition crashes and improve failure logging.

Bug Fixes:
- Protect m_funMap read/write operations with QMutexLocker to avoid thread contention crashes

Enhancements:
- Include QMutex header and declare m_funMapMutex member in FfmpegDynamicInstance
- Add debug logging of symbol resolution and switch failure logs from qDebug to qCritical