### PR TITLE
fix(player): support WV and MP2 media import

### DIFF
--- a/src/music-player/core/player.cpp
+++ b/src/music-player/core/player.cpp
@@ -100,7 +100,9 @@ Player::Player(QObject *parent) : QObject(parent)
                           << "*.m4a"
                           << "*.ac3"
                           << "*.voc"
-                          << "*.aiff";
+                          << "*.aiff"
+                          << "*.wv"
+                          << "*.mp2";
         m_supportedSuffixStr  << "aac"
                               << "amr"
                               << "wav"
@@ -112,7 +114,9 @@ Player::Player(QObject *parent) : QObject(parent)
                               << "m4a"
                               << "ac3"
                               << "voc"
-                              << "aiff";
+                              << "aiff"
+                              << "wv"
+                              << "mp2";
     } else {
         m_supportedSuffix << "*.wav"
                           << "*.ogg"


### PR DESCRIPTION
Add WV and MP2 suffixes to the VLC media format whitelist.

在 VLC 媒体格式白名单中加入 WV 和 MP2 后缀。

Log: 支持导入 WV 和 MP2 音频
PMS: https://pms.uniontech.com/bug-view-365179.html
Influence: VLC 引擎下可通过文件或目录导入 WV、MP2 音频。

## Summary by Sourcery

New Features:
- Allow importing WV and MP2 audio files when using the VLC playback engine.