### PR TITLE
fix(test): use bare include names in test_audiodatadetector

### DIFF
--- a/tests/libdmusic-test/test_audiodatadetector.cpp
+++ b/tests/libdmusic-test/test_audiodatadetector.cpp
@@ -33,9 +33,9 @@
 #include <QStandardPaths>
 #include <memory>
 
-#include "../src/libdmusic/core/audiodatadetector.h"
-#include "../src/libdmusic/core/dynamiclibraries.h"
-#include "../src/libdmusic/global.h"
+#include "audiodatadetector.h"
+#include "dynamiclibraries.h"
+#include "global.h"
 
 #ifndef TEST_DATA_DIR
 #define TEST_DATA_DIR "."


### PR DESCRIPTION
Replace "../src/libdmusic/..." relative includes with bare filenames, relying on the -I paths already configured by CMake, like other tests.

将 "../src/libdmusic/..." 相对路径 include 改为裸文件名，依赖 CMake 已配置的 -I 路径，与其他测试文件写法保持一致。

Log: 修复 QtCreator 下测试编译找不到头文件
Influence: 该测试不再依赖 build 目录深度，QtCreator 默认布局与命令行均可正常编译。

## Summary by Sourcery

Tests:
- Update test_audiodatadetector to include libdmusic headers via configured include paths instead of relative source paths.