### PR TITLE
fix(datamanager): normalize album/artist hash throughout importMetas

### DIFF
--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -1287,17 +1287,17 @@ QVariantList DataManager::allArtistVariantList()
 void DataManager::importMetas(const QStringList &urls, const QString &playlistHash, const bool &playFalg)
 {
     qCDebug(dmMusic) << "Importing metas to playlist:" << playlistHash << "urls count:" << urls.size() << "playFlag:" << playFalg;
+    QString targetPlaylistHash = playlistHash;
+    if (targetPlaylistHash == "album" || targetPlaylistHash == "artist")
+        targetPlaylistHash = "all";
+
     QSet<QString> metaHashs, playMetaHashs, allMetaHashs;
     for (MediaMeta &meta : m_data->m_allMetas) {
         allMetaHashs.insert(meta.hash);
     }
-    if (!playlistHash.isEmpty()) {
-        QString curPlaylistHash = playlistHash;
-        // 专辑或者艺人添加到所有歌单
-        if (playlistHash == "album" || playlistHash == "artist")
-            curPlaylistHash = "all";
+    if (!targetPlaylistHash.isEmpty()) {
         for (PlaylistInfo &playlist : m_data->m_allPlaylist) {
-            if (playlist.uuid == curPlaylistHash) {
+            if (playlist.uuid == targetPlaylistHash) {
                 for (QString &hash : playlist.sortMetas) {
                     metaHashs.insert(hash);
                 }
@@ -1305,7 +1305,7 @@ void DataManager::importMetas(const QStringList &urls, const QString &playlistHa
             }
         }
     }
-    QString curPlaylistHash = playlistHash.isEmpty() ? "all" : playlistHash;
+    QString curPlaylistHash = targetPlaylistHash.isEmpty() ? "all" : targetPlaylistHash;
     bool importPlay = false;
     if (curPlaylistHash == m_data->m_currentHash && curPlaylistHash != "play") {
         for (PlaylistInfo &playlist : m_data->m_allPlaylist) {
@@ -1319,7 +1319,7 @@ void DataManager::importMetas(const QStringList &urls, const QString &playlistHa
         }
     }
     qCDebug(dmMusic) << "Emitting import metas signal with" << metaHashs.size() << "existing metas";
-    emit signalImportMetas(urls, metaHashs, importPlay, playMetaHashs, allMetaHashs, playlistHash, playFalg);
+    emit signalImportMetas(urls, metaHashs, importPlay, playMetaHashs, allMetaHashs, targetPlaylistHash, playFalg);
 }
 
 void DataManager::addMetasToPlayList(const QList<QString> &metaHash,


### PR DESCRIPTION
Extract the "album"/"artist" → "all" normalization into a single targetPlaylistHash variable and use it consistently across the function and the signal emission.

将 "album"/"artist" → "all" 的归一化逻辑提取到统一的 targetPlaylistHash 变量，并在函数体及信号发射中一致使用。

Log: 修复导入时专辑/艺人歌单哈希归一化不一致问题
Influence: 从专辑或艺人视图导入音乐时，信号接收方现在能正确收到 "all" 歌单标识，避免后续逻辑因未归一化的哈希误判歌单。

## Summary by Sourcery

Bug Fixes:
- Ensure imports from album or artist views use the normalized all playlist hash throughout importMetas to prevent misidentification by signal receivers.