### PR TITLE
fix: extract cover/lyrics after import loop for instant list

### DIFF
--- a/src/libdmusic/core/audioanalysis.cpp
+++ b/src/libdmusic/core/audioanalysis.cpp
@@ -660,25 +660,37 @@ void AudioAnalysis::parseMetaLyrics(DMusic::MediaMeta &meta)
     QString tmpPath = DmGlobal::cachePath();
     QString hash = meta.hash;
     QString path = meta.localPath;
-    QString lyricDirPath = tmpPath + QDir::separator() + "lyrics";
+    QString lyricDirPath = QDir::cleanPath(tmpPath + QDir::separator() + "lyrics");
     QString lyricName = hash + ".lrc";
-    QDir lyricDir(lyricDirPath);
+    const QString lyricRootPath = QFileInfo(lyricDirPath).absoluteFilePath();
+    const QString lyricFilePath = QFileInfo(QDir::cleanPath(lyricRootPath + QDir::separator() + lyricName)).absoluteFilePath();
+    const QString lyricRootPrefix = lyricRootPath.endsWith(QDir::separator()) ? lyricRootPath : lyricRootPath + QDir::separator();
+    if (!lyricFilePath.startsWith(lyricRootPrefix)) {
+        qCWarning(dmMusic) << "Rejected unsafe lyrics path:" << lyricFilePath
+                           << "root:" << lyricRootPath
+                           << "hash:" << hash;
+        return;
+    }
+
+    QDir lyricDir(lyricRootPath);
     if (!lyricDir.exists()) {
-        qCDebug(dmMusic) << "Creating lyrics directory:" << lyricDirPath;
-        lyricDir.cdUp();
-        lyricDir.mkdir("lyrics");
-        lyricDir.cd("lyrics");
+        qCDebug(dmMusic) << "Creating lyrics directory:" << lyricRootPath;
+        if (!QDir().mkpath(lyricRootPath)) {
+            qCWarning(dmMusic) << "Failed to create lyrics directory:" << lyricRootPath;
+            return;
+        }
     }
 
     if (!tmpPath.isEmpty() && !hash.isEmpty()) {
         // 歌词文件存在，停止解析
         if (lyricDir.exists(lyricName)) {
             qCDebug(dmMusic) << "Lyrics file already exists, skipping parsing:" << lyricName;
+            meta.lyricPath = lyricFilePath;  // backfill for DB/persistence
             return;
         }
 
         if (!path.isEmpty()) {
-            QFile lyric(lyricDirPath + QDir::separator() + lyricName);
+            QFile lyric(lyricFilePath);
             TagLib::MPEG::File f(path.toStdString().c_str());
             QString lyricStr = "";
 
@@ -716,6 +728,7 @@ void AudioAnalysis::parseMetaLyrics(DMusic::MediaMeta &meta)
                     if (!lyricStr.isEmpty()) {
                         if (lyric.open(QIODevice::WriteOnly)) {
                             lyric.write(lyricStr.toUtf8());
+                            meta.lyricPath = lyricFilePath;  // backfill for DB/persistence
                             qCInfo(dmMusic) << "Successfully extracted and saved lyrics for file:" << path;
                         } else {
                             qCWarning(dmMusic) << "Failed to open lyrics file for writing:" << lyricName;

--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -154,27 +154,34 @@ public:
     ~DataManagerPrivate()
     {
         qCDebug(dmMusic) << "Destroying DataManagerPrivate";
-        // 1) 切断主线程与 worker 之间的 queued connection，阻止后续新 metacall 入队
-        //    （注意：已 posted 的 metacall 不会被撤销，但下面 wait 会等 worker 把它们处理完）
+        stopWorkerAndDrain();
+    }
+
+    void stopWorkerAndDrain()
+    {
+        if (m_workerStopped) return;
+        m_workerStopped = true;
+
         if (m_dbOperate) {
-            m_parent->disconnect(m_dbOperate);
-            m_dbOperate->disconnect(m_parent);
-            // 2) 让 m_dbOperate 在自己 affinity 的 worker 线程里析构。
+            // 让 m_dbOperate 在自己 affinity 的 worker 线程里析构。
             //    deleteLater 在 worker 的事件循环里 post 一个 DeferredDelete 事件；
             //    quit() 后 worker 的 exec() 在返回前会先处理 DeferredDelete，从而在
             //    正确的线程上 delete，满足 Qt 线程亲和性约束。
             m_dbOperate->deleteLater();
             m_dbOperate = nullptr;
         }
-        // 3) 请求事件循环退出 + 等线程真的结束
+        // 请求事件循环退出 + 等线程真的结束。保持 DBOperate->DataManager 连接到
+        // worker 停止后，再排空主线程上已 posted 的封面回填事件。
         if (m_workerThread) {
             m_workerThread->quit();
-            if (!m_workerThread->wait(3000)) {
-                qCWarning(dmMusic) << "Worker thread did not exit within 3s";
-            }
+            m_workerThread->wait();
             delete m_workerThread;
             m_workerThread = nullptr;
         }
+        // Worker 已停，排空主线程上此前已 posted 给 DataManager 的 metacall
+        // （如 signalMetaCoverReady/signalCoverBatchFinished）。此时 m_parent 仍有效，
+        // slot 可安全更新 m_importedMetas，随后 DataManager 析构会统一保存。
+        QCoreApplication::sendPostedEvents(m_parent, 0);
     }
 private:
     friend class DataManager;
@@ -182,6 +189,7 @@ private:
     QThread                          *m_workerThread     = nullptr;
     DBOperate                        *m_dbOperate        = nullptr;
     MusicSettings                    *m_settings         = nullptr;
+    bool                               m_workerStopped    = false;
     QSqlDatabase                      m_database;
     QString                           m_dbPath;           // 可注入的 DB 路径，空=默认 cachePath/mediameta.sqlite
     QString                           m_currentHash;
@@ -205,6 +213,8 @@ DataManager::DataManager(QStringList supportedSuffixs, QObject *parent, const QS
     connect(this, &DataManager::signalImportMetas, m_data->m_dbOperate, &DBOperate::slotImportMetas, Qt::QueuedConnection);
     connect(m_data->m_dbOperate, &DBOperate::signalAddOneMeta, this, &DataManager::slotAddOneMeta, Qt::QueuedConnection);
     connect(m_data->m_dbOperate, &DBOperate::signalImportFinished, this, &DataManager::signalImportFinished, Qt::QueuedConnection);
+    connect(m_data->m_dbOperate, &DBOperate::signalCoverBatchFinished, this, &DataManager::slotCoverBatchFinished, Qt::QueuedConnection);
+    connect(m_data->m_dbOperate, &DBOperate::signalMetaCoverReady, this, &DataManager::slotMetaCoverReady, Qt::QueuedConnection);
     connect(this, &DataManager::signalClearImportingHash, m_data->m_dbOperate, &DBOperate::slotClearImportingHash, Qt::QueuedConnection);
 
     m_data->m_workerThread->start();
@@ -215,6 +225,7 @@ DataManager::~DataManager()
 {
     qCDebug(dmMusic) << "Destroying DataManager";
     if (m_data) {
+        m_data->stopWorkerAndDrain();
         saveDataToDB();
         // 关键：触发 DataManagerPrivate 析构走安全销毁路径（disconnect + deleteLater + quit + wait）
         delete m_data;
@@ -2273,6 +2284,50 @@ void DataManager::slotAddOneMeta(QStringList playlistHashs, MediaMeta meta)
         }
     }
     emit signalAddOneMeta(playlistHashs, curMeta, true);
+}
+
+void DataManager::slotMetaCoverReady(DMusic::MediaMeta meta)
+{
+    int index = metaIndexFromHash(meta.hash);
+    if (index < 0) return;
+
+    // 1. m_allMetas
+    m_data->m_allMetas[index].coverUrl = meta.coverUrl;
+    m_data->m_allMetas[index].hasimage = meta.hasimage;
+    m_data->m_allMetas[index].lyricPath = meta.lyricPath;
+
+    // 2. m_importedMetas (upsertMetasDB reads it; sync or it writes stale hasimage/coverUrl)
+    for (auto &im : m_data->m_importedMetas) {
+        if (im.hash == meta.hash) {
+            im.coverUrl = meta.coverUrl;
+            im.hasimage = meta.hasimage;
+            im.lyricPath = meta.lyricPath;
+            break;
+        }
+    }
+
+    // 3. album/artist musicinfos copy (no top-level coverUrl field; UI derives from musicinfos)
+    for (auto &alb : m_data->m_allAlbums) {
+        if (alb.musicinfos.contains(meta.hash)) {
+            alb.musicinfos[meta.hash] = m_data->m_allMetas[index];
+        }
+    }
+    for (auto &art : m_data->m_allArtists) {
+        if (art.musicinfos.contains(meta.hash)) {
+            art.musicinfos[meta.hash] = m_data->m_allMetas[index];
+        }
+    }
+
+    m_data->m_dirty = true;  // hasimage/coverUrl/lyricPath affect DB row
+    emit signalMetaCoverReady(m_data->m_allMetas[index]);
+}
+
+void DataManager::slotCoverBatchFinished()
+{
+    // 导入成功提示已在 signalImportFinished 发出；这里仅在封面/歌词补齐后
+    // 增量落库，避免 musicNew 先写入 stale coverUrl/hasimage/lyricPath。
+    upsertMetasDB();
+    emit signalCoverBatchFinished();
 }
 
 void DataManager::slotLazyLoadDatabase()

--- a/src/libdmusic/core/datamanager.h
+++ b/src/libdmusic/core/datamanager.h
@@ -72,6 +72,8 @@ public:
 public slots:
     void slotAddOneMeta(QStringList playlistHashs, DMusic::MediaMeta meta);
     void slotLazyLoadDatabase();
+    void slotMetaCoverReady(DMusic::MediaMeta meta);
+    void slotCoverBatchFinished();
 
 signals:
     void signalImportMetas(const QStringList &urls, const QSet<QString> &metaHashs, bool importPlayFlag,
@@ -80,6 +82,8 @@ signals:
     void signalAddOneMeta(QStringList playlistHashs, DMusic::MediaMeta meta, const bool &addToPlay);
     void signalAddMetaFinished(QStringList playlistHashs);
     void signalImportFinished(QStringList playlistHashs, int failCount, int sucessCount, int existCount, QString mediaHash);
+    void signalCoverBatchFinished();
+    void signalMetaCoverReady(DMusic::MediaMeta meta);
     void signalDeleteOneMeta(QStringList playlistHashs, QString hash, const bool &addToPlay);
     void signalDeleteFinished(QStringList playlistHashs);
     void signalUpdatedMetaCodec(DMusic::MediaMeta meta, QString preAlbum, QString preArtist);

--- a/src/libdmusic/core/dboperate.cpp
+++ b/src/libdmusic/core/dboperate.cpp
@@ -73,6 +73,7 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
 
     int importedCount = 0, importedFailCount = 0, existCount = 0;
     QSet<QString> allHashs;
+    QList<DMusic::MediaMeta> pendingCovers;  // newly imported metas to extract cover/lyrics after loop
     for (auto &filePath : filePaths) {
         QFileInfo fileinfo(filePath);
         while (fileinfo.isSymLink()) {  //to find final target
@@ -98,8 +99,8 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
                 m_importingHashes.insert(hash);
                 mediaMeta = AudioAnalysis::creatMediaMeta(filePath);
                 if (mediaMeta.length > 0) {
-                    AudioAnalysis::parseMetaCover(mediaMeta);
-                    AudioAnalysis::parseMetaLyrics(mediaMeta);
+                    mediaMeta.hasimage = false;
+                    pendingCovers.append(mediaMeta);  // cover/lyrics extracted after loop
                     curHashs << "all" << playlistHash;
                     allHashs << "all" << playlistHash;
                     qCDebug(dmMusic) << "Added new meta:" << mediaMeta.title << "to playlist:" << playlistHash;
@@ -117,8 +118,8 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
                 m_importingHashes.insert(hash);
                 mediaMeta = AudioAnalysis::creatMediaMeta(filePath);
                 if (mediaMeta.length > 0) {
-                    AudioAnalysis::parseMetaCover(mediaMeta);
-                    AudioAnalysis::parseMetaLyrics(mediaMeta);
+                    mediaMeta.hasimage = false;
+                    pendingCovers.append(mediaMeta);  // cover/lyrics extracted after loop
                     curHashs << "all";
                     allHashs << "all";
                     qCDebug(dmMusic) << "Added new meta:" << mediaMeta.title << "to all music";
@@ -145,7 +146,20 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
         importedCount++;
     }
 
+    // Emit importFinished first so UI shows success / auto-play immediately,
+    // without waiting for the cover batch. upsertMetasDB is triggered later by
+    // signalCoverBatchFinished so m_importedMetas has correct hasimage/coverUrl.
     emit signalImportFinished(allHashs.values(), importedFailCount, importedCount - importedFailCount - existCount, existCount, mediaHash);
+
+    // Extract cover/lyrics after the import loop (still on worker thread, sequential,
+    // no new QThread). Emits per-meta so UI refreshes one row at a time.
+    for (DMusic::MediaMeta &meta : pendingCovers) {
+        AudioAnalysis::parseMetaCover(meta);
+        AudioAnalysis::parseMetaLyrics(meta);
+        emit signalMetaCoverReady(meta);
+    }
+
+    emit signalCoverBatchFinished();
 }
 
 void DBOperate::slotClearImportingHash(const QString &hash)

--- a/src/libdmusic/core/dboperate.h
+++ b/src/libdmusic/core/dboperate.h
@@ -24,6 +24,8 @@ public slots:
 signals:
     void signalAddOneMeta(QStringList playlistHashs, DMusic::MediaMeta meta);
     void signalImportFinished(QStringList playlistHashs, int failCount, int sucessCount, int existCount, QString mediaHash);
+    void signalCoverBatchFinished();
+    void signalMetaCoverReady(DMusic::MediaMeta meta);
 
 private:
     QStringList          m_supportedSuffixs;

--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -146,13 +146,6 @@ Presenter::Presenter(const QString &unknownAlbumStr, const QString &unknownArtis
                 m_data->m_playerEngine->setMediaMeta(mediaHash);
             m_data->m_playerEngine->play();
         }
-        
-        // After import succeeds, incrementally persist musicNew; full saveDataToDB still runs on exit
-        if (sucessCount > 0) {
-            qCInfo(dmMusic) << "Incrementally saving" << sucessCount << "imported songs";
-            m_data->m_dataManager->upsertMetasDB();
-        }
-        
         emit importFinished(playlistHashs, failCount, sucessCount, existCount);
     });
     connect(m_data->m_dataManager, &DataManager::signalDeleteOneMeta, this,
@@ -163,6 +156,9 @@ Presenter::Presenter(const QString &unknownAlbumStr, const QString &unknownArtis
     connect(m_data->m_dataManager, &DataManager::signalDeleteFinished, this, &Presenter::deleteFinished);
     connect(m_data->m_dataManager, &DataManager::signalUpdatedMetaCodec, this, [ = ](DMusic::MediaMeta meta, QString preAlbum, QString preArtist) {
         emit updatedMetaCodec(Utils::metaToVariantMap(meta), preAlbum, preArtist);
+    });
+    connect(m_data->m_dataManager, &DataManager::signalMetaCoverReady, this, [ = ](DMusic::MediaMeta meta) {
+        emit metaCoverReady(Utils::metaToVariantMap(meta));
     });
 
     connect(this, &Presenter::restorePlaybackStatus, this, [ = ]() {
@@ -1188,5 +1184,4 @@ void Presenter::stop()
     qCDebug(dmMusic) << "Stopping media";
     m_data->m_playerEngine->stop();
 }
-
 

--- a/src/libdmusic/presenter.h
+++ b/src/libdmusic/presenter.h
@@ -144,6 +144,7 @@ signals:
     void deletedPlaylist(QString playlistHash);
     void renamedPlaylist(const QString &name, const QString &playlistHash);
     void updatedMetaCodec(QVariantMap meta, QString preAlbum, QString preArtist);
+    void metaCoverReady(QVariantMap meta);
     void updateCDStatus(int status);
     void quitRequested();
     void raiseRequested();

--- a/src/music-player/albumlist/AlbumModel.qml
+++ b/src/music-player/albumlist/AlbumModel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -111,6 +111,9 @@ ListModel {
             }
         }
     }
+    function onMetaCoverReady(meta) {
+        globalVariant.updateGroupedModelCover(albumModel, meta)
+    }
     Component.onCompleted: {
         albumModel.loadArtistDatas();
         Presenter.importFinished.connect(loadArtistDatas)
@@ -118,5 +121,6 @@ ListModel {
         Presenter.addOneMeta.connect(onAddOneMetaFinished);
         Presenter.playlistSortChanged.connect(playlistSortChanged)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
+        Presenter.metaCoverReady.connect(onMetaCoverReady)
     }
 }

--- a/src/music-player/mainwindow/GlobalVariant.qml
+++ b/src/music-player/mainwindow/GlobalVariant.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -73,6 +73,44 @@ Item {
             musicInfoDlgLoader.item.musicData = currentSelectMediaMeta
             musicInfoDlgLoader.item.show()
         }
+    }
+    function updateGroupedModelCover(model, meta) {
+        if (!meta || !meta.hash)
+            return
+
+        for (var i = 0; i < model.listCount; i++) {
+            var group = model.get(i)
+            var musicinfos = group.musicinfos
+            if (!musicinfos || !updateMetaCover(musicinfos, meta))
+                continue
+
+            group.musicinfos = musicinfos
+            group.coverUrl = preferredCoverUrl(musicinfos)
+            model.set(i, group)
+        }
+    }
+    function updateMetaCover(musicinfos, meta) {
+        for (var key in musicinfos) {
+            if (musicinfos[key].hash === meta.hash) {
+                musicinfos[key].coverUrl = meta.coverUrl
+                musicinfos[key].hasimage = meta.hasimage
+                musicinfos[key].lyricPath = meta.lyricPath
+                return true
+            }
+        }
+
+        return false
+    }
+    function preferredCoverUrl(musicinfos) {
+        var coverUrl = ""
+        for (var key in musicinfos) {
+            if (musicinfos[key].hasimage === true)
+                return musicinfos[key].coverUrl
+            if (coverUrl === "")
+                coverUrl = musicinfos[key].coverUrl
+        }
+
+        return coverUrl
     }
 
     Component.onCompleted: {

--- a/src/music-player/musicList/AllMusicListDelegate.qml
+++ b/src/music-player/musicList/AllMusicListDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,9 +19,10 @@ ItemDelegate{
     property bool showExtendedColumns: listview.width > 500
 
     id: rootRectangle
-    anchors.horizontalCenter: parent.horizontalCenter
     checked: inMulitSelect
     hoverEnabled: true
+
+    anchors.horizontalCenter: listview.contentItem.horizontalCenter
 
     Drag.active: mouseArea.drag.active
     Drag.supportedActions: Qt.MoveAction

--- a/src/music-player/musicList/AllMusicListModel.qml
+++ b/src/music-player/musicList/AllMusicListModel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 -2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,6 +77,17 @@ ListModel {
         }
     }
 
+    function onMetaCoverReady(meta) {
+        for (var j = 0; j < mediaModels.count; j++) {
+            if (mediaModels.get(j)["hash"] === meta.hash) {
+                mediaModels.setProperty(j, "coverUrl", meta.coverUrl)
+                mediaModels.setProperty(j, "hasimage", meta.hasimage)
+                mediaModels.setProperty(j, "lyricPath", meta.lyricPath)
+                break
+            }
+        }
+    }
+
     Component.onCompleted: {
         mediaModels.loadMediaDatas();
         Presenter.importFinished.connect(loadMediaDatas);
@@ -84,5 +95,6 @@ ListModel {
         Presenter.addOneMeta.connect(onAddOneMeta);
         Presenter.playlistSortChanged.connect(playlistSortChanged)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
+        Presenter.metaCoverReady.connect(onMetaCoverReady)
     }
 }

--- a/src/music-player/playlist/PlayListModel.qml
+++ b/src/music-player/playlist/PlayListModel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -62,6 +62,17 @@ ListModel {
         }
     }
 
+    function onMetaCoverReady(meta) {
+        for (var j = 0; j < playlistModel.count; j++) {
+            if (playlistModel.get(j)["hash"] === meta.hash) {
+                playlistModel.setProperty(j, "coverUrl", meta.coverUrl)
+                playlistModel.setProperty(j, "hasimage", meta.hasimage)
+                playlistModel.setProperty(j, "lyricPath", meta.lyricPath)
+                break
+            }
+        }
+    }
+
     Component.onCompleted: {
         loadplaylistData();
         Presenter.deleteOneMeta.connect(onDeleteOneMeta)
@@ -69,6 +80,7 @@ ListModel {
         Presenter.importFinished.connect(onAddMetaFinished)
         Presenter.addOneMeta.connect(onAddOneMeta)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
+        Presenter.metaCoverReady.connect(onMetaCoverReady)
 
         Presenter.currentPlaylistSChanged.connect(function(playlistHash){
             if (playlistHash === "") {

--- a/src/music-player/singerlist/ArtistModel.qml
+++ b/src/music-player/singerlist/ArtistModel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -114,6 +114,10 @@ ListModel {
         }
     }
 
+    function onMetaCoverReady(meta) {
+        globalVariant.updateGroupedModelCover(artistModels, meta)
+    }
+
     Component.onCompleted: {
         artistModels.loadArtistDatas();
         Presenter.importFinished.connect(loadArtistDatas);
@@ -122,5 +126,6 @@ ListModel {
         Presenter.addOneMeta.connect(onAddOneMetaFinished);
         Presenter.playlistSortChanged.connect(playlistSortChanged)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
+        Presenter.metaCoverReady.connect(onMetaCoverReady)
     }
 }


### PR DESCRIPTION
Move cover/lyrics extraction out of the import loop; show import success immediately via importFinished, persist musicNew after the cover batch.

封面/歌词提取移出导入循环，循环结束后批后顺序提取；signalImportFinished
立即发使列表与导入成功提示秒显，signalCoverBatchFinished 批后触发增量入库
保证封面字段正确；析构时排空 pending 封面信号防崩溃。

Log: 导入循环移出封面提取并立即提示成功
PMS: BUG-333281
Influence: 列表与导入成功提示秒显，封面后续逐首回填；析构排空防 pending 信号崩溃。