### PR TITLE
chore: update version to 7.0.59

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-music (7.0.59) unstable; urgency=medium
+
+  * fix: Unresponsive click on tray panel applications
+  * fix(titlebar): fix window control button hover state not displayed
+  * fix: Music app process crash
+  * fix(sidebar): fix playlist name ellipsis overflow beyond blue border
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 11 Jun 2026 19:36:50 +0800
+
 deepin-music (7.0.58) unstable; urgency=medium
 
   * fix(sdlplayer): fallback to stereo when multi-channel device open fails

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.58.1
+  version: 7.0.59.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- bump version to 7.0.59

Log : bump version to 7.0.59

## Summary by Sourcery

Chores:
- Update package version in linglong.yaml from 7.0.58.1 to 7.0.59.1.