### PR TITLE
perf(player): cache playable meta and reuse matched play queue

### DIFF
--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -20,6 +20,8 @@
 #include <QDebug>
 #include <QCoreApplication>
 
+#include <algorithm>
+
 #include "audioanalysis.h"
 #include "utils.h"
 #include "dboperate.h"
@@ -1089,10 +1091,13 @@ void DataManager::saveDataToDB()
 MediaMeta DataManager::metaFromHash(const QString &hash)
 {
     qCDebug(dmMusic) << "Looking up meta for hash:" << hash;
-    MediaMeta mata;
-    int index = metaIndexFromHash(hash);
-    if (index >= 0 && index < m_data->m_allMetas.size()) mata = m_data->m_allMetas[index];
-    return mata;
+    const int index = metaIndexFromHash(hash);
+    // Return the stored value directly so a successful lookup does not first
+    // construct a default MediaMeta (which initializes its default cover path).
+    if (index >= 0 && index < m_data->m_allMetas.size())
+        return m_data->m_allMetas.at(index);
+
+    return {};
 }
 
 PlaylistInfo DataManager::playlistFromHash(const QString &hash)
@@ -1107,6 +1112,48 @@ PlaylistInfo DataManager::playlistFromHash(const QString &hash)
     return playlist;
 }
 
