### PR TITLE
fix: 释放语音服务插件资源

### DIFF
--- a/src/libmusic-plugin/musicvoiceservice.cpp
+++ b/src/libmusic-plugin/musicvoiceservice.cpp
@@ -8,7 +8,7 @@
 
 MusicVoiceService::MusicVoiceService()
 {
-    m_voice = new VoicePlugin();
+    m_voice = new VoicePlugin(this);
 }
 
 QString MusicVoiceService::serviceName()

--- a/src/libmusic-plugin/voiceplugin.cpp
+++ b/src/libmusic-plugin/voiceplugin.cpp
@@ -21,6 +21,9 @@
 VoicePlugin::VoicePlugin(QObject *parent): QObject(parent)
 {
     m_settings = Dtk::Core::DSettings::fromJsonFile(":/speech/data/deepin-music-speechconfig.json");
+    if (m_settings) {
+        m_settings->setParent(this);
+    }
 }
 
 void VoicePlugin::process(const QString &semantic)


### PR DESCRIPTION
Log: 修复MusicVoiceService未释放VoicePlugin的问题
Task: https://pms.uniontech.com/task-view-390625.html
Influence: 服务释放时通过Qt父子对象机制回收VoicePlugin，并释放内部

## Summary by Sourcery

Ensure VoicePlugin instances are properly parented and release their internal resources on destruction to prevent leaks.

Bug Fixes:
- Fix VoicePlugin not being deleted with MusicVoiceService by setting MusicVoiceService as its QObject parent.
- Release VoicePlugin settings configuration object in the VoicePlugin destructor to avoid memory leaks.