### PR TITLE
fix(footer): skip background blur when using default cover image

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -8,6 +8,11 @@ Files: .github/*
 Copyright: None
 License: CC0-1.0
 
+# config
+Files: config.h.in
+Copyright: None
+License: CC0-1.0
+
 # gitignore
 Files: .gitignore 
 Copyright: None

--- a/src/music-player/mainFrame/footerwidget.cpp
+++ b/src/music-player/mainFrame/footerwidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -18,6 +18,7 @@
 #include <QShortcut>
 #include <QFileInfo>
 #include <QTimer>
+#include <QDir>
 
 #include <DHiDPIHelper>
 #include <DPushButton>
@@ -927,13 +928,35 @@ void FooterWidget::resizeEvent(QResizeEvent *event)
 
 void FooterWidget::slotFlushBackground()
 {
-    QImage cover = QImage(":/icons/deepin/builtin/actions/info_cover_142px.svg");
-    QString imagesDirPath = Global::cacheDir() + "/images/" + Player::getInstance()->getActiveMeta().hash + ".jpg";
-    QFileInfo file(imagesDirPath);
-    if (file.exists()) {
-        cover = QImage(Global::cacheDir() + "/images/" + Player::getInstance()->getActiveMeta().hash + ".jpg");
+    auto clearBackground = [this]() {
+        m_forwardWidget->setSourceImage(QImage());
+        m_forwardWidget->update();
+    };
+    
+    QString cacheDir = Global::cacheDir();
+    if (cacheDir.isEmpty()) {
+        qWarning() << "Cache directory is invalid, clearing background";
+        clearBackground();
+        return;
     }
-
+    
+    QString imagesDirPath = QDir(cacheDir).filePath(
+        QString("images/%1.jpg").arg(Player::getInstance()->getActiveMeta().hash)
+    );
+    
+    QFileInfo file(imagesDirPath);
+    if (!file.exists()) {
+        clearBackground();
+        return;
+    }
+    
+    QImage cover(imagesDirPath);
+    if (cover.isNull() || cover.size().isEmpty()) {
+        qWarning() << "Failed to load cover image or invalid size:" << imagesDirPath;
+        clearBackground();
+        return;
+    }
+    
     double windowScale = (width() * 1.0) / height();
     int imageWidth = static_cast<int>(cover.height() * windowScale);
     QImage coverImage;


### PR DESCRIPTION
When no actual cover exists, clear background instead of using default cover.

当无实际封面时，清空背景而非使用默认封面图片。

Log: 无实际封面时不设置背景
PMS: [BUG-357677](https://pms.uniontech.com/bug-view-357677.html)
Influence: 当音乐无封面图片时，底部工具栏不再显示默认封面的模糊背景，界面更加简洁。

## Summary by Sourcery

Bug Fixes:
- Ensure the footer background is cleared instead of using a default blurred cover image when the current track has no real cover artwork.