### PR TITLE
chore: Update version to 7.0.45

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.44.1
+  version: 7.0.45.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.45) unstable; urgency=medium
+
+  * fix: Overlapping Interface Controls Issue
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 04 Sep 2025 20:16:31 +0800
+
 deepin-music (7.0.44) unstable; urgency=medium
 
   * fix: Replace Control with FloatingPanel in Toolbar.qml

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.44.1
+  version: 7.0.45.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.44.1
+  version: 7.0.45.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- update version to 7.0.45

 log: update version to 7.0.45

## Summary by Sourcery

Update the package version for deepin-music to 7.0.45.1 across all manifests and the Debian changelog.

Chores:
- Bump version to 7.0.45.1 in arm64, loong64, and universal linglong.yaml files
- Update Debian changelog to reflect the new version