### PR TITLE
test: add libdmusic unit test cases and fix coverage collection

### DIFF
--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -126,8 +126,8 @@ static bool moreThanArtistTitleDES(const ArtistInfo &v1, const ArtistInfo &v2)
 class DataManagerPrivate
 {
 public:
-    DataManagerPrivate(QStringList supportedSuffixs, DataManager *parent)
-        : m_parent(parent)
+    DataManagerPrivate(QStringList supportedSuffixs, DataManager *parent, const QString &dbPath)
+        : m_parent(parent), m_dbPath(dbPath)
     {
         qCDebug(dmMusic) << "Initializing DataManagerPrivate with supported suffixes:" << supportedSuffixs;
         m_settings = new MusicSettings(m_parent);
@@ -170,6 +170,7 @@ private:
     DBOperate                        *m_dbOperate        = nullptr;
     MusicSettings                    *m_settings         = nullptr;
     QSqlDatabase                      m_database;
+    QString                           m_dbPath;           // 可注入的 DB 路径，空=默认 cachePath/mediameta.sqlite
     QString                           m_currentHash;
     QList<DMusic::MediaMeta>          m_allMetas;
     QList<DMusic::AlbumInfo>          m_allAlbums;
@@ -180,8 +181,8 @@ private:
     QList<QString>                    m_searchAlbums;
 };
 
-DataManager::DataManager(QStringList supportedSuffixs, QObject *parent)
-    : QObject(parent), m_data(new DataManagerPrivate(supportedSuffixs, this))
+DataManager::DataManager(QStringList supportedSuffixs, QObject *parent, const QString &dbPath)
+    : QObject(parent), m_data(new DataManagerPrivate(supportedSuffixs, this, dbPath))
 {
     qCDebug(dmMusic) << "Initializing DataManager with supported suffixes:" << supportedSuffixs;
     initPlaylist();
@@ -2230,7 +2231,19 @@ void DataManager::initPlaylist()
     playlistMeta.saveFalg = false;
     m_data->m_allPlaylist << playlistMeta;
 
-    QString dbPath = DmGlobal::cachePath() + "/mediameta.sqlite";
+    // DB 路径白名单（安全）：仅允许测试用 ":memory:"（内存库，无文件系统副作用）；
+    // 空=默认 cachePath/mediameta.sqlite；其他任何路径一律拒绝并回退默认，
+    // 防止路径遍历导致任意文件创建/覆盖。
+    QString dbPath;
+    if (m_data->m_dbPath == ":memory:") {
+        dbPath = m_data->m_dbPath;
+    } else if (m_data->m_dbPath.isEmpty()) {
+        dbPath = DmGlobal::cachePath() + "/mediameta.sqlite";
+    } else {
+        qCWarning(dmMusic) << "Security: injected dbPath is not ':memory:' or empty, "
+                              "rejected to prevent path traversal, falling back to default.";
+        dbPath = DmGlobal::cachePath() + "/mediameta.sqlite";
+    }
     qCDebug(dmMusic) << "Opening database at:" << dbPath;
     m_data->m_database = QSqlDatabase::addDatabase("QSQLITE");
     m_data->m_database.setDatabaseName(dbPath);

--- a/src/libdmusic/core/datamanager.h
+++ b/src/libdmusic/core/datamanager.h
@@ -12,7 +12,8 @@ class DataManager : public QObject
 {
     Q_OBJECT
 public:
-    DataManager(QStringList supportedSuffixs, QObject *parent = nullptr);
+    // dbPath 可选：测试注入 ":memory:" 或临时文件以隔离数据；为空走默认 cachePath/mediameta.sqlite
+    explicit DataManager(QStringList supportedSuffixs, QObject *parent = nullptr, const QString &dbPath = QString());
     ~DataManager();
 
     void setCurrentPlayliHash(const QString &hash);

--- a/tests/libdmusic-test/test_ckmeans.cpp
+++ b/tests/libdmusic-test/test_ckmeans.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ckmeans.cpp 的单元测试：k-means 颜色聚类，从图像提取主色。
+// 对应 docs/unit-test-plan.md Phase 1 / ③。
+//
+// 注意事项（来自源码阅读）：
+// 1. CKMeans 默认 m_clusterCount = 1，只会产生 1 个聚类中心，因此 getColorSecond /
+//    getCommColorSecond 在访问 centroids[1] 时会越界（源码缺陷）。本文件只测主色，
+//    副色用例标记 DISABLED_ 待源码修复。
+// 2. kMeans() 内部会缩放图像并采样所有像素，给纯色图断言主色最稳定。
+
+#include <gtest/gtest.h>
+
+#include <QImage>
+#include <QColor>
+#include <QVector3D>
+
+#include "ckmeans.h"
+
+// 工具：构造一张纯色图
+static QImage makeSolidImage(const QColor &color, int size = 32)
+{
+    QImage img(size, size, QImage::Format_RGB32);
+    img.fill(color.rgb());
+    return img;
+}
+
+// ============================================================================
+// 构造 & 默认值
+// ============================================================================
+TEST(CKMeansTest, defaultConstructorHasNoCentroids)
+{
+    CKMeans km;
+    // 未设置图像时，centroids 为空，主色回退到黑色
+    EXPECT_EQ(km.getCommColorMain(), QColor(Qt::black));
+    // QVector3D 接口在空 centroids 时返回 (0,0,0)
+    EXPECT_EQ(km.getColorMain(), QVector3D(0, 0, 0));
+}
+
+TEST(CKMeansTest, getPicPathEmptyByDefault)
+{
+    CKMeans km;
+    EXPECT_TRUE(km.getPicPath().isEmpty());
+}
+
+// ============================================================================
+// 纯色图的主色提取
+// ============================================================================
+TEST(CKMeansTest, dominantColorOfSolidRedImage)
+{
+    CKMeans km;
+    km.setShowImage(makeSolidImage(QColor(255, 0, 0)));
+
+    const QColor main = km.getCommColorMain();
+    // 纯红图的主色应强烈偏红（聚类中心 ≈ 红色通道高）
+    EXPECT_GT(main.red(), 200);
+    EXPECT_LT(main.green(), 60);
+    EXPECT_LT(main.blue(), 60);
+}
+
+TEST(CKMeansTest, dominantColorOfSolidGreenImage)
+{
+    CKMeans km;
+    km.setShowImage(makeSolidImage(QColor(0, 255, 0)));
+
+    const QColor main = km.getCommColorMain();
+    EXPECT_LT(main.red(), 60);
+    EXPECT_GT(main.green(), 200);
+    EXPECT_LT(main.blue(), 60);
+}
+
+TEST(CKMeansTest, dominantColorOfSolidBlueImage)
+{
+    CKMeans km;
+    km.setShowImage(makeSolidImage(QColor(0, 0, 255)));
+
+    const QColor main = km.getCommColorMain();
+    EXPECT_LT(main.red(), 60);
+    EXPECT_LT(main.green(), 60);
+    EXPECT_GT(main.blue(), 200);
+}
+
+TEST(CKMeansTest, getColorMainIsNormalizedToUnitRange)
+{
+    // getColorMain 返回 RGB/255，应在 [0,1] 范围
+    CKMeans km;
+    km.setShowImage(makeSolidImage(QColor(255, 255, 255)));
+
+    const QVector3D v = km.getColorMain();
+    EXPECT_GE(v.x(), 0.0f);  EXPECT_LE(v.x(), 1.0f);
+    EXPECT_GE(v.y(), 0.0f);  EXPECT_LE(v.y(), 1.0f);
+    EXPECT_GE(v.z(), 0.0f);  EXPECT_LE(v.z(), 1.0f);
+    // 纯白图归一化后应接近 (1,1,1)
+    EXPECT_GT(v.x(), 0.9f);
+    EXPECT_GT(v.y(), 0.9f);
+    EXPECT_GT(v.z(), 0.9f);
+}
+
+// ============================================================================
+// 一致性：同一图像两次提取，主色应稳定
+// ============================================================================
+TEST(CKMeansTest, mainColorIsStableAcrossInstances)
+{
+    const QImage img = makeSolidImage(QColor(200, 100, 50));
+
+    CKMeans km1;
+    km1.setShowImage(img);
+    const QColor c1 = km1.getCommColorMain();
+
+    CKMeans km2;
+    km2.setShowImage(img);
+    const QColor c2 = km2.getCommColorMain();
+
+    // 纯色图聚类结果应确定性一致
+    EXPECT_EQ(c1.rgb(), c2.rgb());
+}
+
+// ============================================================================
+// 空图像：不应崩溃
+// ============================================================================
+TEST(CKMeansTest, nullImageDoesNotCrash)
+{
+    QImage nullImg;
+    CKMeans km;
+    km.setShowImage(nullImg);   // kMeans 内部检测 isNull 直接 return
+    // 不崩溃即通过；主色回退黑
+    EXPECT_EQ(km.getCommColorMain(), QColor(Qt::black));
+}
+
+// ============================================================================
+// 副色接口：当前 clusterCount=1 会越界，标记 DISABLED_ 待源码修复
+// 参见 docs/unit-test-plan.md「已知缺陷」。
+// ============================================================================
+TEST(CKMeansTest, DISABLED_secondColorAvailableWhenClusterCountGreaterThanOne)
+{
+    CKMeans km;
+    km.setShowImage(makeSolidImage(QColor(255, 0, 0)));
+    // 待源码支持多聚类中心后启用
+    const QVector3D second = km.getColorSecond();
+    EXPECT_GE(second.x(), 0.0f);
+}

--- a/tests/libdmusic-test/test_datamanager.cpp
+++ b/tests/libdmusic-test/test_datamanager.cpp
@@ -1,0 +1,214 @@
+// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// datamanager.cpp 的单元测试：歌单 CRUD、查询、设置读写。
+// 对应 docs/unit-test-plan.md Phase 2。
+//
+// 关键：所有测试用 ":memory:" 内存 DB 注入，数据完全隔离，绝不触碰
+// ~/.cache/mediameta.sqlite 真实库。每个用例用独立 DataManager 实例 + 作用域隔离，
+// 避免 QSqlDatabase 默认连接名冲突。
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QString>
+#include <QStringList>
+#include <QVariant>
+
+#include "datamanager.h"
+#include "global.h"
+
+namespace {
+// 内存 DB 的 DataManager 工厂
+DataManager *makeDataMgr(const QStringList &suffix = QStringList{"mp3", "flac"})
+{
+    return new DataManager(suffix, nullptr, ":memory:");
+}
+}
+
+// ============================================================================
+// 内置歌单：内存 DB 构造后应预置一组只读内置歌单（album/artist/fav/play 等）
+// ============================================================================
+TEST(DataManagerBuiltInTest, hasBuiltinPlaylistsAfterConstruction)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto playlists = dm->allPlaylistInfos();
+    EXPECT_GT(playlists.size(), 0);
+
+    // 收集所有内置 uuid，验证关键内置歌单存在
+    QStringList uuids;
+    for (const auto &pl : playlists) uuids << pl.uuid;
+    EXPECT_TRUE(uuids.contains("play"));
+}
+
+TEST(DataManagerBuiltInTest, customPlaylistsInitiallyHasNoUserList)
+{
+    // customPlaylistInfos 返回非内置（用户自建）歌单；全新内存库应为空或仅内置
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto customs = dm->customPlaylistInfos();
+    // 内置歌单 hide=true，customPlaylistInfos 通常排除 hide 的；这里只验证不崩溃且可调用
+    EXPECT_GE(customs.size(), 0);
+}
+
+// ============================================================================
+// addPlayList : 新建歌单，返回有效 uuid；重名自动加序号
+// ============================================================================
+TEST(DataManagerAddPlaylistTest, createsPlaylistWithUuid)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto pl = dm->addPlayList("MyList");
+    EXPECT_FALSE(pl.uuid.isEmpty());
+    EXPECT_EQ(pl.displayName, "MyList");
+}
+
+TEST(DataManagerAddPlaylistTest, duplicateNameGetsSuffix)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto pl1 = dm->addPlayList("Dup");
+    const auto pl2 = dm->addPlayList("Dup");
+    EXPECT_EQ(pl1.displayName, "Dup");
+    EXPECT_EQ(pl2.displayName, "Dup 1");   // 重名自动加序号
+    EXPECT_NE(pl1.uuid, pl2.uuid);
+}
+
+// ============================================================================
+// deletePlaylist : 删除存在的歌单返回 true；不存在返回 false
+// ============================================================================
+TEST(DataManagerDeletePlaylistTest, deletesExistingPlaylist)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto pl = dm->addPlayList("ToDelete");
+    EXPECT_TRUE(dm->deletePlaylist(pl.uuid));
+}
+
+TEST(DataManagerDeletePlaylistTest, returnsFalseForNonexistent)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    EXPECT_FALSE(dm->deletePlaylist("nonexistent-uuid-xyz"));
+}
+
+TEST(DataManagerDeletePlaylistTest, deletesFromAllPlaylistInfos)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto pl = dm->addPlayList("WillDelete");
+    const int before = dm->allPlaylistInfos().size();
+    dm->deletePlaylist(pl.uuid);
+    const int after = dm->allPlaylistInfos().size();
+    EXPECT_EQ(after, before - 1);
+}
+
+// ============================================================================
+// renamePlaylist : 改名成功；重名拒绝
+// ============================================================================
+TEST(DataManagerRenamePlaylistTest, renamesSuccessfully)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto pl = dm->addPlayList("OldName");
+    EXPECT_TRUE(dm->renamePlaylist("NewName", pl.uuid));
+    // 通过 allPlaylistInfos 找回验证
+    const auto playlists = dm->allPlaylistInfos();
+    bool found = false;
+    for (const auto &p : playlists) {
+        if (p.uuid == pl.uuid) {
+            EXPECT_EQ(p.displayName, "NewName");
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST(DataManagerRenamePlaylistTest, rejectsDuplicateName)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    dm->addPlayList("NameA");
+    const auto plB = dm->addPlayList("NameB");
+    // 把 B 改成 A 的名字，应被拒绝
+    EXPECT_FALSE(dm->renamePlaylist("NameA", plB.uuid));
+}
+
+TEST(DataManagerRenamePlaylistTest, returnsFalseForNonexistent)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    EXPECT_FALSE(dm->renamePlaylist("Whatever", "nonexistent-uuid"));
+}
+
+// ============================================================================
+// currentPlayliHash / setCurrentPlayliHash : 当前歌单读写
+// ============================================================================
+TEST(DataManagerCurrentPlaylistTest, setAndGetCurrentPlaylist)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    dm->setCurrentPlayliHash("play");
+    EXPECT_EQ(dm->currentPlayliHash(), "play");
+}
+
+// ============================================================================
+// isExistMeta() : 无 meta 时返回 false
+// ============================================================================
+TEST(DataManagerIsExistMetaTest, emptyLibraryReturnsFalse)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    EXPECT_FALSE(dm->isExistMeta());
+}
+
+// ============================================================================
+// getPlaylistMetas : 空库查询不崩溃，返回空
+// ============================================================================
+TEST(DataManagerGetMetasTest, emptyPlaylistReturnsEmpty)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto metas = dm->getPlaylistMetas("play");
+    EXPECT_TRUE(metas.isEmpty());
+}
+
+TEST(DataManagerGetMetasTest, nonexistentPlaylistReturnsEmpty)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    const auto metas = dm->getPlaylistMetas("no-such-playlist");
+    EXPECT_TRUE(metas.isEmpty());
+}
+
+// ============================================================================
+// valueFromSettings / setValueToSettings : 设置读写回环
+// 注意：底层 MusicSettings 基于 DTK DSettings（schema 约束），只能读写 schema 中
+// 已定义的 key（见 src/libdmusic/data/music-settings.json）。写入未定义 key 会使
+// DSettings::setOption 返回空指针并解引用崩溃（源码缺陷，见文档「已知缺陷」）。
+// 故这里只用真实存在的 key 测试。
+// ============================================================================
+TEST(DataManagerSettingsTest, setAndGetVolumeRoundtrip)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    dm->setValueToSettings("base.play.volume", 80);
+    EXPECT_EQ(dm->valueFromSettings("base.play.volume").toInt(), 80);
+}
+
+TEST(DataManagerSettingsTest, overwriteExistingValue)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    dm->setValueToSettings("base.play.volume", 30);
+    dm->setValueToSettings("base.play.volume", 70);
+    EXPECT_EQ(dm->valueFromSettings("base.play.volume").toInt(), 70);
+}
+
+TEST(DataManagerSettingsTest, setAndGetMuteFlag)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    dm->setValueToSettings("base.play.mute", true);
+    EXPECT_EQ(dm->valueFromSettings("base.play.mute").toBool(), true);
+}
+
+// ============================================================================
+// quickSearchText : 空库搜索不崩溃，返回空结果
+// ============================================================================
+TEST(DataManagerSearchTest, emptyLibrarySearchReturnsNoResults)
+{
+    std::unique_ptr<DataManager> dm(makeDataMgr());
+    QStringList metaTitles;
+    QList<QPair<QString, QString>> albums, artists;
+    dm->quickSearchText("anything", metaTitles, albums, artists);
+    EXPECT_TRUE(metaTitles.isEmpty());
+    EXPECT_TRUE(albums.isEmpty());
+    EXPECT_TRUE(artists.isEmpty());
+}

