### PR TITLE
fix: persist only newly imported metas instead of full rewrite

### DIFF
--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -173,6 +173,7 @@ private:
     QString                           m_dbPath;           // 可注入的 DB 路径，空=默认 cachePath/mediameta.sqlite
     QString                           m_currentHash;
     QList<DMusic::MediaMeta>          m_allMetas;
+    QList<DMusic::MediaMeta>          m_importedMetas;   // newly imported metas this batch; consumed and cleared by upsertMetasDB
     QList<DMusic::AlbumInfo>          m_allAlbums;
     QList<DMusic::ArtistInfo>         m_allArtists;
     QList<DMusic::PlaylistInfo>       m_allPlaylist;
@@ -738,6 +739,86 @@ int DataManager::addMetasToPlaylistDB(const QString &uuid, const QList<MediaMeta
 
     qCInfo(dmMusic) << "Successfully added" << insert_count << "metas to playlist" << uuid;
     return insert_count;
+}
+
+bool DataManager::upsertMetasDB()
+{
+    if (m_data->m_importedMetas.isEmpty()) {
+        qCDebug(dmMusic) << "upsertMetasDB: no imported metas, skip";
+        return true;
+    }
+
+    qCDebug(dmMusic) << "upsertMetasDB: incrementally writing" << m_data->m_importedMetas.size() << "metas";
+    m_data->m_database.transaction();
+
+    QSqlQuery query(m_data->m_database);
+    bool isPrepare = query.prepare("INSERT OR REPLACE INTO musicNew ("
+                                   "hash, timestamp, title, artist, album, "
+                                   "filetype, size, track, offset, hasimage, favourite, localpath, length, "
+                                   "py_title, py_title_short, py_artist, py_artist_short, "
+                                   "py_album, py_album_short, lyricPath, codec, cuepath, orititle, oriartist, orialbum "
+                                   ") "
+                                   "VALUES ("
+                                   ":hash, :timestamp, :title, :artist, :album, "
+                                   ":filetype, :size, :track, :offset, :hasimage, :favourite, :localpath, :length, "
+                                   ":py_title, :py_title_short, :py_artist, :py_artist_short, "
+                                   ":py_album, :py_album_short, :lyricPath, :codec, :cuepath, :orititle, :oriartist, :orialbum "
+                                   ")");
+    if (!isPrepare) {
+        qCCritical(dmMusic) << "upsertMetasDB: prepare failed:" << query.lastError();
+        m_data->m_database.rollback();
+        return false;
+    }
+
+    int idx = 0;
+    for (const MediaMeta &meta : m_data->m_importedMetas) {
+        query.bindValue(":hash", meta.hash);
+        query.bindValue(":timestamp", meta.timestamp);
+        query.bindValue(":title", meta.title);
+        query.bindValue(":artist", meta.artist);
+        query.bindValue(":album", meta.album);
+        query.bindValue(":filetype", meta.filetype);
+        query.bindValue(":size", meta.size);
+        query.bindValue(":track", meta.track);
+        query.bindValue(":offset", meta.offset);
+        query.bindValue(":hasimage", meta.hasimage);
+        query.bindValue(":favourite", meta.favourite);
+        query.bindValue(":localpath", meta.localPath);
+        query.bindValue(":length", meta.length);
+        query.bindValue(":py_title", meta.pinyinTitle);
+        query.bindValue(":py_title_short", meta.pinyinTitleShort);
+        query.bindValue(":py_artist", meta.pinyinArtist);
+        query.bindValue(":py_artist_short", meta.pinyinArtistShort);
+        query.bindValue(":py_album", meta.pinyinAlbum);
+        query.bindValue(":py_album_short", meta.pinyinAlbumShort);
+        query.bindValue(":lyricPath", meta.lyricPath);
+        query.bindValue(":codec", meta.codec);
+        query.bindValue(":cuepath", meta.cuePath);
+        query.bindValue(":orititle", meta.originalTitle);
+        query.bindValue(":oriartist", meta.originalArtist);
+        query.bindValue(":orialbum", meta.originalAlbum);
+
+        if (!query.exec()) {
+            // Any single failure aborts the whole batch: rollback guarantees
+            // atomicity (no partial/silent loss). Exit-time full saveDataToDB
+            // will still persist on next shutdown.
+            qCCritical(dmMusic) << "upsertMetasDB: exec failed at index" << idx
+                                << "meta:" << meta.title << "error:" << query.lastError();
+            m_data->m_database.rollback();
+            return false;
+        }
+        idx++;
+    }
+
+    if (!m_data->m_database.commit()) {
+        qCCritical(dmMusic) << "upsertMetasDB: commit failed:" << m_data->m_database.lastError();
+        m_data->m_database.rollback();
+        return false;
+    }
+
+    qCInfo(dmMusic) << "upsertMetasDB: wrote" << m_data->m_importedMetas.size() << "metas";
+    m_data->m_importedMetas.clear();
+    return true;
 }
 
 void DataManager::saveDataToDB()
