### PR TITLE
fix: Music app process crash

### DIFF
--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -141,11 +141,26 @@ public:
     ~DataManagerPrivate()
     {
         qCDebug(dmMusic) << "Destroying DataManagerPrivate";
-        m_workerThread->quit();
+        // 1) 切断主线程与 worker 之间的 queued connection，阻止后续新 metacall 入队
+        //    （注意：已 posted 的 metacall 不会被撤销，但下面 wait 会等 worker 把它们处理完）
         if (m_dbOperate) {
-            qCDebug(dmMusic) << "Destroying DBOperate";
-            delete m_dbOperate;
+            m_parent->disconnect(m_dbOperate);
+            m_dbOperate->disconnect(m_parent);
+            // 2) 让 m_dbOperate 在自己 affinity 的 worker 线程里析构。
+            //    deleteLater 在 worker 的事件循环里 post 一个 DeferredDelete 事件；
+            //    quit() 后 worker 的 exec() 在返回前会先处理 DeferredDelete，从而在
+            //    正确的线程上 delete，满足 Qt 线程亲和性约束。
+            m_dbOperate->deleteLater();
             m_dbOperate = nullptr;
+        }
+        // 3) 请求事件循环退出 + 等线程真的结束
+        if (m_workerThread) {
+            m_workerThread->quit();
+            if (!m_workerThread->wait(3000)) {
+                qCWarning(dmMusic) << "Worker thread did not exit within 3s";
+            }
+            delete m_workerThread;
+            m_workerThread = nullptr;
         }
     }
 private:
@@ -183,8 +198,12 @@ DataManager::DataManager(QStringList supportedSuffixs, QObject *parent)
 DataManager::~DataManager()
 {
     qCDebug(dmMusic) << "Destroying DataManager";
-    m_data->m_workerThread->quit();
-    saveDataToDB();
+    if (m_data) {
+        saveDataToDB();
+        // 关键：触发 DataManagerPrivate 析构走安全销毁路径（disconnect + deleteLater + quit + wait）
+        delete m_data;
+        m_data = nullptr;
+    }
     qCDebug(dmMusic) << "DataManager destroyed";
 }
 


### PR DESCRIPTION
log: When destructing DataManagerPrivate in the main thread, m_dbOperate was deleted without waiting for the worker thread m_workerThread to fully exit. Since m_dbOperate has thread affinity with the worker, and the worker might still be processing a queued slot at that moment, this leads to concurrent access on the connection list inside QObject::~QObject(), resulting in a SIGSEGV during repeated open/exit cycles.

Two changes are required to fully fix this:

1. DataManager::~DataManager() must explicitly delete m_data. Because m_data is a raw pointer to DataManagerPrivate (a plain C++ class, not a QObject with parent-child auto cleanup), nothing else triggers its destructor automatically; without this delete, any cleanup logic inside ~DataManagerPrivate() is dead code. The old m_data->m_workerThread->quit() call is also removed to avoid a second quit() landing on a freed QThread.

2. ~DataManagerPrivate() uses the deleteLater() pattern instead of a main-thread delete on m_dbOperate. The new order is: disconnect both directions -> m_dbOperate->deleteLater() -> m_workerThread->quit() -> m_workerThread->wait(3000) -> delete m_workerThread The DeferredDelete event is dispatched by the worker's own event loop before exec() returns, so m_dbOperate is destroyed on its affinity thread, eliminating the cross-thread QObject destruction UB.

pms: bug-363153