### PR TITLE
fix: Music application crashes due to PulseAudio module anomaly

### DIFF
--- a/src/music-player/core/vlc/sdlplayer.h
+++ b/src/music-player/core/vlc/sdlplayer.h
@@ -146,6 +146,9 @@ private:
 
     static void switchToDefaultSink();
 
+    // 将状态码翻译成文字信息，人类可读
+    static QString transPaContextState(int code);
+
 public:
     unsigned int _rate, _channels, _sampleRate;
 


### PR DESCRIPTION
By using `pa_context_get_state()` to monitor the context state in real-time, and refraining from calling `OpenAudio()` when the state is abnormal, the application crash can be avoided.

fix: PulseAudio模块异常导致音乐应用崩溃

通过pa_context_get_state()实时检测context状态，状态异常时就不调用OpenAudio()，避免应用崩溃。

Bug: https://pms.uniontech.com/bug-view-331841.html

## Summary by Sourcery

Add real-time PulseAudio context state checks and improved logging to avoid crashes when PulseAudio encounters anomalies

Bug Fixes:
- Prevent crash by skipping SDL OpenAudio call when PulseAudio context state is abnormal

Enhancements:
- Monitor PulseAudio context state in real-time and log state before OpenAudio
- Add transPaContextState function to translate PulseAudio states to readable strings
- Refine logging messages to use qCritical and qInfo for PulseAudio connection and state changes