### PR TITLE
fix(sidebar): fix playlist name ellipsis overflow beyond blue border

### DIFF
--- a/src/music-player/musicbaseandsonglist/SideBarItemDelegate.qml
+++ b/src/music-player/musicbaseandsonglist/SideBarItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -72,8 +72,8 @@ ItemDelegate {
     }
     Label {
         id: songName
-        width: 154;
         anchors.left: siderIcon.right; anchors.leftMargin: 10
+        anchors.right: item.right; anchors.rightMargin: 10
         anchors.verticalCenter: item.verticalCenter
         text: "%1".arg(model.displayName)
         textFormat: Text.PlainText


### PR DESCRIPTION
- Replace fixed width with bilateral anchor layout for playlist name Label
- Remove hardcoded width: 154, use anchors.right for dynamic sizing
- Fix misaligned ellipsis when name is too long

歌单名称过长时，省略号不再出现在蓝色选中边框外部，
正确显示在边框内侧，与右边缘对齐。

Log: 修复歌单名称省略号超出选中边框的问题
PMS: BUG-364545
Influence: 左侧歌单列表名称省略显示样式恢复正常

## Summary by Sourcery

Bug Fixes:
- Fix playlist name ellipsis overflowing outside the blue selected border by using a dynamic, anchored label width.