### PR TITLE
fix: 修正 AI DBus 信号连接的 slot 名称     

### DIFF
--- a/src/music-player/ai/dbusaiinterface.cpp
+++ b/src/music-player/ai/dbusaiinterface.cpp
@@ -12,8 +12,8 @@ DBusAIInterface::DBusAIInterface(QString &aiServicePath, QObject *parent) : QObj
     mp_interface = new QDBusInterface("com.deepin.copilot", aiServicePath, "com.deepin.copilot.app", QDBusConnection::sessionBus());
 
     if (mp_interface->isValid()) {
-        connect(mp_interface, SIGNAL(chatTextReceived(QString, QString)), this, SLOT(slotProcessChange(QString, QString)));
-        connect(mp_interface, SIGNAL(error(QString, qint32, QString)), this, SLOT(slotProcessEnd(QString, qint32, QString)));
+        connect(mp_interface, SIGNAL(chatTextReceived(QString, QString)), this, SLOT(slotChatTextReceived(QString, QString)));
+        connect(mp_interface, SIGNAL(error(QString, qint32, QString)), this, SLOT(slotError(QString, qint32, QString)));
     }
 
 }


### PR DESCRIPTION
Log: 修复 DBusAIInterface 中 chatTextReceived 和 error 信号连接到不存在 slot 的问题，改为连接到已定义的slotChatTextReceived 和 slotError。
Task: https://pms.uniontech.com/task-view-390625.html
## Summary by Sourcery

Bug Fixes:
- Prevent high CPU usage during MetaBufferDetector destruction by using QThread::wait() instead of an empty busy-wait loop when stopping the detector thread.