### PR TITLE
fix:The maximize button in the top-right corner shows hover state on mouseover in the music app.

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -29,7 +29,7 @@ Copyright: None
 License: CC0-1.0
 
 # Project file
-Files: *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/*
+Files: *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/* config.h.in
 Copyright: None
 License: CC0-1.0
 
@@ -62,3 +62,4 @@ License: GPL-3.0-or-later
 Files: tests/*
 Copyright: UnionTech Software Technology Co., Ltd.
 License: GPL-3.0-or-later
+

--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -90,8 +90,6 @@ MainFrame::MainFrame()
     m_titlebar = new DTitlebar(this);
     m_titlebar->setTitle(tr("Music"));
     m_titlebar->setIcon(QIcon::fromTheme("deepin-music"));    //titlebar->setCustomWidget(titlebarwidget, Qt::AlignLeft, false);
-    // 禁止分割屏幕，因为应用的最小尺寸会被分割屏幕功能破坏 setMinimumSize(QSize(1070, 680))
-    m_titlebar->setSplitScreenEnabled(false);
 
     m_titlebar->setCustomWidget(m_titlebarwidget);
     m_titlebar->layout()->setAlignment(m_titlebarwidget, Qt::AlignCenter);


### PR DESCRIPTION
fix: The maximize button in the top-right corner shows hover state on mouseover in the music app.

This reverts commit 79274ab715d147ef6d9648dad8c9a40a4a4cf539.

Log: 修复音乐应用最大化按钮hover菜单无法显示的问题
Bug: https://pms.uniontech.com/bug-view-355491.html
Influence: 当鼠标移动到右上角最大化时显示hover状态，可选择将窗口拼贴到屏幕左侧、将窗口拼贴到屏幕右侧、还原
