### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/music-player/data/deepin-music.desktop
+++ b/src/music-player/data/deepin-music.desktop
@@ -182,9 +182,9 @@ Name[ug]=Deepin مۇزىكا
 Name[uk]=Deepin Музика
 Name[vi]=Trình nghe nhạc Deepin
 Name[lo]=Deepin ເພງ
-Name[zh_CN]=深度音乐
-Name[zh_HK]=Deepin 音樂
-Name[zh_TW]=Deepin 音樂
+Name[zh_CN]=音乐
+Name[zh_HK]=音樂
+Name[zh_TW]=音樂
 
 [X-Next Shortcut Group]
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Remove "深度"/"deepin"/"Deepin" prefixes from zh_CN, zh_HK, and zh_TW Name/Comment translations in the deepin-music desktop entry to align with branding requirements.