### PR TITLE
feat: merge cover and lyrics extraction into single TagLib pass with concurrent processing

### DIFF
--- a/src/libdmusic/CMakeLists.txt
+++ b/src/libdmusic/CMakeLists.txt
@@ -3,7 +3,7 @@ project(libdmusic)
 set(CMD_NAME dmusic)
 add_definitions(-DLIBDMUSIC_LIBRARY)
 
-set(QT_MODULES Core Multimedia DBus Sql Core5Compat)
+set(QT_MODULES Core Multimedia DBus Sql Core5Compat Concurrent)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -47,8 +47,11 @@ pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavcodec libavformat)
 # pkg_check_modules(udisks2 REQUIRED IMPORTED_TARGET udisks2-qt5)
 
 set(TARGET_LIBS PkgConfig::TAGLIB PkgConfig::DTK)
-target_link_libraries(${CMD_NAME} ${TARGET_LIBS} PkgConfig::MPRIS PkgConfig::TAGLIB PkgConfig::DTK ICU::i18n PkgConfig::FFMPEG)
-target_link_libraries(${CMD_NAME} Qt6::Core Qt6::Multimedia Qt6::DBus Qt6::Sql Qt6::Core5Compat)
+target_link_libraries(${CMD_NAME} ${TARGET_LIBS} PkgConfig::TAGLIB PkgConfig::DTK ICU::i18n PkgConfig::FFMPEG)
+if(LINUX)
+  target_link_libraries(${CMD_NAME} PkgConfig::MPRIS)
+endif()
+target_link_libraries(${CMD_NAME} Qt6::Core Qt6::Multimedia Qt6::DBus Qt6::Sql Qt6::Core5Compat Qt6::Concurrent)
 
 # qt5_use_modules(${CMD_NAME} )
 

--- a/src/libdmusic/core/audioanalysis.cpp
+++ b/src/libdmusic/core/audioanalysis.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -836,4 +836,195 @@ void AudioAnalysis::parseData()
 
     emit audioSpectrumData(curSampleData);
     qCDebug(dmMusic) << "Emitted audio spectrum data with" << curSampleData.size() << "samples";
