### PR TITLE
fix(window): allow half-screen snapping

### DIFF
--- a/src/music-player/mainFrame/mainframe.cpp
+++ b/src/music-player/mainFrame/mainframe.cpp
@@ -19,6 +19,8 @@
 #include <QDBusConnection>
 #include <QDesktopWidget>
 #include <QScrollArea>
+#include <QScreen>
+#include <QGuiApplication>
 
 #include <DUtil>
 #include <DWidgetUtil>
@@ -199,9 +201,32 @@ MainFrame::~MainFrame()
     MusicSettings::release();
 }
 
+void MainFrame::applyDynamicMinimumSize()
+{
+    constexpr int defaultMinWidth = 900;
+    constexpr int defaultMinHeight = 600;
+    constexpr int minimumDimension = 100;
+    constexpr int snapMargin = 10;
+
+    QScreen *screen = QGuiApplication::primaryScreen();
+    if (!screen) {
+        setMinimumSize(defaultMinWidth, defaultMinHeight);
+        return;
+    }
+
+    const QRect availableGeometry = screen->availableGeometry();
+    const int minimumWidth = qBound(minimumDimension,
+                                    availableGeometry.width() / 2 - snapMargin,
+                                    defaultMinWidth);
+    const int minimumHeight = qBound(minimumDimension,
+                                     availableGeometry.height() / 2 - snapMargin,
+                                     defaultMinHeight);
+    setMinimumSize(minimumWidth, minimumHeight);
+}
+
 void MainFrame::initUI(bool showLoading)
 {
-    this->setMinimumSize(QSize(900, 600));
+    applyDynamicMinimumSize();
     this->setFocusPolicy(Qt::ClickFocus);
 
     m_titlebarwidget->setEnabled(showLoading);
@@ -1049,7 +1074,7 @@ void MainFrame::showEvent(QShowEvent *event)
 {
     Q_UNUSED(event)
     if (m_geometryBa.isEmpty()) {//初次直接显示默认窗口
-        this->setMinimumSize(QSize(1070, 680));
+        applyDynamicMinimumSize();
         this->resize(QSize(1070, 680));
         Dtk::Widget::moveToCenter(this);
 

--- a/src/music-player/mainFrame/mainframe.h
+++ b/src/music-player/mainFrame/mainframe.h
@@ -66,6 +66,7 @@ public slots:
 #endif
 
 private:
+    void applyDynamicMinimumSize();
     /**
      * @brief initMenuAndShortCut
      */


### PR DESCRIPTION
## 问题

PMS BUG-369275：在 FlemingZ 环境中，将音乐窗口拖拽至屏幕左右侧分屏后，窗口宽度超过半屏。

## 根因

首次显示窗口时，将默认启动尺寸 `1070 x 680` 同时设置为最小窗口尺寸，导致窗管请求半屏宽度时受 `1070px` 最小宽度限制。

## 修复

移除首次显示时对 `1070 x 680` 的最小尺寸设置，保留默认启动尺寸与初始化阶段 `900 x 600` 的最小尺寸。

## 验证

`cmake --build obj-x86_64-linux-gnu --target deepin-music -j2` 通过。

关联根因报告：`.pms/bugs/369275/analysis-report.md`

## Summary by Sourcery

Bug Fixes:
- Fix music player window exceeding half-screen width when snapped to screen sides by removing an overly large minimum size constraint on first show.