--- a/tests/libdmusic-test/test_lyricanalysis.cpp
+++ b/tests/libdmusic-test/test_lyricanalysis.cpp
@@ -1,0 +1,162 @@
+// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// lyricanalysis.cpp 的单元测试：LRC 歌词解析（时间戳 + 文本）。
+// 对应 docs/unit-test-plan.md Phase 1 / ②。
+//
+// 注意：parseLyric 使用 QRegExp "mm:ss.z" 解析时间，时间精度依赖 Qt 的
+// QTime::fromString。这里优先使用「自洽性断言」（如 getIndex(getPostion(i))==i）
+// 和「相对关系断言」，避免对绝对毫秒值过度敏感。
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QTemporaryFile>
+
+#include "lyricanalysis.h"
+
+namespace {
+// RAII 临时 LRC 文件：构造时写入内容，析构时自动删除磁盘文件。
+// 相比返回裸路径的 helper：避免 new QTemporaryFile 泄漏对象，且 ASSERT 失败时
+// 栈展开仍会析构并删除文件，不残留在 /tmp。
+class TempLrcFile
+{
+public:
+    explicit TempLrcFile(const QString &content)
+    {
+        // QTemporaryFile 默认 autoRemove(true)：析构时自动删除文件
+        if (m_file.open()) {
+            m_file.write(content.toUtf8());
+            m_file.close();  // 落盘并释放句柄，供 setFromFile 读取
+            m_path = m_file.fileName();
+        }
+    }
+
+    QString path() const
+    {
+        return m_path;
+    }
+
+private:
+    QTemporaryFile m_file;
+    QString        m_path;
+};
+}
+
+// ============================================================================
+// 基本解析：时间戳 + 歌词文本
+// ============================================================================
+TEST(LyricAnalysisTest, parsesMultipleLines)
+{
+    TempLrcFile tempLrc("[00:01.20]first line\n[00:03.50]second line\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    EXPECT_EQ(la.getCount(), 2);
+}
+
+TEST(LyricAnalysisTest, getLineAtReturnsText)
+{
+    TempLrcFile tempLrc("[00:01.20]first line\n[00:03.50]second line\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("first line"));
+    EXPECT_EQ(la.getLineAt(1), QStringLiteral("second line"));
+}
+
+TEST(LyricAnalysisTest, getLineAtInvalidIndexReturnsEmpty)
+{
+    TempLrcFile tempLrc("[00:01.20]only\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    EXPECT_TRUE(la.getLineAt(-1).isNull()  || la.getLineAt(-1).isEmpty());
+    EXPECT_TRUE(la.getLineAt(99).isNull()  || la.getLineAt(99).isEmpty());
+}
+
+// ============================================================================
+// 时间顺序：解析后按时间升序排列，getPostion 单调递增
+// ============================================================================
+TEST(LyricAnalysisTest, lyricsAreSortedByTimeAscending)
+{
+    // 故意乱序写入，解析后应排序
+    TempLrcFile tempLrc(
+        "[00:05.00]third\n[00:01.00]first\n[00:03.00]second\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+
+    ASSERT_EQ(la.getCount(), 3);
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("first"));
+    EXPECT_EQ(la.getLineAt(1), QStringLiteral("second"));
+    EXPECT_EQ(la.getLineAt(2), QStringLiteral("third"));
+
+    // 位置单调递增（时间排序的体现）
+    EXPECT_LE(la.getPostion(0), la.getPostion(1));
+    EXPECT_LE(la.getPostion(1), la.getPostion(2));
+}
+
+TEST(LyricAnalysisTest, getPostionInvalidIndexReturnsZero)
+{
+    LyricAnalysis la;  // 未加载任何文件
+    EXPECT_EQ(la.getPostion(0), 0);
+    EXPECT_EQ(la.getPostion(999), 0);
+}
+
+// ============================================================================
+// getIndex / getPostion 的自洽性：二分查找应能定位回原行
+// ============================================================================
+TEST(LyricAnalysisTest, getIndexPostionAreConsistent)
+{
+    TempLrcFile tempLrc(
+        "[00:01.00]a\n[00:03.00]b\n[00:05.00]c\n[00:07.00]d\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    const int n = la.getCount();
+    ASSERT_EQ(n, 4);
+
+    for (int i = 0; i < n; ++i) {
+        const qint64 pos = la.getPostion(i);
+        // 用该行的时间点去查 index，应定位回同一行
+        EXPECT_EQ(la.getIndex(pos), i);
+    }
+}
+
+TEST(LyricAnalysisTest, getIndexFallsBackToLastForPositionBeyondEnd)
+{
+    TempLrcFile tempLrc("[00:01.00]a\n[00:03.00]b\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    ASSERT_EQ(la.getCount(), 2);
+    // 超出最后时间点，二分应落在最后一行
+    EXPECT_EQ(la.getIndex(99999999), 1);
+    // 早于第一行，落在第 0 行
+    EXPECT_EQ(la.getIndex(0), 0);
+}
+
+// ============================================================================
+// 空文件 / 无效行：鲁棒性
+// ============================================================================
+TEST(LyricAnalysisTest, emptyFileProducesNoLyrics)
+{
+    TempLrcFile tempLrc("");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    EXPECT_EQ(la.getCount(), 0);
+    EXPECT_TRUE(la.allLyrics().isEmpty());
+}
+
+TEST(LyricAnalysisTest, linesWithoutTimestampAreIgnored)
+{
+    // 纯文本、无 [mm:ss] 标记的行应被忽略，不计入
+    TempLrcFile tempLrc("this is not a lyric line\nplain text\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    EXPECT_EQ(la.getCount(), 0);
+}
+
+TEST(LyricAnalysisTest, nonExistentFileProducesNoLyrics)
+{
+    LyricAnalysis la;
+    la.setFromFile("/nonexistent/path/to/file.lrc");
+    EXPECT_EQ(la.getCount(), 0);
+}

--- a/tests/libdmusic-test/test_main.cpp
+++ b/tests/libdmusic-test/test_main.cpp
@@ -46,12 +46,14 @@ void QTestMain::initTestCase()
 void QTestMain::cleanupTestCase()
 {
     qDebug() << "=====stop test=====";
-    exit(0);
+    // 不再调用 exit(0)：直接 exit 会绕过进程正常退出流程，导致 gcov 的 .gcda
+    // 覆盖率数据无法 flush 到磁盘，覆盖率统计恒为 0。改为正常返回，让 QTest::qExec
+    // 返回后进程自然退出，atexit 注册的 __gcov_dump 得以执行。
 }
 
 void QTestMain::testGTest()
 {
-    testing::GTEST_FLAG(output) = "xml:./report/report_deepin-movie-test.xml";
+    testing::GTEST_FLAG(output) = "xml:./report/report_deepin-music-test.xml";
     testing::InitGoogleTest(&m_argc,m_argv);
     int ret = RUN_ALL_TESTS();
 #ifndef __mips__

--- a/tests/libdmusic-test/test_utils.cpp
+++ b/tests/libdmusic-test/test_utils.cpp
@@ -1,0 +1,236 @@
+// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// utils.cpp 的单元测试：纯函数为主，零外部依赖，用 GTest 参数化覆盖边界条件。
+// 对应 docs/unit-test-plan.md Phase 1 / ①。
+
+#include <gtest/gtest.h>
+
+#include <QChar>
+#include <QString>
+#include <QStringList>
+#include <QVariantMap>
+#include <complex>
+
+#include "utils.h"
+#include "global.h"
+
+// ============================================================================
+// isChinese : CJK 统一汉字范围 [0x4E00, 0x9FBF]
+// ============================================================================
+struct IsChineseCase {
+    QChar input;
+    bool expected;
+};
+
+class IsChineseTest : public ::testing::WithParamInterface<IsChineseCase>,
+                      public ::testing::Test {
+};
+
+TEST_P(IsChineseTest, detectsChineseRange)
+{
+    EXPECT_EQ(Utils::isChinese(GetParam().input), GetParam().expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(Detect, IsChineseTest, ::testing::Values(
+    IsChineseCase{QChar(0x4E00), true},   // 范围下界 "一"
+    IsChineseCase{QChar(0x4E2D), true},   // "中"
+    IsChineseCase{QChar(0x9FBF), true},   // 范围上界
+    IsChineseCase{QChar('a'),   false},   // 拉丁字母
+    IsChineseCase{QChar('1'),   false},   // 数字
+    IsChineseCase{QChar(' '),   false},   // 空格
+    IsChineseCase{QChar(0x3042), false}   // 日文平假名，不在中文范围
+));
+
+// ============================================================================
+// filePathHash : MD5，确定性 + 不同输入产生不同输出
+// ============================================================================
+TEST(UtilsFilePathHashTest, IsDeterministicForSameInput)
+{
+    EXPECT_EQ(Utils::filePathHash("/a/b.mp3"), Utils::filePathHash("/a/b.mp3"));
+}
+
+TEST(UtilsFilePathHashTest, DiffersForDifferentInput)
+{
+    EXPECT_NE(Utils::filePathHash("/a/b.mp3"), Utils::filePathHash("/a/c.mp3"));
+}
+
+TEST(UtilsFilePathHashTest, IsHexMd5Length32)
+{
+    const QString hash = Utils::filePathHash("x");
+    EXPECT_EQ(hash.length(), 32);
+    // 仅含十六进制字符
+    EXPECT_TRUE(std::all_of(hash.begin(), hash.end(), [](const QChar &c) {
+        QChar ch = c.toLower();
+        return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f');
+    }));
+}
+
+// ============================================================================
+// containsStr : 中文/英文搜索，大小写不敏感
+// ============================================================================
+TEST(UtilsContainsStrTest, matchesEnglishCaseInsensitive)
+{
+    EXPECT_TRUE(Utils::containsStr("love", "Deepin Love"));
+    EXPECT_TRUE(Utils::containsStr("LOVE", "deepin love"));
+}
+
+TEST(UtilsContainsStrTest, matchesChineseSubstring)
+{
+    EXPECT_TRUE(Utils::containsStr("音乐", "深度音乐"));
+    EXPECT_FALSE(Utils::containsStr("不存在", "深度音乐"));
+}
+
+TEST(UtilsContainsStrTest, noMatchReturnsFalse)
+{
+    EXPECT_FALSE(Utils::containsStr("xyzabc", "hello world"));
+}
+
+TEST(UtilsContainsStrTest, ignoresNewlineAndCarriageReturn)
+{
+    // 源码会 remove \r \n，跨行搜索应能命中
+    EXPECT_TRUE(Utils::containsStr("world", "hello\nworld"));
+}
+
+// ============================================================================
+// simplifyPlaylistSortType : ASC/DES 归并到无方向的基础类型
+// 枚举值来自 global.h：ASC/DES 为 0~5，基础类型 10~14
+// ============================================================================
+struct SortTypeCase {
+    int input;
+    int expected;
+};
+
+class SimplifySortTypeTest : public ::testing::WithParamInterface<SortTypeCase>,
+                             public ::testing::Test {
+};
+
+TEST_P(SimplifySortTypeTest, mapsToBaseType)
+{
+    EXPECT_EQ(Utils::simplifyPlaylistSortType(GetParam().input), GetParam().expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(Map, SimplifySortTypeTest, ::testing::Values(
+    // ASC / DES 成对归并
+    SortTypeCase{DmGlobal::SortByAddTimeASC, DmGlobal::SortByAddTime},
+    SortTypeCase{DmGlobal::SortByAddTimeDES, DmGlobal::SortByAddTime},
+    SortTypeCase{DmGlobal::SortByTitleASC,   DmGlobal::SortByTitle},
+    SortTypeCase{DmGlobal::SortByTitleDES,   DmGlobal::SortByTitle},
+    SortTypeCase{DmGlobal::SortByAblumASC,   DmGlobal::SortByAblum},
+    SortTypeCase{DmGlobal::SortByAblumDES,   DmGlobal::SortByAblum},
+    SortTypeCase{DmGlobal::SortByArtistASC,  DmGlobal::SortByArtist},
+    SortTypeCase{DmGlobal::SortByArtistDES,  DmGlobal::SortByArtist},
+    SortTypeCase{DmGlobal::SortByCustomASC,  DmGlobal::SortByCustom},
+    SortTypeCase{DmGlobal::SortByCustomDES,  DmGlobal::SortByCustom},
+    // 未知值回退到 SortByAddTime
+    SortTypeCase{999, DmGlobal::SortByAddTime},
+    SortTypeCase{-1,  DmGlobal::SortByAddTime}
+));
+
+// ============================================================================
+// metaToVariantMap : 字段完整映射到 QVariantMap
+// ============================================================================
+TEST(UtilsMetaToVariantMapTest, mapsAllStringFields)
+{
+    DMusic::MediaMeta meta;
+    meta.hash = "h1";
+    meta.localPath = "/a/b.mp3";
+    meta.title = "T";
+    meta.artist = "A";
+    meta.album = "Al";
+
+    const QVariantMap m = Utils::metaToVariantMap(meta);
+    EXPECT_EQ(m.value("hash").toString(),      "h1");
+    EXPECT_EQ(m.value("localPath").toString(), "/a/b.mp3");
+    EXPECT_EQ(m.value("title").toString(),     "T");
+    EXPECT_EQ(m.value("artist").toString(),    "A");
+    EXPECT_EQ(m.value("album").toString(),     "Al");
+}
+
+TEST(UtilsMetaToVariantMapTest, mapsNumericAndFlagFields)
+{
+    DMusic::MediaMeta meta;
+    meta.length = 12345;
+    meta.size = 6789;
+    meta.favourite = true;
+    meta.hasimage = false;
+
+    const QVariantMap m = Utils::metaToVariantMap(meta);
+    EXPECT_EQ(m.value("length").toLongLong(),    12345);
+    EXPECT_EQ(m.value("size").toLongLong(),      6789);
+    EXPECT_EQ(m.value("favourite").toBool(),     true);
+    EXPECT_EQ(m.value("hasimage").toBool(),      false);
+}
+
+TEST(UtilsMetaToVariantMapTest, containsAllExpectedKeys)
+{
+    const QVariantMap m = Utils::metaToVariantMap(DMusic::MediaMeta{});
+    const QStringList expectedKeys = {
+        "hash", "localPath", "cuePath", "title", "artist", "album", "lyricPath",
+        "pinyinTitle", "filetype", "mmType", "timestamp", "length", "size",
+        "favourite", "invalid", "codec", "inMulitSelect", "dragFlag"
+    };
+    for (const auto &key : expectedKeys) {
+        EXPECT_TRUE(m.contains(key)) << "Missing key: " << key.toStdString();
+    }
+}
+
+// ============================================================================
+// playlistToVariantMap : 内部会调用 simplifyPlaylistSortType
+// ============================================================================
+TEST(UtilsPlaylistToVariantMapTest, mapsCoreFields)
+{
+    DMusic::PlaylistInfo pl;
+    pl.uuid = "u1";
+    pl.displayName = "My List";
+    pl.sortType = DmGlobal::SortByTitleASC;  // 应被简化为 SortByTitle
+
+    const QVariantMap m = Utils::playlistToVariantMap(pl);
+    EXPECT_EQ(m.value("uuid").toString(), "u1");
+    EXPECT_EQ(m.value("displayName").toString(), "My List");
+    EXPECT_EQ(m.value("sortType").toInt(), DmGlobal::SortByTitle);
+}
+
+// ============================================================================
+// fft : 傅里叶变换数学性质
+//
+// 注意：当前 utils.cpp 的 fft() 实现存在变量复用缺陷——外层循环变量 i 被最内层
+// for(i=0; i<length/step; i++) 覆盖，导致外层循环条件恒成立而陷入死循环。
+// 因此以下用例标记为 DISABLED_，gtest 会跳过它们（不阻塞整套测试）。
+// 待 src/libdmusic/util/utils.cpp 的 fft() 修复后，移除 DISABLED_ 前缀即可启用。
+// 参见 docs/unit-test-plan.md「已知缺陷」。
+// ============================================================================
+TEST(UtilsFftTest, DISABLED_dcSignalConcentratesInFirstBin)
+{
+    const int Log2N = 3;          // length = 8
+    const int length = 1 << Log2N;
+    std::vector<std::complex<float>> data(length, std::complex<float>(1.0f, 0.0f));
+
+    Utils::fft(data.data(), Log2N, -1);   // 正变换
+
+    // 直流分量 = N，其余分量幅值应趋近 0
+    EXPECT_NEAR(data[0].real(), static_cast<float>(length), 1e-3f);
+    for (int i = 1; i < length; ++i) {
+        EXPECT_NEAR(std::abs(data[i]), 0.0f, 1e-3f);
+    }
+}
+
+TEST(UtilsFftTest, DISABLED_inverseFftRestoresOriginalSignal)
+{
+    const int Log2N = 3;
+    const int length = 1 << Log2N;
+    const std::vector<std::complex<float>> original = {
+        {1, 0}, {2, 0}, {3, 0}, {4, 0}, {3, 0}, {2, 0}, {1, 0}, {0, 0}
+    };
+    std::vector<std::complex<float>> data = original;
+
+    Utils::fft(data.data(), Log2N, -1);   // 正变换
+    Utils::fft(data.data(), Log2N, 1);    // 逆变换（源码 sign==1 时除以 length）
+
+    for (int i = 0; i < length; ++i) {
+        EXPECT_NEAR(data[i].real(), original[i].real(), 1e-3f);
+        EXPECT_NEAR(data[i].imag(), 0.0f, 1e-3f);
+    }
+}

--- a/tests/libdmusic-test/ut-build-run.sh
+++ b/tests/libdmusic-test/ut-build-run.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-#workdir=$(cd ../$(dirname $0)/deepin-movie/build-ut; pwd)
+# 单元测试运行 + 覆盖率收集脚本（libdmusic-test）
+#
+# 关键修正（相对原版）：
+# 1. lcov --directory 指向构建根目录，递归采集「被测库 dmusic」的覆盖率（原版只采
+#    测试自身，分母仅几百行，无统计意义）。
+# 2. --remove 过滤掉测试代码自身、系统头、autogen moc，使分母 = 纯业务源码。
+# 3. ASAN 关闭 leak 检测：测试中 Presenter 未释放会触发 leak，抢先 abort 导致
+#    gcov 的 .gcda 无法 flush（覆盖率恒为 0）。
+# 4. timeout 保护：防止任一用例死循环（如 fft 缺陷）阻塞整个 CI。
+
 executable=libdmusic-test #可执行程序的文件名
 
 platform=`uname -m`
@@ -12,25 +21,37 @@ mkdir -p html
 mkdir -p report
 
 echo " ===================CREAT LCOV REPROT==================== "
-lcov --directory ./CMakeFiles/libdmusic-test.dir --zerocounters
-ASAN_OPTIONS="fast_unwind_on_malloc=1" ./$executable
-lcov --directory . --capture --output-file ./html/${executable}_Coverage.info
+# zerocounters 必须覆盖整个构建目录（含 dmusic.dir），否则历史 .gcda 会污染统计
+lcov --directory ../../ --zerocounters
+# 关闭 leak 检测 + 超时保护运行测试，确保进程正常退出以 flush .gcda
+QT_QPA_PLATFORM=offscreen ASAN_OPTIONS="fast_unwind_on_malloc=1:detect_leaks=0" \
+    timeout 120 ./$executable
+# --directory ../../  递归采集 dmusic + 测试的 .gcda（业务代码覆盖率的关键）
+lcov --directory ../../ --capture --output-file ./html/${executable}_Coverage.info
 
 echo " =================== do filter begin ==================== "
 
-lcov --remove ./html/${executable}_Coverage.info '*/usr/include/*' '/usr/local/*'  -o ./html/${executable}_Coverage_fileter.info
+# 过滤：系统头、第三方库、Qt/DTK 头、测试代码自身、构建产物（build-ut 整个目录，
+# 含 autogen 生成的 moc/qrc），只保留被测业务源码 src/libdmusic/
+lcov --remove ./html/${executable}_Coverage.info \
+    '*/usr/include/*' \
+    '/usr/local/*' \
+    '*/tests/*' \
+    '*/build-ut/*' \
+    '*/build*/*_autogen/*' \
+    '*/moc_*.cpp' \
+    '*/qrc_*.cpp' \
+    -o ./html/${executable}_Coverage_fileter.info
 
 echo " =================== do filter end ====================== "
-    
+
 genhtml -o ./html ./html/${executable}_Coverage_fileter.info
-    
+
 mv ./html/index.html ./html/cov_${executable}.html
-mv asan.log* asan_${executable}.log
+mv asan.log* asan_${executable}.log 2>/dev/null || true
 
 cp -r ./html/ ../../
 cp -r ./report/ ../../
-cp ./asan_${executable}.log ../../
-
-#ls report/
+cp ./asan_${executable}.log ../../ 2>/dev/null || true
 
 exit 0


### PR DESCRIPTION
- Make DataManager's DB path injectable via an optional dbPath ctor arg, so tests use ":memory:" for isolation without touching real cache db.
- Drop exit(0) in cleanupTestCase; a hard exit skips gcov's .gcda flush, so coverage was always 0. Return normally so __gcov_dump runs.
- Rewrite ut-build-run.sh: lcov the build root to capture the *tested* dmusic lib (not just the test binary), filter system/Qt/DTK/test/ build-ut dir/moc sources, disable ASAN leak detect so leak-abort won't preempt the .gcda flush, and add a timeout guard.
- Add GTest suites for utils, lyricanalysis, ckmeans, datamanager.

- 使 DataManager 的数据库路径可通过构造参数注入，测试用 ":memory:" 内存库实现数据隔离，不触碰真实 mediameta.sqlite，默认行为不变。
- 移除 cleanupTestCase 中的 exit(0)：硬退出会跳过 gcov 的 .gcda 刷盘， 导致覆盖率恒为 0。改为正常返回，使 __gcov_dump 在 atexit 执行。
- 重写 ut-build-run.sh：lcov 指向构建根目录以采集被测 dmusic 库（而非 仅测试二进制），过滤系统/Qt/DTK/测试/build-ut 目录/moc 源码，关闭 ASAN 泄漏检测以免抢先 abort 导致 .gcda 无法刷盘，并加超时保护。
- 新增 utils/lyricanalysis/ckmeans/datamanager 四个 GTest 测试套件。

Log: 补充 libdmusic 单元测试用例并修复覆盖率采集
Influence: 新增四模块测试用例，覆盖率采集改为统计被测库而非测试自身，
并修复 gcov 无法刷盘导致的覆盖率恒 0 问题，建立真实基线。

## Summary by Sourcery

Add libdmusic unit tests and improve coverage collection to measure the actual library code instead of the test binary.

New Features:
- Add GTest-based unit test suites for utils, lyric analysis, ckmeans color clustering, and DataManager using an in-memory database.

Bug Fixes:
- Allow DataManager to accept an injectable database path so tests can run against an isolated in-memory SQLite database without touching the real cache file.
- Fix coverage collection by letting the test runner exit normally instead of calling exit(0), ensuring gcov data is flushed.

Enhancements:
- Update the unit-test coverage script to reset and capture coverage from the full build tree, filter out non-business sources, disable ASAN leak detection, and add timeout protection for the test run.