### PR TITLE
fix: favorite icon turns white when list item is selected

### DIFF
--- a/src/music-player/musicList/AllMusicListDelegate.qml
+++ b/src/music-player/musicList/AllMusicListDelegate.qml
@@ -205,7 +205,7 @@ ItemDelegate{
                     anchors.verticalCenter: numlabel.verticalCenter
                     icon.width: 20; icon.height: 20
                     icon.name: favourite ? "heart_check" : "heart"
-                    palette.windowText: (favourite & !rootRectangle.checked)  ? "#F75B5B" : undefined
+                    palette.windowText: favourite ? "#F75B5B" : undefined
                     onClicked: {
                         if (mmType !== DmGlobal.MimeTypeCDA) {
                             if(favourite === false){

--- a/src/music-player/musicsublist/AlbumSublistDelegate.qml
+++ b/src/music-player/musicsublist/AlbumSublistDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -187,7 +187,7 @@ ItemDelegate {
                             anchors.verticalCenter: parent.verticalCenter
                             icon.width: 20; icon.height: 20
                             icon.name: model.favourite ? "heart_check" : "heart"
-                            palette.windowText: (favourite & !sublistDelegate.checked)  ? "#F75B5B" : undefined
+                            palette.windowText: favourite ? "#F75B5B" : undefined
                             onClicked: {
                                 if(favourite === false){
                                     Presenter.addMetasToPlayList(hash, "fav")

--- a/src/music-player/musicsublist/ArtistSublistDelegate.qml
+++ b/src/music-player/musicsublist/ArtistSublistDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -138,7 +138,7 @@ ItemDelegate {
                     anchors.verticalCenter: parent.verticalCenter
                     icon.width: 20; icon.height: 20
                     icon.name: favourite ? "heart_check" : "heart"
-                    palette.windowText: (favourite & !sublistDelegate.checked)  ? "#F75B5B" : undefined
+                    palette.windowText: favourite ? "#F75B5B" : undefined
                     onClicked: {
                         if(favourite === false) {
                             Presenter.addMetasToPlayList(hash, "fav")

--- a/src/music-player/playlist/CurrentPlayListDelegate.qml
+++ b/src/music-player/playlist/CurrentPlayListDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -113,7 +113,7 @@ ItemDelegate{
             ActionButton {
                 id: heartBtn
                 icon.name: favourite ? "heart_check" : "playlist_heart"
-                palette.windowText: (favourite & !rootRectangle.checked)  ? "#F75B5B" : undefined
+                palette.windowText: favourite ? "#F75B5B" : undefined
                 icon.width: 20
                 icon.height: 20
                 onClicked: {


### PR DESCRIPTION
When a music list item is checked/selected, the favorite heart icon incorrectly falls back to palette.highlightedText (white) because `!checked` condition forces palette.windowText to undefined.

音乐列表项选中时，收藏图标因 `!checked` 条件将颜色回退为
palette.highlightedText（白色），导致已收藏的心形图标变白。

Log: 修复音乐列表选中时收藏图标颜色变为白色的问题
PMS: BUG-326295
Influence: 修复后，音乐列表中已收藏的歌曲在选中状态下心形图标仍保持红色，涉及所有音乐列表、播放列表、歌手和专辑子列表页面。