### PR TITLE
fix: import music from default music dir on empty state click

### DIFF
--- a/src/music-player/albumlist/AlbumDefaultPage.qml
+++ b/src/music-player/albumlist/AlbumDefaultPage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,7 @@ import QtQuick 2.0
 import QtQuick.Window 2.11
 import QtQuick.Layouts 1.11
 import QtQuick.Controls 2.0
+import Qt.labs.platform 1.0
 import org.deepin.dtk 1.0
 
 import "../dialogs"
@@ -67,7 +68,11 @@ Rectangle {
                     anchors.fill: parent
                     acceptedButtons: Qt.LeftButton
                     onClicked: {
-                        Presenter.importMetas(null,"album");
+                        // StandardPaths.MusicLocation reliably returns $HOME/Music on Linux;
+                        // matches the pattern used in AllMusicDefaultPage.qml.
+                        var list = []
+                        list.push(StandardPaths.standardLocations(StandardPaths.MusicLocation)[0])
+                        Presenter.importMetas(list, "album");
                     }
                 }
             }

--- a/src/music-player/singerlist/ArtistDefaultPage.qml
+++ b/src/music-player/singerlist/ArtistDefaultPage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,7 @@ import QtQuick 2.0
 import QtQuick.Window 2.11
 import QtQuick.Layouts 1.11
 import QtQuick.Controls 2.0
+import Qt.labs.platform 1.0
 import org.deepin.dtk 1.0
 
 import "../dialogs"
@@ -68,7 +69,11 @@ Rectangle {
                     anchors.fill: parent
                     acceptedButtons: Qt.LeftButton
                     onClicked: {
-                        Presenter.importMetas(null,"artist");
+                        // StandardPaths.MusicLocation reliably returns $HOME/Music on Linux;
+                        // matches the pattern used in AllMusicDefaultPage.qml.
+                        var list = []
+                        list.push(StandardPaths.standardLocations(StandardPaths.MusicLocation)[0])
+                        Presenter.importMetas(list, "artist");
                     }
                 }
             }


### PR DESCRIPTION
Pass StandardPaths.MusicLocation to importMetas instead of null when clicking empty state in album/artist default pages.

点击专辑/歌手默认页空状态时，传入系统音乐目录路径而非 null，自动导入默认音乐目录。

Log: 空状态点击改为导入默认音乐目录
Influence: 在专辑/歌手列表空状态点击时，会自动导入系统音乐目录中的音乐文件，提升首次使用体验。

## Summary by Sourcery

Bug Fixes:
- Ensure empty-state clicks on album and artist default pages trigger importing from the system music directory instead of passing a null path.