+}
+
+void AudioAnalysis::parseMetaCoverAndLyrics(DMusic::MediaMeta &meta)
+{
+    qCDebug(dmMusic) << "parseMetaCoverAndLyrics for:" << meta.localPath << "hash:" << meta.hash;
+
+    QString tmpPath = DmGlobal::cachePath();
+    QString hash = meta.hash;
+    QString path = meta.localPath;
+
+    // --- 目录准备 ---
+    QString imagesDirPath = tmpPath + "/images";
+    QString imageName = hash + ".jpg";
+    QString coverPath = imagesDirPath + "/" + imageName;
+    QDir imageDir(imagesDirPath);
+    if (!imageDir.exists()) {
+        bool ok = imageDir.cdUp() && imageDir.mkdir("images") && imageDir.cd("images");
+        if (!ok) {
+            qCWarning(dmMusic) << "Failed to create images directory:" << imagesDirPath;
+        }
+    }
+
+    QString lyricDirPath = tmpPath + "/lyrics";
+    QString lyricName = hash + ".lrc";
+    QString lyricPath = lyricDirPath + "/" + lyricName;
+    QDir lyricDir(lyricDirPath);
+    if (!lyricDir.exists()) {
+        bool ok = lyricDir.cdUp() && lyricDir.mkdir("lyrics") && lyricDir.cd("lyrics");
+        if (!ok) {
+            qCWarning(dmMusic) << "Failed to create lyrics directory:" << lyricDirPath;
+        }
+    }
+
+    bool coverCached = QFile::exists(coverPath);
+    bool lyricsCached = QFile::exists(lyricPath);
+
+    if (coverCached) {
+        QImage image(coverPath);
+        if (!image.isNull()) {
+            meta.coverUrl = coverPath;
+            meta.hasimage = true;
+        }
+    }
+    if (lyricsCached) {
+        meta.lyricPath = lyricPath;
+    }
+
+    // 两个都已缓存，直接返回
+    if (coverCached && meta.hasimage && lyricsCached) {
+        qCDebug(dmMusic) << "Both cover and lyrics cached, skipping file open for:" << hash;
+        return;
+    }
+
+    if (path.isEmpty()) {
+        qCWarning(dmMusic) << "Path is empty, cannot parse cover/lyrics for:" << hash;
+        return;
+    }
+
+    // --- 单次 TagLib 打开，同时提取封面和歌词 ---
+#ifdef Q_OS_WIN
+    TagLib::MPEG::File f(path.toStdWString().c_str());
+#else
+    TagLib::MPEG::File f(path.toStdString().c_str());
+#endif
+
+    if (!f.isValid()) {
+        qCWarning(dmMusic) << "Invalid MPEG file for cover/lyrics extraction:" << path;
+        return;
+    }
+
+    // --- 封面提取 (APIC) ---
+    if (!coverCached && f.ID3v2Tag() != nullptr) {
+        TagLib::ID3v2::FrameList frameList = f.ID3v2Tag()->frameListMap()["APIC"];
+        if (!frameList.isEmpty()) {
+            TagLib::ID3v2::AttachedPictureFrame *picFrame =
+                static_cast<TagLib::ID3v2::AttachedPictureFrame *>(frameList.front());
+            QBuffer buffer;
+            buffer.setData(picFrame->picture().data(), static_cast<int>(picFrame->picture().size()));
+            QImageReader imageReader(&buffer);
+            QImage image = imageReader.read();
+            if (!image.isNull()) {
+                QByteArray byteArray;
+                QBuffer buf(&byteArray);
+                buf.open(QIODevice::WriteOnly);
+                image.save(&buf, "jpg");
+                image = image.scaled(QSize(200, 200), Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+                image.save(coverPath);
+                meta.coverUrl = coverPath;
+                meta.hasimage = true;
+                qCInfo(dmMusic) << "Cover extracted via TagLib (merged pass):" << coverPath;
+            }
+        }
+    }
+
+    // --- 歌词提取 (SYLT / USLT) ---
+    if (!lyricsCached && f.ID3v2Tag() != nullptr) {
+        QString lyricStr;
+
+        // 先尝试同步歌词
+        TagLib::ID3v2::FrameList syltFrames = f.ID3v2Tag()->frameListMap()["SYLT"];
+        if (!syltFrames.isEmpty()) {
+            TagLib::ID3v2::SynchronizedLyricsFrame *frame =
+                dynamic_cast<TagLib::ID3v2::SynchronizedLyricsFrame *>(syltFrames.front());
+            if (frame) {
+                TagLib::ID3v2::SynchronizedLyricsFrame::SynchedTextList synchedTextList = frame->synchedText();
+                for (unsigned int i = 0; i < synchedTextList.size(); i++) {
+                    QString time = QDateTime::fromMSecsSinceEpoch(synchedTextList[i].time).toString("mm:ss.zzz");
+                    QString text = TStringToQString(synchedTextList[i].text).trimmed();
+                    lyricStr.append(QString("[%1]%2\n").arg(time).arg(text));
+                }
+            }
+        }
+
+        // 未获取到同步歌词，尝试非同步歌词
+        if (lyricStr.isEmpty()) {
+            TagLib::ID3v2::FrameList usltFrames = f.ID3v2Tag()->frameListMap()["USLT"];
+            if (!usltFrames.isEmpty()) {
+                TagLib::ID3v2::UnsynchronizedLyricsFrame *frame =
+                    dynamic_cast<TagLib::ID3v2::UnsynchronizedLyricsFrame *>(usltFrames.front());
+                if (frame) {
+                    lyricStr = TStringToQString(frame->text());
+                }
+            }
+        }
+
+        if (!lyricStr.isEmpty()) {
+            QDir lyricDir(lyricDirPath);
+            if (!lyricDir.exists()) {
+                QDir().mkpath(lyricDirPath);
+            }
+            QFile lyric(lyricPath);
+            if (lyric.open(QIODevice::WriteOnly)) {
+                lyric.write(lyricStr.toUtf8());
+                lyric.close();
+                meta.lyricPath = lyricPath;
+                qCInfo(dmMusic) << "Lyrics extracted via TagLib (merged pass):" << lyricPath;
+            } else {
+                qCWarning(dmMusic) << "Failed to write lyrics file:" << lyricPath;
+            }
+        }
+    }
+
+    // TagLib 未找到封面，回退到 FFmpeg 提取
+    if (!meta.hasimage && !coverCached) {
+        int engineType = DmGlobal::playbackEngineType();
+        if (engineType == 1) {
+            qCDebug(dmMusic) << "TagLib cover miss, trying FFmpeg for:" << path;
+            format_alloc_context_function format_alloc_context = (format_alloc_context_function)DynamicLibraries::instance()->resolve("avformat_alloc_context", true);
+            format_open_input_function format_open_input = (format_open_input_function)DynamicLibraries::instance()->resolve("avformat_open_input", true);
+            format_close_input_function format_close_input = (format_close_input_function)DynamicLibraries::instance()->resolve("avformat_close_input", true);
+            format_free_context_function format_free_context = (format_free_context_function)DynamicLibraries::instance()->resolve("avformat_free_context", true);
+
+            AVFormatContext *pFormatCtx = format_alloc_context();
+            format_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr);
+
+            if (pFormatCtx) {
+#if LIBAVFORMAT_VERSION_MAJOR < 61
+                if (pFormatCtx->iformat != nullptr && pFormatCtx->iformat->read_header(pFormatCtx) >= 0) {
+#else
+                if (avformat_find_stream_info(pFormatCtx, nullptr) >= 0) {
+#endif
+                    for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
+                        if (pFormatCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
+                            AVPacket pkt = pFormatCtx->streams[i]->attached_pic;
+                            QImage image = QImage::fromData(static_cast<uchar *>(pkt.data), pkt.size);
+                            if (!image.isNull()) {
+                                image = image.scaled(QSize(200, 200), Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+                                image.save(coverPath);
+                                meta.coverUrl = coverPath;
+                                meta.hasimage = true;
+                                qCInfo(dmMusic) << "Cover extracted via FFmpeg (merged pass):" << coverPath;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            format_close_input(&pFormatCtx);
+            format_free_context(pFormatCtx);
+        }
+    }
+
+    // FFmpeg 也没找到封面，使用默认封面
+    if (!meta.hasimage) {
+        meta.coverUrl = DmGlobal::cachePath() + "/images/default_cover.png";
+        qCDebug(dmMusic) << "Using default cover for:" << path;
+    }
+
+    f.clear();
+    qCInfo(dmMusic) << "parseMetaCoverAndLyrics completed for:" << hash
+                    << "hasimage:" << meta.hasimage << "lyricPath:" << meta.lyricPath;
 }

--- a/src/libdmusic/core/audioanalysis.h
+++ b/src/libdmusic/core/audioanalysis.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Deepin Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -28,6 +28,10 @@ public:
     static QImage getMetaCoverImage(DMusic::MediaMeta meta);
 
     static void parseMetaLyrics(DMusic::MediaMeta &meta);
+
+    // Merged: extract cover + lyrics in a single TagLib file-open pass.
+    // Falls back to FFmpeg for cover if TagLib APIC is empty.
+    static void parseMetaCoverAndLyrics(DMusic::MediaMeta &meta);
 
 public slots:
     void startRecorder();

--- a/src/libdmusic/core/dboperate.cpp
+++ b/src/libdmusic/core/dboperate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -151,12 +151,9 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
     // signalCoverBatchFinished so m_importedMetas has correct hasimage/coverUrl.
     emit signalImportFinished(allHashs.values(), importedFailCount, importedCount - importedFailCount - existCount, existCount, mediaHash);
 
-    // Extract cover/lyrics after the import loop (still on worker thread, sequential,
-    // no new QThread). Emits per-meta so UI refreshes one row at a time.
-    for (DMusic::MediaMeta &meta : pendingCovers) {
-        AudioAnalysis::parseMetaCover(meta);
-        AudioAnalysis::parseMetaLyrics(meta);
-        emit signalMetaCoverReady(meta);
+    // Extract cover/lyrics after the import loop using parallel batch processing.
+    if (!pendingCovers.isEmpty()) {
+        processPendingCovers(pendingCovers);
     }
 
     emit signalCoverBatchFinished();
@@ -165,4 +162,29 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
 void DBOperate::slotClearImportingHash(const QString &hash)
 {
     m_importingHashes.remove(hash);
+}
+
+void DBOperate::processPendingCovers(QList<DMusic::MediaMeta> &pendingCovers)
+{
+    qCInfo(dmMusic) << "Processing" << pendingCovers.size() << "covers/lyrics in parallel batch mode";
+
+    const int batchSize = 8;
+
+    // 使用 QtConcurrent::map 并行处理（修改原地数据）
+    QtConcurrent::map(pendingCovers, [](DMusic::MediaMeta &meta) {
+        AudioAnalysis::parseMetaCoverAndLyrics(meta);
+    }).waitForFinished();
+
+    // 分批发送批量信号，避免一次性更新过多 UI
+    for (int i = 0; i < pendingCovers.size(); i += batchSize) {
+        int end = qMin(i + batchSize, pendingCovers.size());
+        QList<DMusic::MediaMeta> batch = pendingCovers.mid(i, end - i);
+
+        // 逐条发送以保持与现有 UI 逻辑兼容
+        for (const DMusic::MediaMeta &meta : batch) {
+            emit signalMetaCoverReady(meta);
+        }
+    }
+
+    qCInfo(dmMusic) << "Parallel cover/lyrics batch processing completed";
 }

--- a/src/libdmusic/core/dboperate.h
+++ b/src/libdmusic/core/dboperate.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Deepin Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -8,6 +8,8 @@
 
 #include "global.h"
 #include <QSet>
+#include <QtConcurrent>
+#include <QFuture>
 
 class DBOperate : public QObject
 {
@@ -26,6 +28,9 @@ signals:
     void signalImportFinished(QStringList playlistHashs, int failCount, int sucessCount, int existCount, QString mediaHash);
     void signalCoverBatchFinished();
     void signalMetaCoverReady(DMusic::MediaMeta meta);
+
+private:
+    void processPendingCovers(QList<DMusic::MediaMeta> &pendingCovers);
 
 private:
     QStringList          m_supportedSuffixs;


### PR DESCRIPTION
…concurrent processing

- Add parseMetaCoverAndLyrics() to extract cover art and lyrics in one TagLib file-open, reducing redundant I/O
- Fall back to FFmpeg for cover extraction when TagLib APIC frame is empty
- Add QtConcurrent-based concurrent cover processing in DBOperate for batch imports
- Conditionally link MPRIS only on Linux, add Qt6::Concurrent module

feat: 将封面和歌词提取合并为单次 TagLib 读取，并支持并发处理

- 新增 parseMetaCoverAndLyrics() 方法，在一次 TagLib 文件打开中同时提取封面和歌词，减少重复 I/O
- 当 TagLib APIC 帧为空时，回退到 FFmpeg 提取封面
- 在 DBOperate 中添加基于 QtConcurrent 的并发封面处理，用于批量导入
- 仅在 Linux 上链接 MPRIS，添加 Qt6::Concurrent 模块

## Summary by Sourcery

Unify cover art and lyrics extraction into a single metadata pass and process pending covers concurrently during batch imports, while updating build configuration for conditional MPRIS linking and QtConcurrent support.

New Features:
- Add a combined metadata extractor that reads cover art and lyrics in a single TagLib file-open and falls back to FFmpeg when no embedded cover is found.
- Introduce concurrent batch processing for cover and lyrics extraction during media imports using QtConcurrent.

Enhancements:
- Cache and reuse extracted cover art and lyrics on disk, including a default cover when none can be found.
- Refine logging and metadata handling around cover and lyrics parsing for improved observability.

Build:
- Link Qt6::Concurrent and include the Concurrent module in the libdmusic build.
- Link the MPRIS library conditionally only on Linux platforms.