### PR TITLE
chore: update version to 7.0.56

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.56) unstable; urgency=medium
+
+  * fix(ui): simplify titlebar responsive logic and make about dialog modal
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 10 Apr 2026 16:05:48 +0800
+
 deepin-music (7.0.55) unstable; urgency=medium
 
   * fix(playlist): fix drag-and-drop sorting in current playlist

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.55.1
+  version: 7.0.56.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- bump version to 7.0.56

Log : bump version to 7.0.56

## Summary by Sourcery

Chores:
- Update linglong.yaml package version from 7.0.55.1 to 7.0.56.1.