@@ -2080,6 +2161,7 @@ void DataManager::slotAddOneMeta(QStringList playlistHashs, MediaMeta meta)
                     // 检查是否已存在，避免重复添加
                     if (existingIndex < 0) {
                         m_data->m_allMetas.append(curMeta);
+                        m_data->m_importedMetas.append(curMeta);
                         addMetaToAlbum(curMeta);
                         addMetaToArtist(curMeta);
                         qCDebug(dmMusic) << "Added meta to all collections";

--- a/src/libdmusic/core/datamanager.h
+++ b/src/libdmusic/core/datamanager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -47,7 +47,9 @@ public:
     void movePlaylist(const QString &hash, const QString &nextHash);
     bool isExistMeta(const QString &metaHash, const QString &playlistHash);
     void saveDataToDB();
-
+    // Incrementally persist newly imported metas to musicNew; no table clear, no history rewrite.
+    // Consumes and clears m_importedMetas. Called after import finishes.
+    bool upsertMetasDB();
     // 更新编码
     void updateMetaCodec(const DMusic::MediaMeta &meta);
 

--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -147,10 +147,10 @@ Presenter::Presenter(const QString &unknownAlbumStr, const QString &unknownArtis
             m_data->m_playerEngine->play();
         }
         
-        // 导入歌曲成功后保存数据库
+        // After import succeeds, incrementally persist musicNew; full saveDataToDB still runs on exit
         if (sucessCount > 0) {
-            qCInfo(dmMusic) << "Saving database after importing" << sucessCount << "songs";
-            saveDataToDB();
+            qCInfo(dmMusic) << "Incrementally saving" << sucessCount << "imported songs";
+            m_data->m_dataManager->upsertMetasDB();
         }
         
         emit importFinished(playlistHashs, failCount, sucessCount, existCount);


### PR DESCRIPTION
Replace full-table saveDataToDB (DELETE + reinsert all) on import with incremental upsertMetasDB writing only newly imported metas to musicNew.

导入音乐后改为增量持久化新增 meta 到 musicNew 表，不再全表清空重写；
退出时仍保留全量 saveDataToDB 兜底，保证最终数据一致。

Log: 导入音乐增量持久化优化
PMS: BUG-333281
Influence: 导入耗时不再随库规模线性增长，UI 阻塞显著降低；崩溃时 meta 已落盘。

## Summary by Sourcery

Introduce incremental persistence of newly imported media metadata instead of rewriting the entire musicNew table after each import.

Bug Fixes:
- Avoid full-table delete-and-reinsert on musicNew during imports to prevent import time and UI blocking from scaling linearly with library size.

Enhancements:
- Track newly imported media metadata in-memory and add an upsert operation to write only those entries to the musicNew table after import.
- Adjust the presenter import flow to call the new incremental upsert instead of triggering a full saveDataToDB on each successful import.
- Refresh copyright year ranges across touched source files.