### PR TITLE
fix(titlebar): fix window control button hover state not displayed

### DIFF
--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,7 +26,7 @@ TitleBar {
     id: titleBar
     icon.name: globalVariant.appIconName
     icon.opacity: opat
-    hoverEnabled: false
+    hoverEnabled: true
     ActionButton {
         icon.name: "go_down"
         icon.width: 12


### PR DESCRIPTION
- Enable hover handling on the main TitleBar
- Restore hover state display for minimize, maximize/restore, and close buttons
- Keep existing titlebar layout and button behavior unchanged

鼠标移动到窗口最小化、最大化/还原、关闭按钮时，
按钮 hover 状态能够正常显示。

Log: 修复窗口控制按钮hover状态不显示的问题
PMS: BUG-355493
Influence: 主窗口标题栏最小化、最大化/还原、关闭按钮hover显示恢复正常