### PR TITLE
fix(playlist): restore thumbnail shadows

### DIFF
--- a/src/music-player/listView/musicInfoList/playitemdelegate.cpp
+++ b/src/music-player/listView/musicInfoList/playitemdelegate.cpp
@@ -529,6 +529,14 @@ void PlayItemDelegate::drawIconMode(QPainter &painter, const QStyleOptionViewIte
         icon = qvariant_cast<QIcon>(value);
     }
     QRect pixmapRect(option.rect.x() + xoffset, option.rect.y() + yoffset, imgWidthAndHeight(), imgWidthAndHeight());
+    QRect shadowRect = pixmapRect.adjusted(-10, 0, 8, 8);
+    QPainterPath roundRectShadowPath;
+    roundRectShadowPath.addRoundRect(shadowRect, 8, 8);
+    painter.save();
+    painter.setClipPath(roundRectShadowPath);
+    painter.drawPixmap(shadowRect, m_shadowImg);
+    painter.restore();
+
     // 绘制选中时效果
     QBrush fillBrush(QColor(128, 128, 128, 0));
     if (option.state & QStyle::State_Selected) {
@@ -816,7 +824,7 @@ PlayItemDelegate::PlayItemDelegate(QWidget *parent)
     : QStyledItemDelegate(parent)
 {
     setObjectName("PlayItemStyleProxy");
-    m_shadowImg = DHiDPIHelper::loadNxPixmap(":/mpimage/light/shadow.svg");
+    m_shadowImg = DHiDPIHelper::loadNxPixmap(":/icons/deepin/builtin/actions/shadow_176px.svg");
     m_shadowImg = m_shadowImg.copy(5, 5, m_shadowImg.width() - 10, m_shadowImg.height() - 10);
     DStyle d;
     m_selectedPix = d.standardIcon(DStyle::SP_IndicatorChecked).pixmap(QSize(14, 14));


### PR DESCRIPTION
## 问题

PMS BUG-241393：所有音乐、我的收藏和我的歌单在图标模式下的缩略图底部没有阴影，与专辑缩略图视觉效果不一致。

## 根因

`PlayItemDelegate` 未绘制阴影，且加载的资源路径未在项目资源中注册。

## 修复

- 使用与专辑缩略图相同的 `shadow_176px.svg` 资源。
- 在歌曲缩略图绘制前增加圆角裁剪的阴影绘制。

## 验证

`cmake --build obj-x86_64-linux-gnu --target deepin-music -j2` 通过。

关联根因报告：`.pms/bugs/241393/analysis-report.md`

## Summary by Sourcery

Restore consistent thumbnail shadow rendering for playlist items in icon mode to match album visuals.

Bug Fixes:
- Fix missing bottom shadow on music, favorites, and playlist thumbnails in icon mode by drawing a rounded shadow behind song cover images.

Enhancements:
- Align song thumbnail shadow asset with the album thumbnail by using the shared shadow_176px.svg resource.