+bool DataManager::isPlaylistQueueMatched(const QString &hash, const QList<DMusic::MediaMeta> &metas) const
+{
+    const QString curHash = !hash.isEmpty() ? hash : "all";
+    const auto playlistIt = std::find_if(m_data->m_allPlaylist.cbegin(), m_data->m_allPlaylist.cend(),
+                                         [&curHash](const PlaylistInfo &playlist) {
+        return playlist.uuid == curHash;
+    });
+    if (playlistIt == m_data->m_allPlaylist.cend())
+        return false;
+
+    int metaIndex = 0;
+    const auto matchesHash = [&metas, &metaIndex](const QString &metaHash) {
+        return metaIndex < metas.size() && metas.at(metaIndex++).hash == metaHash;
+    };
+
+    if (curHash == "all" && playlistIt->sortMetas.isEmpty()) {
+        for (const MediaMeta &meta : m_data->m_allMetas) {
+            if (!meta.hash.isEmpty() && !matchesHash(meta.hash))
+                return false;
+        }
+        return metaIndex == metas.size();
+    }
+
+    const QStringList &metaHashes = curHash == "musicResult" ? m_data->m_searchMetas
+                                    : (playlistIt->sortType == DmGlobal::SortByCustomASC
+                                       && !playlistIt->sortCustomMetas.isEmpty()
+                                       ? playlistIt->sortCustomMetas : playlistIt->sortMetas);
+    for (const QString &metaHash : metaHashes) {
+        const auto metaIt = m_data->m_metaHashIndex.constFind(metaHash);
+        if (metaIt == m_data->m_metaHashIndex.constEnd())
+            return false;
+
+        const int index = metaIt.value();
+        if (index < 0 || index >= m_data->m_allMetas.size()
+                || m_data->m_allMetas.at(index).hash != metaHash
+                || !matchesHash(metaHash))
+            return false;
+    }
+
+    return metaIndex == metas.size();
+}
+
 QList<DMusic::MediaMeta> DataManager::getPlaylistMetas(const QString &hash, int count)
 {
     qCDebug(dmMusic) << "Looking up playlist metas for hash:" << hash << "count:" << count;
@@ -1116,12 +1163,20 @@ QList<DMusic::MediaMeta> DataManager::getPlaylistMetas(const QString &hash, int 
     if (index < 0 || index >= m_data->m_allPlaylist.size())  return metas;
     int favIndex = playlistIndexFromHash("fav");
     bool favExist = (favIndex >= 0 && favIndex < m_data->m_allPlaylist.size());
+    QSet<QString> favouriteHashes;
+    if (favExist) {
+        const QStringList &favouriteMetas = m_data->m_allPlaylist[favIndex].sortMetas;
+        favouriteHashes.reserve(favouriteMetas.size());
+        for (const QString &favouriteHash : favouriteMetas)
+            favouriteHashes.insert(favouriteHash);
+    }
 
     if (hash == "all" && m_data->m_allPlaylist[index].sortMetas.isEmpty()) {
         qCDebug(dmMusic) << "Playlist metas is empty, using all metas";
+        metas.reserve(count >= 0 ? qMin(count, m_data->m_allMetas.size()) : m_data->m_allMetas.size());
         for (const DMusic::MediaMeta &meta : m_data->m_allMetas) {
             DMusic::MediaMeta curMeta = meta;
-            if (favExist && m_data->m_allPlaylist[favIndex].sortMetas.contains(curMeta.hash)) curMeta.favourite = true;
+            if (favouriteHashes.contains(curMeta.hash)) curMeta.favourite = true;
             if (!meta.hash.isEmpty())
                 metas.append(curMeta);
             if (count >= 0 && count == metas.size()) break;
@@ -1131,9 +1186,10 @@ QList<DMusic::MediaMeta> DataManager::getPlaylistMetas(const QString &hash, int 
         QStringList metaHashs = (hash == "musicResult") ? m_data->m_searchMetas :
                                 (m_data->m_allPlaylist[index].sortType == DmGlobal::SortByCustomASC && m_data->m_allPlaylist[index].sortCustomMetas.size() > 0 ? m_data->m_allPlaylist[index].sortCustomMetas
                                  : m_data->m_allPlaylist[index].sortMetas);
-        for (QString metaHash : metaHashs) {
+        metas.reserve(count >= 0 ? qMin(count, metaHashs.size()) : metaHashs.size());
+        for (const QString &metaHash : metaHashs) {
             DMusic::MediaMeta meta = metaFromHash(metaHash);
-            if (favExist && m_data->m_allPlaylist[favIndex].sortMetas.contains(meta.hash)) meta.favourite = true;
+            if (favouriteHashes.contains(meta.hash)) meta.favourite = true;
             if (!meta.hash.isEmpty())
                 metas.append(meta);
             if (count >= 0 && count == metas.size()) break;

--- a/src/libdmusic/core/datamanager.h
+++ b/src/libdmusic/core/datamanager.h
@@ -20,6 +20,7 @@ public:
     QString currentPlayliHash();
     DMusic::MediaMeta metaFromHash(const QString &hash);
     DMusic::PlaylistInfo playlistFromHash(const QString &hash);
+    bool isPlaylistQueueMatched(const QString &hash, const QList<DMusic::MediaMeta> &metas) const;
     QList<DMusic::MediaMeta> getPlaylistMetas(const QString &hash = "", int count = -1);
     QList<DMusic::PlaylistInfo> allPlaylistInfos();
     QVariantList allPlaylistVariantList();

--- a/src/libdmusic/player/playerengine.cpp
+++ b/src/libdmusic/player/playerengine.cpp
@@ -6,6 +6,7 @@
 #include "playerengine.h"
 
 #include <QMimeDatabase>
+#include <QElapsedTimer>
 #include <QTimer>
 #include <QFile>
 #include <QFileInfo>
@@ -20,6 +21,7 @@
 #include "util/log.h"
 
 static const int sFadeInOutAnimationDuration = 900; //ms
+static const int sPlayableMetaCacheDuration = 1000; //ms
 static int INT_LAST_PROGRESS_FLAG = 1;
 static qint64 INT_LAST_PROGRESS_VALUE = 0;
 
@@ -61,6 +63,11 @@ private:
     QPropertyAnimation         *m_fadeInAnimation       = nullptr;
     QPropertyAnimation         *m_fadeOutAnimation      = nullptr;
     bool                        m_fadeInOut             = false;
+    bool                        m_playableMetaCacheValid = false;
+    QElapsedTimer                m_playableMetaCacheTimer;
+    QString                     m_playableMetaCacheHash;
+    bool                        m_hasNextPlayableMeta    = false;
+    bool                        m_hasPreviousPlayableMeta = false;
 };
 
 PlayerEnginePrivate::PlayerEnginePrivate(PlayerEngine *parent, PlayerBase *injectedPlayer)
@@ -312,10 +319,80 @@ MediaMeta PlayerEngine::getMediaMeta()
     return m_data->m_player->getMediaMeta();
 }
 
+bool PlayerEngine::hasNextPlayableMeta(const QString &metaHash)
+{
+    qCDebug(dmMusic) << "Checking next playable meta after:" << metaHash;
+    updatePlayableMetaCache(metaHash);
+    qCDebug(dmMusic) << "Next playable meta found:" << m_data->m_hasNextPlayableMeta;
+    return m_data->m_hasNextPlayableMeta;
+}
+
+bool PlayerEngine::hasPreviousPlayableMeta(const QString &metaHash)
+{
+    qCDebug(dmMusic) << "Checking previous playable meta before:" << metaHash;
+    updatePlayableMetaCache(metaHash);
+    qCDebug(dmMusic) << "Previous playable meta found:" << m_data->m_hasPreviousPlayableMeta;
+    return m_data->m_hasPreviousPlayableMeta;
+}
+
+void PlayerEngine::updatePlayableMetaCache(const QString &metaHash)
+{
+    if (m_data->m_playableMetaCacheValid && m_data->m_playableMetaCacheHash == metaHash
+            && m_data->m_playableMetaCacheTimer.isValid()
+            && m_data->m_playableMetaCacheTimer.elapsed() < sPlayableMetaCacheDuration)
+        return;
+
+    qCDebug(dmMusic) << "Updating playable meta cache for:" << metaHash;
+    const QStringList supportedSuffixes = supportedSuffixList();
+    bool hasCurrentMeta = false;
+    bool hasNextMeta = false;
+    bool hasPreviousMeta = false;
+
+    for (const MediaMeta &meta : m_data->m_metaList) {
+        const bool playable = meta.mmType == DmGlobal::MimeTypeCDA
+                              || (QFile::exists(meta.localPath)
+                                  && supportedSuffixes.contains(QFileInfo(meta.localPath).suffix().toLower()));
+        if (!playable)
+            continue;
+
+        if (meta.hash == metaHash) {
+            hasCurrentMeta = true;
+            continue;
+        }
+
+        if (hasCurrentMeta) {
+            hasNextMeta = true;
+            break;
+        }
+
+        hasPreviousMeta = true;
+    }
+
+    m_data->m_playableMetaCacheValid = true;
+    m_data->m_playableMetaCacheTimer.restart();
+    m_data->m_playableMetaCacheHash = metaHash;
+    m_data->m_hasNextPlayableMeta = hasCurrentMeta && hasNextMeta;
+    m_data->m_hasPreviousPlayableMeta = hasCurrentMeta && hasPreviousMeta;
+}
+
+void PlayerEngine::invalidatePlayableMetaCache()
+{
+    qCDebug(dmMusic) << "Invalidating playable meta cache";
+    m_data->m_playableMetaCacheValid = false;
+}
+
 void PlayerEngine::addMetasToPlayList(const QList<MediaMeta> &metaList)
 {
     qCDebug(dmMusic) << "Adding metas to play list";
     m_data->m_metaList << metaList;
+    invalidatePlayableMetaCache();
+}
+
+void PlayerEngine::replaceMetasToPlayList(const QList<MediaMeta> &metaList)
+{
+    qCDebug(dmMusic) << "Replacing play list with" << metaList.size() << "metas";
+    m_data->m_metaList = metaList;
+    invalidatePlayableMetaCache();
 }
 
 void PlayerEngine::removeMetaFromPlayList(const QString &metaHash)
@@ -324,6 +401,7 @@ void PlayerEngine::removeMetaFromPlayList(const QString &metaHash)
     for (int i = 0; i < m_data->m_metaList.size(); i++) {
         if (m_data->m_metaList[i].hash == metaHash) {
             m_data->m_metaList.removeAt(i);
+            invalidatePlayableMetaCache();
             qCDebug(dmMusic) << "Meta removed from play list";
             break;
         }
@@ -336,6 +414,7 @@ void PlayerEngine::removeMetasFromPlayList(const QStringList &metaHashs)
     QStringList curMetaHashs = metaHashs;
     QString playHash = getMediaMeta().hash;
     bool playFlag = curMetaHashs.contains(playHash);
+    bool metaListChanged = false;
     int curIndex = -1;
     for (int i = m_data->m_metaList.size() - 1; i >= 0; i--) {
         if (curIndex >= 0) curIndex = i - 1;
@@ -343,6 +422,7 @@ void PlayerEngine::removeMetasFromPlayList(const QStringList &metaHashs)
         if (curMetaHashs.contains(m_data->m_metaList[i].hash)) {
             curMetaHashs.removeOne(m_data->m_metaList[i].hash);
             m_data->m_metaList.removeAt(i);
+            metaListChanged = true;
             qCDebug(dmMusic) << "Meta removed from play list";
         }
         if (curMetaHashs.isEmpty()) {
@@ -350,6 +430,9 @@ void PlayerEngine::removeMetasFromPlayList(const QStringList &metaHashs)
             break;
         }
     }
+    if (metaListChanged)
+        invalidatePlayableMetaCache();
+
     if (m_data->m_metaList.isEmpty()) {
         qCDebug(dmMusic) << "Play list is empty, stop";
         stop();
@@ -370,6 +453,7 @@ void PlayerEngine::clearPlayList(bool stopFlag)
 {
     qCDebug(dmMusic) << "Clearing play list";
     m_data->m_metaList.clear();
+    invalidatePlayableMetaCache();
     if (stopFlag && !getMediaMeta().hash.isEmpty()) {
         qCDebug(dmMusic) << "Stop flag is true, stop player";
         stop();

--- a/src/libdmusic/player/playerengine.h
+++ b/src/libdmusic/player/playerengine.h
@@ -27,7 +27,10 @@ public:
     void setMediaMeta(const DMusic::MediaMeta &metaList);
     QStringList supportedSuffixList()const;
     DMusic::MediaMeta getMediaMeta();
+    bool hasNextPlayableMeta(const QString &metaHash);
+    bool hasPreviousPlayableMeta(const QString &metaHash);
     void addMetasToPlayList(const QList<DMusic::MediaMeta> &metaList);
+    void replaceMetasToPlayList(const QList<DMusic::MediaMeta> &metaList);
     void removeMetaFromPlayList(const QString &metaHash);
     void removeMetasFromPlayList(const QStringList &metaHashs);
     void clearPlayList(bool stopFlag = true);
@@ -86,6 +89,8 @@ private:
     void resetDBusMpris(const DMusic::MediaMeta &meta);
     void switchToNewTrackWithFade(const DMusic::MediaMeta &meta, bool playFlag = true);
     void switchToNewTrackWithFade(const QString &metaHash, bool playFlag = true);
+    void updatePlayableMetaCache(const QString &metaHash);
+    void invalidatePlayableMetaCache();
 
 private:
     PlayerEnginePrivate  *m_data = nullptr;

--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -470,41 +470,17 @@ void Presenter::showMetaFile(const QString &hash)
 bool Presenter::nextMetaFromPlay(const QString &metaHash)
 {
     qCDebug(dmMusic) << "Playing next track after:" << metaHash;
-    bool flag = false, hasMeta = false;
-    QList<DMusic::MediaMeta> allMetas = m_data->m_dataManager->getPlaylistMetas("play");
-    for (int i = 0; i < allMetas.size(); i++) {
-        if ((hasMeta || allMetas[i].hash == metaHash) && ((QFile::exists(allMetas[i].localPath) && m_data->m_playerEngine->supportedSuffixList().contains(
-                                                               QFileInfo(allMetas[i].localPath).suffix().toLower())) || allMetas[i].mmType == DmGlobal::MimeTypeCDA)) {
-            if (hasMeta) {
-                flag = true;
-                break;
-            } else {
-                hasMeta = true;
-            }
-        }
-    }
-    qCDebug(dmMusic) << "Next track found:" << flag;
-    return flag;
+    const bool hasNextMeta = m_data->m_playerEngine->hasNextPlayableMeta(metaHash);
+    qCDebug(dmMusic) << "Next track found:" << hasNextMeta;
+    return hasNextMeta;
 }
 
 bool Presenter::preMetaFromPlay(const QString &metaHash)
 {
     qCDebug(dmMusic) << "Playing previous track before:" << metaHash;
-    bool flag = false, hasMeta = false;
-    QList<DMusic::MediaMeta> allMetas = m_data->m_dataManager->getPlaylistMetas("play");
-    for (int i = allMetas.size() - 1; i >= 0; i--) {
-        if ((hasMeta || allMetas[i].hash == metaHash) && ((QFile::exists(allMetas[i].localPath) && m_data->m_playerEngine->supportedSuffixList().contains(
-                                                               QFileInfo(allMetas[i].localPath).suffix().toLower())) || allMetas[i].mmType == DmGlobal::MimeTypeCDA)) {
-            if (hasMeta) {
-                flag = true;
-                break;
-            } else {
-                hasMeta = true;
-            }
-        }
-    }
-    qCDebug(dmMusic) << "Previous track found:" << flag;
-    return flag;
+    const bool hasPreviousMeta = m_data->m_playerEngine->hasPreviousPlayableMeta(metaHash);
+    qCDebug(dmMusic) << "Previous track found:" << hasPreviousMeta;
+    return hasPreviousMeta;
 }
 
 void Presenter::playAlbum(const QString &album, const QString &metaHash)
@@ -602,45 +578,66 @@ void Presenter::playPlaylist(const QString &playlistHash, const QString &metaHas
     }
 
     qCInfo(dmMusic) << "Playing playlist:" << playlistHash << "Starting with track:" << metaHash;
-    bool playFlag = m_data->m_playerEngine->getMediaMeta().hash != metaHash;
+    const DMusic::MediaMeta currentMeta = m_data->m_playerEngine->getMediaMeta();
+    const QString currentMetaHash = currentMeta.hash;
+    bool playFlag = currentMetaHash != metaHash;
+    const QList<DMusic::MediaMeta> currentMetas = m_data->m_playerEngine->getMetas();
+    const bool canCompareQueue = playlistHash != "album" && playlistHash != "artist"
+                                 && playlistHash != "cdarole";
+    bool currentMetaInQueue = currentMetaHash.isEmpty();
+    if (canCompareQueue && !currentMetaInQueue) {
+        for (const auto &meta : currentMetas) {
+            if (meta.hash == currentMetaHash) {
+                currentMetaInQueue = true;
+                break;
+            }
+        }
+    }
+    const bool samePlayQueue = canCompareQueue && !currentMetas.isEmpty() && currentMetaInQueue
+                               && m_data->m_dataManager->isPlaylistQueueMatched(playlistHash, currentMetas);
     QList<DMusic::MediaMeta> allMetas;
-    
-    if (playlistHash != "album" && playlistHash != "artist") {
-        allMetas = m_data->m_dataManager->getPlaylistMetas(playlistHash);
-    } else if (playlistHash == "album") {
-        auto albums = m_data->m_dataManager->allAlbumInfos();
-        for (auto album : albums) {
-            allMetas += album.musicinfos.values();
+
+    if (!samePlayQueue) {
+        if (playlistHash != "album" && playlistHash != "artist") {
+            allMetas = m_data->m_dataManager->getPlaylistMetas(playlistHash);
+        } else if (playlistHash == "album") {
+            auto albums = m_data->m_dataManager->allAlbumInfos();
+            for (auto album : albums) {
+                allMetas += album.musicinfos.values();
+            }
+        } else {
+            auto artists = m_data->m_dataManager->allArtistInfos();
+            for (auto artist : artists) {
+                allMetas += artist.musicinfos.values();
+            }
         }
+
+        if (playlistHash == "cdarole") {
+            qCDebug(dmMusic) << "Adding CD audio tracks to playlist";
+            allMetas = m_data->m_playerEngine->getCdaMetaInfo() + allMetas;
+        }
+
+        for (const auto &meta : allMetas) {
+            if (currentMetaHash == meta.hash) {
+                playFlag = false;
+                break;
+            }
+        }
+
+        if (allMetas.isEmpty()) {
+            qCWarning(dmMusic) << "No tracks found in playlist:" << playlistHash;
+            return;
+        }
+
+        qCDebug(dmMusic) << "Loading" << allMetas.size() << "tracks from playlist";
+        m_data->m_playerEngine->clearPlayList(playFlag);
+        m_data->m_playerEngine->replaceMetasToPlayList(allMetas);
     } else {
-        auto artists = m_data->m_dataManager->allArtistInfos();
-        for (auto artist : artists) {
-            allMetas += artist.musicinfos.values();
-        }
+        // The active engine queue already matches the requested playback queue.
+        qCDebug(dmMusic) << "Reusing current play queue with" << currentMetas.size() << "tracks";
     }
     
-    if (playlistHash == "cdarole") {
-        qCDebug(dmMusic) << "Adding CD audio tracks to playlist";
-        allMetas = m_data->m_playerEngine->getCdaMetaInfo() + allMetas;
-    }
-    
-    for (auto meta : allMetas) {
-        if (m_data->m_playerEngine->getMediaMeta().hash == meta.hash) {
-            playFlag = false;
-            break;
-        }
-    }
-
-    if (allMetas.isEmpty()) {
-        qCWarning(dmMusic) << "No tracks found in playlist:" << playlistHash;
-        return;
-    }
-
-    qCDebug(dmMusic) << "Loading" << allMetas.size() << "tracks from playlist";
-    m_data->m_playerEngine->clearPlayList(playFlag);
-    m_data->m_playerEngine->addMetasToPlayList(allMetas);
-    
-    if (!metaHash.isEmpty() && m_data->m_playerEngine->getMediaMeta().hash != metaHash) {
+    if (!metaHash.isEmpty() && currentMetaHash != metaHash) {
         qCDebug(dmMusic) << "Setting start track to:" << metaHash;
         m_data->m_playerEngine->setMediaMeta(metaHash);
     }
@@ -653,8 +650,10 @@ void Presenter::playPlaylist(const QString &playlistHash, const QString &metaHas
     }
 
     m_data->m_dataManager->setCurrentPlayliHash(playlistHash);
-    m_data->m_dataManager->clearPlayList("play", false);
-    m_data->m_dataManager->addMetasToPlayList(allMetas, "play", false);
+    if (!samePlayQueue) {
+        m_data->m_dataManager->clearPlayList("play", false);
+        m_data->m_dataManager->addMetasToPlayList(allMetas, "play", false);
+    }
     
     qCInfo(dmMusic) << "Playlist playback started successfully";
 }


### PR DESCRIPTION
Cache next/previous playable meta lookups in PlayerEngine with a short TTL, and skip rebuilding the play queue when it already matches the requested playlist.

在 PlayerEngine 中缓存上一首/下一首可播放曲目（短时 TTL），当当前
播放队列已与请求的歌单匹配时直接复用，避免无谓的清空与重建。

Log: 优化播放队列与上一/下一首查询性能
Influence: 切换歌单时若队列已匹配则不再重建，提升响应速度并降低开销。