### PR TITLE
chore: update version to 7.0.61

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-music (7.0.61) unstable; urgency=medium
+
+  * fix(player): coalesce rapid manual track switches and cancel stale fades
+  * fix: remove deepin prefix from Chinese translations in desktop file
+  * perf(player): cache playable meta and reuse matched play queue
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 16 Jul 2026 21:38:08 +0800
+
 deepin-music (7.0.60) unstable; urgency=medium
 
   * chore: Update version to 7.0.60

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.60.1
+  version: 7.0.61.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- bump version to 7.0.61

Log : bump version to 7.0.61

## Summary by Sourcery

Bump the deepin-music package version metadata to 7.0.61.1 in linglong configuration.