### PR TITLE
fix: update m_preMaxFlag when window state changes

### DIFF
--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -1136,6 +1136,10 @@ void MainFrame::changeEvent(QEvent *event)
         if (m_playQueueWidget) {
             m_playQueueWidget->stopAnimation();
         }
+        // 只在非最小化状态改变时更新标志位，避免与托盘收起逻辑冲突
+        if (!isMinimized()) {
+            m_preMaxFlag = isMaximized();
+        }
     }
 }
 


### PR DESCRIPTION
Add m_preMaxFlag update in changeEvent to ensure tray icon restores correct window size after manual resize operations.

修复窗口状态改变时未更新最大化标志位的问题，确保托盘打开时能正确恢复窗口大小。

Log: 修复托盘打开窗口大小异常的问题
Bug: https://pms.uniontech.com/bug-view-244221.html
Influence: 用户调整窗口大小后，通过托盘打开窗口时能正确恢复之前的大小

## Summary by Sourcery

Bug Fixes:
- Fix incorrect window size restoration when reopening the player from the system tray after manually resizing the window.