### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/src/music-player/data/deepin-music.desktop
+++ b/src/music-player/data/deepin-music.desktop
@@ -11,6 +11,7 @@ Type=Application
 X-Deepin-ManualID=deepin-music
 X-Deepin-TurboType=dtkwidget
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add X-Deepin-Singleton=true to the Deepin Music desktop file to declare it as a singleton app for AM/Treeland integration.