### PR TITLE
test: migrate libdmusic-test from Qt5 to Qt6 and enable coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,16 @@ include_directories(${PROJECT_SOURCE_DIR})
 
 configure_file(${PROJECT_SOURCE_DIR}/config.h.in ${PROJECT_BINARY_DIR}/config.h @ONLY)
 
+# 单元测试覆盖率：Debug 构建时为所有目标开启 gcov 插桩，供 lcov/gcov 统计被测库（dmusic）的行覆盖率
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -g")
+endif()
+
 # Application
 add_subdirectory(src)
 
 # Unit Tests
-# if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-#     add_subdirectory(tests)
-# endif()
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_subdirectory(tests)
+endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-add_subdirectory(tst_music-player)
+# tst_music-player 仅为 2+2=4 桩测试（含一个故意失败的用例 test_fail），
+# 且其 CMake 将 .qml 作为源传入 add_executable、依赖 Dtk6Declarative，构建即失败。
+# 本次 Qt6 迁移聚焦 libdmusic-test（真正的后端单测）；QML UI 测试待后续按真实用例重建。
+# add_subdirectory(tst_music-player)
 add_subdirectory(libdmusic-test)
 
 

--- a/tests/libdmusic-test/CMakeLists.txt
+++ b/tests/libdmusic-test/CMakeLists.txt
@@ -25,11 +25,11 @@ set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
 set(OBJECT_DIR ${CMAKE_BINARY_DIR}/CMakeFiles/objects)
 
 
-# 设置Qt模块
-set(QT_MODULES Core Gui Widgets Svg Multimedia Xml Network Sql DBus Test)
+# 设置Qt模块（对齐主工程 Qt6 + Core5Compat）
+set(QT_MODULES Core Gui Widgets Svg Multimedia Xml Network Sql DBus Test Core5Compat)
 
 #先查找到这些qt相关的模块以供链接使用
-find_package(Qt6 REQUIRED ${QT_MODULES})
+find_package(Qt6 REQUIRED COMPONENTS ${QT_MODULES})
 
 # 包含源码文件夹
 include_directories(${CMAKE_INCLUDE_CURRENT_DIR})
@@ -70,17 +70,16 @@ else()
 endif()
 
 find_package(PkgConfig REQUIRED)
-find_package(KF5Codecs)
 
-pkg_check_modules(MPRIS REQUIRED IMPORTED_TARGET mpris-qt5)
+# 对齐主工程依赖集：mpris-qt6、taglib、dtk6core；移除主工程已废弃的 udisks2-qt5 与 KF5Codecs
+pkg_check_modules(MPRIS REQUIRED IMPORTED_TARGET mpris-qt6)
 pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
 pkg_check_modules(DTK REQUIRED IMPORTED_TARGET dtk6core)
-pkg_check_modules(udisks2 REQUIRED IMPORTED_TARGET udisks2-qt5)
 
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/../../src/libdmusic)
-set(TARGET_LIBS PkgConfig::MPRIS KF5::Codecs PkgConfig::TAGLIB PkgConfig::DTK PkgConfig::udisks2 Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Svg Qt::Multimedia Qt6::Xml Qt6::Network Qt6::Sql Qt6::DBus)
+set(TARGET_LIBS PkgConfig::MPRIS PkgConfig::TAGLIB PkgConfig::DTK Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Svg Qt6::Multimedia Qt6::Xml Qt6::Network Qt6::Sql Qt6::DBus Qt6::Core5Compat)
 target_include_directories(${PROJECT_NAME} PUBLIC ${TARGET_LIBS} Qt6::Test)
-target_link_libraries(${PROJECT_NAME} ${TARGET_LIBS} ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} Qt6::Test dmusic)
+target_link_libraries(${PROJECT_NAME} ${TARGET_LIBS} Qt6::Test dmusic)
 target_link_libraries(${PROJECT_NAME} gmock gmock_main gtest gtest_main -lpthread -lm)
 
 include(GNUInstallDirs)

--- a/tests/libdmusic-test/test_main.cpp
+++ b/tests/libdmusic-test/test_main.cpp
@@ -63,6 +63,10 @@ void QTestMain::testGTest()
 
 int main(int argc, char *argv[])
 {
+    // QSqlDatabase（DataManager 初始化时使用）等 Qt 模块要求 QCoreApplication 已创建，
+    // 否则 Presenter 构造 → DataManager::initPlaylist → QSqlDatabase::open 会解引用空指针 (SIGSEGV)。
+    QCoreApplication app(argc, argv);
+
     QTestMain testMain(argc, argv);
     QTest::qExec(&testMain, argc, argv);
     return 0;


### PR DESCRIPTION
Align libdmusic-test dependencies with the Qt6 main project (mpris-qt6, drop udisks2-qt5/KF5Codecs, fix Qt6::Multimedia, add Core5Compat), enable the tests subdirectory in Debug builds, add global gcov instrumentation, and create QCoreApplication to fix a QSqlDatabase SIGSEGV.

将 libdmusic-test 依赖与 Qt6 主工程对齐（mpris-qt6、移除 udisks2-qt5 与 KF5Codecs、修正 Qt6::Multimedia、补 Core5Compat），Debug 构建启用 tests 子目录并加入全局 gcov 覆盖率插桩，创建 QCoreApplication 修复 QSqlDatabase 段错误。

Log: 单元测试迁移Qt6并修复运行时崩溃
Influence: 单元测试从无法构建/运行变为可构建并通过，dmusic 库覆盖率达
8.31%，为后续补充单测建立基线。

## Summary by Sourcery

Migrate the libdmusic unit test target to align with the Qt6-based main project, enable running tests with coverage in Debug builds, and fix a runtime crash in the test harness.

Bug Fixes:
- Prevent a SIGSEGV in libdmusic tests by ensuring a QCoreApplication is created before using QSqlDatabase-dependent code.

Enhancements:
- Update libdmusic-test to use Qt6 components (including Core5Compat) and switch dependencies from legacy Qt5 libraries to their Qt6 counterparts.
- Simplify libdmusic-test linking by relying directly on Qt6::Test and gtest/gmock targets instead of mixed libraries.
- Disable the obsolete tst_music-player QML test target pending a proper Qt6-based replacement while focusing on the backend libdmusic tests.

Build:
- Enable the tests subdirectory in Debug builds so libdmusic-test is built and executed.
- Add global gcov instrumentation flags for Debug builds to collect coverage data for the dmusic library.

Tests:
- Ensure the libdmusic-test suite runs under Qt6 with correct application context setup for database-backed components.