### PR TITLE
fix: Probabilistic crash issue in music application

### DIFF
--- a/src/music-player/core/vlc/vlcdynamicinstance.cpp
+++ b/src/music-player/core/vlc/vlcdynamicinstance.cpp
@@ -43,6 +43,9 @@ VlcDynamicInstance *VlcDynamicInstance::VlcFunctionInstance()
 
 QFunctionPointer VlcDynamicInstance::resolveSymbol(const char *symbol, bool bffmpeg)
 {
+    qDebug() << __func__ << symbol << bffmpeg;
+    // m_funMap是非线程安全的，对读写操作进行加锁
+    QMutexLocker locker(&m_funMapMutex);  // 自动加锁解锁
     if (m_funMap.contains(symbol)) {
         return m_funMap[symbol];
     }
@@ -53,7 +56,7 @@ QFunctionPointer VlcDynamicInstance::resolveSymbol(const char *symbol, bool bffm
             fgp = libdformate.resolve(symbol);
             if (!fgp) {
                 //never get here if obey the rule
-                qDebug() << "[VlcDynamicInstance::resolveSymbol] resolve function:" << symbol;
+                qCritical() << "[VlcDynamicInstance::resolveSymbol] resolve function:" << symbol << "FAILED";
             }
         }
         m_funMap[symbol] = fgp;
@@ -67,7 +70,7 @@ QFunctionPointer VlcDynamicInstance::resolveSymbol(const char *symbol, bool bffm
 
     if (!fp) {
         //never get here if obey the rule
-        qDebug() << "[VlcDynamicInstance::resolveSymbol] resolve function:" << symbol;
+        qCritical() << "[VlcDynamicInstance::resolveSymbol] resolve function:" << symbol << "FAILED";
         return fp;
     } else {
         //cache fuctionpointer for next visiting
@@ -79,6 +82,8 @@ QFunctionPointer VlcDynamicInstance::resolveSymbol(const char *symbol, bool bffm
 
 QFunctionPointer VlcDynamicInstance::resolveSdlSymbol(const char *symbol)
 {
+    // m_funMap是非线程安全的，对读写操作进行加锁
+    QMutexLocker locker(&m_funMapMutex);  // 自动加锁解锁
     if (m_funMap.contains(symbol)) {
         return m_funMap[symbol];
     }

--- a/src/music-player/core/vlc/vlcdynamicinstance.h
+++ b/src/music-player/core/vlc/vlcdynamicinstance.h
@@ -9,6 +9,7 @@
 #include <QObject>
 #include <QMap>
 #include <QLibrary>
+#include <QMutex>
 
 class VlcDynamicInstance : public QObject
 {
@@ -43,6 +44,7 @@ private:
     QLibrary libsdl2;
 
     QMap<QString, QFunctionPointer> m_funMap;
+    QMutex m_funMapMutex;  // 添加互斥锁
 };
 
 #endif // VLCDYNAMICINSTANCE_H


### PR DESCRIPTION
The `m_funMap` is not thread-safe and requires locking before read and write operations to avoid crash issues caused by thread contention.

fix: 音乐应用概率性崩溃问题（潜在隐患）

m_funMap不是线程安全的，需要在读写操作前加锁，避免线程竞争导致的崩溃问题。

Bug: https://pms.uniontech.com/bug-view-332355.html

## Summary by Sourcery

Make access to the VLC function pointer cache thread-safe to prevent crashes under concurrent use by introducing a mutex and locking around all accesses, and improve logging on symbol resolution failures.

Bug Fixes:
- Prevent intermittent crashes by synchronizing access to the non-thread-safe m_funMap with a mutex.

Enhancements:
- Add QMutex and QMutexLocker to VlcDynamicInstance to guard m_funMap reads and writes.
- Upgrade failure logs in resolveSymbol to qCritical and insert debug logs for symbol resolution attempts.