### PR TITLE
fix(player): play current track on dbus play after restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ obj-x86_64-linux-gnu/
 .npm-cache/
 .cursor/
 .codegraph/
+.trellis/
+AGENTS.md

--- a/src/libdmusic/player/playerengine.cpp
+++ b/src/libdmusic/player/playerengine.cpp
@@ -246,8 +246,14 @@ void PlayerEngine::setMprisPlayer(const QString &serviceName, const QString &des
                 resume();
             } else {
                 if (playbackStatus() != DmGlobal::Playing) {
-                    //播放列表为空时也应考虑，不然会出现dbus调用无效的情况
-                    playNextMeta(false);
+                    // After restart setMediaMeta restores the current track while the
+                    // backend state stays Stopped; play the current track instead of the next
+                    if (!getMediaMeta().localPath.isEmpty() && !getMediaMeta().hash.isEmpty()) {
+                        play();
+                    } else {
+                        // Empty playlist must also be handled, otherwise dbus calls are no-ops
+                        playNextMeta(false);
+                    }
                 } else {
                     pauseNow();
                 }


### PR DESCRIPTION
After restart the restored track has a Stopped backend state, so playRequested skipped to playNextMeta. Guard with a localPath and hash check to play the current track.

重启后恢复的当前曲目后端为 Stopped 状态，playRequested 误调 playNextMeta 跳到下一首。增加 localPath 与 hash 校验，播放当前曲目。

Log: 修复重启后dbus播放跳到下一首的问题
PMS: BUG-367253
Influence: 重启后dbus触发播放时播放当前恢复曲目而非下一首。