### PR TITLE
fix: 补充 FFmpeg API 返回值检查

### DIFF
--- a/src/libdmusic/metadetector.cpp
+++ b/src/libdmusic/metadetector.cpp
@@ -74,6 +74,16 @@ typedef int (*codec_close_function)(AVCodecContext *);
 typedef int (*codec_send_packet_function)(AVCodecContext *, const AVPacket *);
 typedef int (*codec_receive_frame_function)(AVCodecContext *, AVFrame *);
 typedef const char *(*avcodec_get_name_function)(enum AVCodecID);
+
+static bool checkFfmpegSymbol(const char *name, bool valid)
+{
+    if (!valid) {
+        qWarning() << Q_FUNC_INFO << "resolve ffmpeg symbol failed:" << name;
+        return false;
+    }
+    return true;
+}
+
 void MetaDetector::init()
 {
     localeCodes.insert("zh_CN", "GB18030");
@@ -139,12 +149,29 @@ QString MetaDetector::getAudioType(MediaMeta meta)
     QString audioType;
     format_alloc_context_function format_alloc_context = (format_alloc_context_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_alloc_context", true);
     format_open_input_function format_open_input = (format_open_input_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_open_input", true);
-    format_find_stream_info_function format_find_stream_info = (format_find_stream_info_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_find_stream_info", true);
     format_close_input_function format_close_input = (format_close_input_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_close_input", true);
     format_free_context_function format_free_context = (format_free_context_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_free_context", true);
     avcodec_get_name_function avcodec_get_name = (avcodec_get_name_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avcodec_get_name", true);
+    if (!checkFfmpegSymbol("avformat_alloc_context", format_alloc_context)
+            || !checkFfmpegSymbol("avformat_open_input", format_open_input)
+            || !checkFfmpegSymbol("avformat_close_input", format_close_input)
+            || !checkFfmpegSymbol("avformat_free_context", format_free_context)
+            || !checkFfmpegSymbol("avcodec_get_name", avcodec_get_name)) {
+        return audioType;
+    }
+
     AVFormatContext *pFormatCtx = format_alloc_context();
-    format_open_input(&pFormatCtx, meta.localPath.toStdString().c_str(), nullptr, nullptr);
+    if (pFormatCtx == nullptr) {
+        return audioType;
+    }
+
+    if (format_open_input(&pFormatCtx, meta.localPath.toStdString().c_str(), nullptr, nullptr) < 0 || pFormatCtx == nullptr) {
+        if (pFormatCtx != nullptr) {
+            format_free_context(pFormatCtx);
+        }
+        return audioType;
+    }
+
     if (pFormatCtx) {
         // 遍历所有流
         for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
@@ -160,7 +187,7 @@ QString MetaDetector::getAudioType(MediaMeta meta)
         }
     }
     format_close_input(&pFormatCtx);
-    format_free_context(pFormatCtx);
+    qWarning() << "getAudioType exit audioType:" << audioType;
     return audioType;
 }
 
@@ -181,17 +208,26 @@ MediaMeta MetaDetector::updateMetaFromLocalfile(MediaMeta meta, const QFileInfo 
         format_find_stream_info_function format_find_stream_info = (format_find_stream_info_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_find_stream_info", true);
         format_close_input_function format_close_input = (format_close_input_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_close_input", true);
         format_free_context_function format_free_context = (format_free_context_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_free_context", true);
-        AVFormatContext *pFormatCtx = format_alloc_context();
-        format_open_input(&pFormatCtx, meta.localPath.toStdString().c_str(), nullptr, nullptr);
-        if (pFormatCtx) {
-            format_find_stream_info(pFormatCtx, nullptr);
-            int64_t duration = pFormatCtx->duration / 1000;
-            if (duration > 0) {
-                meta.length = duration;
+        if (checkFfmpegSymbol("avformat_alloc_context", format_alloc_context)
+                && checkFfmpegSymbol("avformat_open_input", format_open_input)
+                && checkFfmpegSymbol("avformat_find_stream_info", format_find_stream_info)
+                && checkFfmpegSymbol("avformat_close_input", format_close_input)
+                && checkFfmpegSymbol("avformat_free_context", format_free_context)) {
+            AVFormatContext *pFormatCtx = format_alloc_context();
+            if (pFormatCtx) {
+                if (format_open_input(&pFormatCtx, meta.localPath.toStdString().c_str(), nullptr, nullptr) == 0 && pFormatCtx) {
+                    if (format_find_stream_info(pFormatCtx, nullptr) >= 0) {
+                        int64_t duration = pFormatCtx->duration / 1000;
+                        if (duration > 0) {
+                            meta.length = duration;
+                        }
+                    }
+                    format_close_input(&pFormatCtx);
+                } else if (pFormatCtx) {
+                    format_free_context(pFormatCtx);
+                }
             }
         }
-        format_close_input(&pFormatCtx);
-        format_free_context(pFormatCtx);
     }
 
     meta.size = fileInfo.size();
@@ -351,23 +387,28 @@ void MetaDetector::getCoverData(const QString &path, const QString &tmpPath, con
             format_close_input_function format_close_input = (format_close_input_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_close_input", true);
             format_free_context_function format_free_context = (format_free_context_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_free_context", true);
 
-            AVFormatContext *pFormatCtx = format_alloc_context();
-            format_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr);
-
-            if (pFormatCtx) {
-                if (pFormatCtx->iformat != nullptr && pFormatCtx->iformat->read_header(pFormatCtx) >= 0) {
-                    for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
-                        if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
-                            AVPacket pkt = pFormatCtx->streams[i]->attached_pic;
-                            image = QImage::fromData(static_cast<uchar *>(pkt.data), pkt.size);
-                            break;
+            if (checkFfmpegSymbol("avformat_alloc_context", format_alloc_context)
+                    && checkFfmpegSymbol("avformat_open_input", format_open_input)
+                    && checkFfmpegSymbol("avformat_close_input", format_close_input)
+                    && checkFfmpegSymbol("avformat_free_context", format_free_context)) {
+                AVFormatContext *pFormatCtx = format_alloc_context();
+                if (pFormatCtx) {
+                    if (format_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr) == 0 && pFormatCtx) {
+                        if (pFormatCtx->iformat != nullptr && pFormatCtx->iformat->read_header != nullptr && pFormatCtx->iformat->read_header(pFormatCtx) >= 0) {
+                            for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
+                                if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
+                                    AVPacket pkt = pFormatCtx->streams[i]->attached_pic;
+                                    image = QImage::fromData(static_cast<uchar *>(pkt.data), pkt.size);
+                                    break;
+                                }
+                            }
                         }
+                        format_close_input(&pFormatCtx);
+                    } else if (pFormatCtx) {
+                        format_free_context(pFormatCtx);
                     }
                 }
             }
-
-            format_close_input(&pFormatCtx);
-            format_free_context(pFormatCtx);
         } else {
 #ifdef _WIN32
             TagLib::MPEG::File f(path.toStdString().c_str());
@@ -413,24 +454,37 @@ QPixmap MetaDetector::getCoverDataPixmap(MediaMeta meta, int engineType)
         format_close_input_function format_close_input = (format_close_input_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_close_input", true);
         format_free_context_function format_free_context = (format_free_context_function)FfmpegDynamicInstance::VlcFunctionInstance()->resolveSymbol("avformat_free_context", true);
 
-        AVFormatContext *pFormatCtx = format_alloc_context();
-        format_open_input(&pFormatCtx, meta.localPath.toUtf8().data(), nullptr, nullptr);
-
         QImage image;
-        if (pFormatCtx) {
-            if (pFormatCtx->iformat != nullptr && pFormatCtx->iformat->read_header(pFormatCtx) >= 0) {
-                for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
-                    if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
-                        AVPacket pkt = pFormatCtx->streams[i]->attached_pic;
-                        image = QImage::fromData(static_cast<uchar *>(pkt.data), pkt.size);
-                        break;
+        if (checkFfmpegSymbol("avformat_alloc_context", format_alloc_context)
+                && checkFfmpegSymbol("avformat_open_input", format_open_input)
+                && checkFfmpegSymbol("avformat_close_input", format_close_input)
+                && checkFfmpegSymbol("avformat_free_context", format_free_context)) {
+            AVFormatContext *pFormatCtx = format_alloc_context();
+            int openRet = -1;
+            if (pFormatCtx) {
+                openRet = format_open_input(&pFormatCtx, meta.localPath.toUtf8().data(), nullptr, nullptr);
+            }
+            qWarning() << "getCoverDataPixmap avformat_open_input ret:" << openRet << "pFormatCtx:" << (void *)pFormatCtx;
+
+            if (openRet == 0 && pFormatCtx) {
+                if (pFormatCtx->iformat != nullptr && pFormatCtx->iformat->read_header != nullptr && pFormatCtx->iformat->read_header(pFormatCtx) >= 0) {
+                    for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
+                        if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
+                            AVPacket pkt = pFormatCtx->streams[i]->attached_pic;
+                            image = QImage::fromData(static_cast<uchar *>(pkt.data), pkt.size);
+                            qWarning() << "getCoverDataPixmap found attached_pic at stream:" << i;
+                            break;
+                        }
                     }
+                } else {
+                    qWarning() << "getCoverDataPixmap iformat is null or read_header failed, iformat:" << (void *)pFormatCtx->iformat;
                 }
+                format_close_input(&pFormatCtx);
+            } else if (pFormatCtx) {
+                format_free_context(pFormatCtx);
             }
         }
 
-        format_close_input(&pFormatCtx);
-        format_free_context(pFormatCtx);
         pixmap = QPixmap::fromImage(image);
     } else {
 #ifdef _WIN32

--- a/src/music-player/core/metabufferdetector.cpp
+++ b/src/music-player/core/metabufferdetector.cpp
@@ -126,22 +126,32 @@ void MetaBufferDetector::run()
     }
 
     AVFormatContext *pFormatCtx = format_alloc_context();
-    format_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr);
-
     if (pFormatCtx == nullptr) {
-        format_free_context(pFormatCtx);
         m_curPath.clear();
         m_curHash.clear();
         return;
     }
 
-    format_find_stream_info(pFormatCtx, nullptr);
+    if (format_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr) < 0 || pFormatCtx == nullptr) {
+        if (pFormatCtx != nullptr) {
+            format_free_context(pFormatCtx);
+        }
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
+
+    if (format_find_stream_info(pFormatCtx, nullptr) < 0) {
+        format_close_input(&pFormatCtx);
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
 
     int audio_stream_index = -1;
     audio_stream_index = find_best_stream(pFormatCtx, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
     if (audio_stream_index < 0) {
         format_close_input(&pFormatCtx);
-        format_free_context(pFormatCtx);
         m_curPath.clear();
         m_curHash.clear();
         return;
@@ -151,13 +161,45 @@ void MetaBufferDetector::run()
     AVCodecParameters *in_codecpar = in_stream->codecpar;
 
     AVCodecContext *pCodecCtx = codec_alloc_context3(nullptr);
-    codec_parameters_to_context(pCodecCtx, in_codecpar);
+    if (pCodecCtx == nullptr) {
+        format_close_input(&pFormatCtx);
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
+
+    if (codec_parameters_to_context(pCodecCtx, in_codecpar) < 0) {
+        codec_close(pCodecCtx);
+        format_close_input(&pFormatCtx);
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
 
     AVCodec *pCodec = codec_find_decoder(pCodecCtx->codec_id);
-    codec_open2(pCodecCtx, pCodec, nullptr);
+    if (pCodec == nullptr || codec_open2(pCodecCtx, pCodec, nullptr) < 0) {
+        codec_close(pCodecCtx);
+        format_close_input(&pFormatCtx);
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
 
     AVPacket *packet = packet_alloc();
     AVFrame *frame = frame_alloc();
+    if (packet == nullptr || frame == nullptr) {
+        if (packet != nullptr) {
+            packet_unref(packet);
+        }
+        if (frame != nullptr) {
+            frame_free(&frame);
+        }
+        codec_close(pCodecCtx);
+        format_close_input(&pFormatCtx);
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
 
     QVector<float> curData;
 
@@ -168,7 +210,6 @@ void MetaBufferDetector::run()
             frame_free(&frame);
             codec_close(pCodecCtx);
             format_close_input(&pFormatCtx);
-            format_free_context(pFormatCtx);
             resample(curData, hash, true);//刷新波浪条
             m_stopFlag = false;
             m_curPath.clear();
@@ -208,7 +249,6 @@ void MetaBufferDetector::run()
     frame_free(&frame);
     codec_close(pCodecCtx);
     format_close_input(&pFormatCtx);
-    format_free_context(pFormatCtx);
     resample(curData, hash);
 }
 


### PR DESCRIPTION
fix: 补充 FFmpeg API 返回值检查

  补充 MetaBufferDetector 波形解析流程中的 FFmpeg API 返回值检查，
  避免打开文件、获取流信息、初始化解码器或分配包/帧失败后继续使用
  无效对象导致崩溃。

  同步修复 MetaDetector 中 FFmpeg 动态符号缺失和打开失败后的保护逻辑，
  避免媒体信息、封面解析路径在异常 FFmpeg 环境下崩溃。

  Log: 补充 FFmpeg 返回值检查并修复同类崩溃风险
  Task: https://pms.uniontech.com/task-view-390625.html
  Influence: 正常音频播放、波形生成和媒体信息解析流程不变；异常文件或
  FFmpeg 符号缺失时跳过当前解析，避免应用崩溃。