### PR TITLE
chore: Update version to 7.0.46

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.45.1
+  version: 7.0.46.1
   kind: app
   description: |
     music for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.46) unstable; urgency=medium
+
+  *  fix: Save database after importing songs and creating playlists
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 11 Sep 2025 09:55:48 +0800
+
 deepin-music (7.0.45) unstable; urgency=medium
 
   * fix: Overlapping Interface Controls Issue

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.45.1
+  version: 7.0.46.1
   kind: app
   description: |
     music for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.45.1
+  version: 7.0.46.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- Incremented version number to 7.0.46 in all relevant configuration files.
- Updated changelog to reflect the new version and added a note about saving the database after importing songs and creating playlists.

## Summary by Sourcery

Bump application version to 7.0.46 in all packaging configs and update the changelog with the new version and a database-save note

Build:
- Bump version to 7.0.46.1 in all linglong.yaml packaging files

Documentation:
- Update debian changelog to reflect the new version and add a note about saving the database after importing songs and creating playlists