### PR TITLE
refactor: replace DApplication with QGuiApplication + DGuiApplication…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### deepin-music
 
-Deepin music  is a local music player with beautiful design and simple functions  developed by Deepin Technology.
+Deepin music is a local music player with beautiful design and simple functions developed by Deepin Technology.
 
 ### Dependencies
 
@@ -8,28 +8,50 @@ Deepin music  is a local music player with beautiful design and simple functions
 
 _The **master** branch is current development branch, build dependencies may changes without update README.md, refer to `./debian/control` for a working build depends list_
 
+* cmake (>= 3.10)
 * pkg-config
-* libtag1-dev
-* libicu-dev
-* libgsettings-qt-dev
-* libdbusextended-qt5-dev
-* libkf5codecs-dev
 * libavutil-dev
 * libavcodec-dev
 * libavformat-dev
-* libdtkcore-dev
-* libdtkgui-dev
-* libudisks2-qt5-dev 
+* libdtk6core-bin
+* libdtk6gui-dev
+* libdbusextended-qt5-dev
+* libgsettings-qt-dev
+* libicu-dev
+* libmpris-qt6-dev
+* libtag1-dev
+* libxtst-dev
 * libvlc-dev
 * libvlccore-dev
-* Qt5(>= 5.6) with modules:
-  - qt5-qmake
-  - libqt5svg5-dev
-  - qttools5-dev-tools
-  - qtmultimedia5-dev
-  - libkf5codecs-dev
-* Deepin-tool-kit(>=2.0) with modules:
-  - libdtkwidget-dev
+* libsdl2-dev
+* Qt6 with modules:
+  - qt6-svg-dev
+  - qt6-multimedia-dev
+  - qt6-tools-dev
+  - qt6-tools-dev-tools
+  - qt6-declarative-dev
+  - qt6-5compat-dev
+  - libqt6sql6-sqlite
+  - qml6-module-qtquick-dialogs
+* Deepin-tool-kit (>= 6.0) with modules:
+  - libdtk6declarative-dev
+  - libdtk6gui-dev
+  - libdtk6core-bin
+
+### Runtime dependencies
+
+* libvlc5
+* vlc-plugin-base
+* gstreamer1.0-fluendo-mp3
+* gstreamer1.0-libav
+* gstreamer1.0-plugins-base
+* gstreamer1.0-plugins-good
+* gstreamer1.0-plugins-bad
+* gstreamer1.0-plugins-ugly
+* gstreamer1.0-pulseaudio
+* gvfs-bin
+* libuchardet0
+* libmpris-qt6
 
 ## Installation
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -8,28 +8,50 @@ Deepin music  is a local music player with beautiful design and simple functions
 
 _The **master** branch is current development branch, build dependencies may changes without update README.md, refer to `./debian/control` for a working build depends list_
 
+* cmake (>= 3.10)
 * pkg-config
-* libtag1-dev
-* libicu-dev
-* libgsettings-qt-dev
-* libdbusextended-qt5-dev
-* libkf5codecs-dev
 * libavutil-dev
 * libavcodec-dev
 * libavformat-dev
-* libdtkcore-dev
-* libdtkgui-dev
-* libudisks2-qt5-dev 
+* libdtk6core-bin
+* libdtk6gui-dev
+* libdbusextended-qt5-dev
+* libgsettings-qt-dev
+* libicu-dev
+* libmpris-qt6-dev
+* libtag1-dev
+* libxtst-dev
 * libvlc-dev
 * libvlccore-dev
-* Qt5(>= 5.6) with modules:
-  - qt5-qmake
-  - libqt5svg5-dev
-  - qttools5-dev-tools
-  - qtmultimedia5-dev
-  - libkf5codecs-dev
-* Deepin-tool-kit(>=2.0) with modules:
-  - libdtkwidget-dev
+* libsdl2-dev
+* Qt6 with modules:
+  - qt6-svg-dev
+  - qt6-multimedia-dev
+  - qt6-tools-dev
+  - qt6-tools-dev-tools
+  - qt6-declarative-dev
+  - qt6-5compat-dev
+  - libqt6sql6-sqlite
+  - qml6-module-qtquick-dialogs
+* Deepin-tool-kit (>= 6.0) with modules:
+  - libdtk6declarative-dev
+  - libdtk6gui-dev
+  - libdtk6core-bin
+
+### Runtime dependencies
+
+* libvlc5
+* vlc-plugin-base
+* gstreamer1.0-fluendo-mp3
+* gstreamer1.0-libav
+* gstreamer1.0-plugins-base
+* gstreamer1.0-plugins-good
+* gstreamer1.0-plugins-bad
+* gstreamer1.0-plugins-ugly
+* gstreamer1.0-pulseaudio
+* gvfs-bin
+* libuchardet0
+* libmpris-qt6
 
 ## 安装
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Build-Depends:
  libavformat-dev,
  libdtk6core-bin,
  libdtk6gui-dev,
- libdtk6widget-dev,
  libdbusextended-qt5-dev,
  libgsettings-qt-dev,
  libicu-dev,

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -21,7 +21,7 @@ command:
 
 build: |
   # 下载和安装依赖
-  apt -y install --download-only libavutil-dev libavcodec-dev libavformat-dev libdtk6core-bin libdtk6gui-dev libdtk6widget-dev libdbusextended-qt5-dev libgsettings-qt-dev libicu-dev libmpris-qt6-dev libtag1-dev qt6-svg-dev libqt6sql6-sqlite libxtst-dev libvlc-dev libvlccore-dev vlc-plugin-base qt6-multimedia-dev qt6-tools-dev qt6-tools-dev-tools qml6-module-qtquick-dialogs qt6-declarative-dev libdtk6declarative-dev qt6-5compat-dev libsdl2-dev libsdl1.2debian
+  apt -y install --download-only libavutil-dev libavcodec-dev libavformat-dev libdtk6core-bin libdtk6gui-dev libdbusextended-qt5-dev libgsettings-qt-dev libicu-dev libmpris-qt6-dev libtag1-dev qt6-svg-dev libqt6sql6-sqlite libxtst-dev libvlc-dev libvlccore-dev vlc-plugin-base qt6-multimedia-dev qt6-tools-dev qt6-tools-dev-tools qml6-module-qtquick-dialogs qt6-declarative-dev libdtk6declarative-dev qt6-5compat-dev libsdl2-dev libsdl1.2debian
   bash ./install_dep /var/cache/apt/archives "$PREFIX"
 
   # 修改路径

--- a/src/music-player/CMakeLists.txt
+++ b/src/music-player/CMakeLists.txt
@@ -45,9 +45,9 @@ endif ()
 add_executable(${BIN_NAME} ${RCC_SOURCES} ${ALLSOURCE} ${QM_FILES})
 
 # Use target_link_libraries instead of qt6_use_modules
-target_link_libraries(${BIN_NAME} Qt6::Core Qt6::Widgets)
+target_link_libraries(${BIN_NAME} Qt6::Core)
 
-set(TARGET_LIBS Qt6::Quick PkgConfig::DTK dmusic ${Dtk6Declarative_LIBRARIES} Dtk6::Widget)
+set(TARGET_LIBS Qt6::Quick PkgConfig::DTK dmusic ${Dtk6Declarative_LIBRARIES} Dtk6::Gui)
 
 target_link_libraries(${BIN_NAME} ${TARGET_LIBS})
 

--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -12,7 +12,8 @@
 #include <QDBusReply>
 
 #include <DLog>
-#include <DApplication>
+#include <DGuiApplicationHelper>
+#include <QGuiApplication>
 #include <QSurfaceFormat>
 
 #include <stdio.h>
@@ -31,8 +32,8 @@
 #include "util/dbusadpator.h"
 #include "util/log.h"
 
-DWIDGET_USE_NAMESPACE;
 DCORE_USE_NAMESPACE;
+DGUI_USE_NAMESPACE;
 
 QScopedPointer<Presenter, QScopedPointerPodDeleter> presenter;
 
@@ -72,12 +73,12 @@ int main(int argc, char *argv[])
     }
     qputenv("D_POPUP_MODE", "embed");
 
-    DApplication *app = new DApplication(argc, argv);
+    QGuiApplication *app = new QGuiApplication(argc, argv);
     app->setAttribute(Qt::AA_UseHighDpiPixmaps);
     app->setOrganizationName("deepin");
     app->setApplicationName("deepin-music");
     // Version Time
-    app->setApplicationVersion(DApplication::buildVersion(VERSION));
+    app->setApplicationVersion(VERSION);
 
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();
@@ -101,7 +102,7 @@ int main(int argc, char *argv[])
         OpenFilePaths = strList;
     }
 
-    if (!app->setSingleInstance("deepinmusic")) {
+    if (!DGuiApplicationHelper::setSingleInstance("deepinmusic")) {
         qCDebug(dmMusic) << "another deepin music has started";
         QDBusInterface speechbus("org.mpris.MediaPlayer2.DeepinMusic",
                                  "/org/mpris/speech",
@@ -129,21 +130,14 @@ int main(int argc, char *argv[])
 
     DmGlobal::initPlaybackEngineType();
     app->setQuitOnLastWindowClosed(false);
-    app->loadTranslator();
+    DGuiApplicationHelper::loadTranslator();
 
     // 请在此处注册QML中的C++类型
     qmlRegisterType<ShaderImageView>("audio.image", 1, 0, "View_image");
     qmlRegisterType<ShaderDataView>("audio.image", 1, 0, "View_data");
     qmlRegisterType<DmGlobal>("audio.global", 1, 0, "DmGlobal");
 
-    QString descriptionText = QObject::tr("Music is a local music player with beautiful design and simple functions.");
-    QString acknowledgementLink = "https://www.deepin.org/acknowledgments/deepin-music#thanks";
     DmGlobal::setAppName(QObject::tr("Music"));
-    qApp->setProductName(DmGlobal::getAppName());
-    qApp->setApplicationAcknowledgementPage(acknowledgementLink);
-    qApp->setProductIcon(QIcon::fromTheme("deepin-music"));
-    qApp->setApplicationDescription(descriptionText);
-    qApp->setApplicationDisplayName(DmGlobal::getAppName());
 
     QQmlApplicationEngine engine;
     // 请在此处注册需要导入到QML中的C++类型


### PR DESCRIPTION
…Helper

refactor: 将 DApplication 替换为 QGuiApplication + DGuiApplicationHelper

- Replace DApplication (dtkwidget) with QGuiApplication + DGuiApplicationHelper (dtkgui)
- Use DGuiApplicationHelper::setSingleInstance() instead of DApplication::setSingleInstance()
- Use DGuiApplicationHelper::loadTranslator() instead of DApplication::loadTranslator()
- Remove DAboutDialog-related settings (productName, productIcon, etc.) as they are only needed by DAboutDialog
- Update CMakeLists.txt to link against Dtk6::Gui instead of Dtk6::Widget
- Remove Qt6::Widgets dependency from the music player target

- 使用 QGuiApplication + DGuiApplicationHelper (dtkgui) 替代 DApplication (dtkwidget)
- 使用 DGuiApplicationHelper::setSingleInstance() 替代 DApplication::setSingleInstance()
- 使用 DGuiApplicationHelper::loadTranslator() 替代 DApplication::loadTranslator()
- 移除 DAboutDialog 相关设置（productName、productIcon 等），这些仅 DAboutDialog 使用
- 更新 CMakeLists.txt，链接 Dtk6::Gui 替代 Dtk6::Widget
- 移除 music player 目标的 Qt6::Widgets 依赖

## Summary by Sourcery

Refactor the music player to use QGuiApplication with DGuiApplicationHelper instead of DApplication and remove widget-specific dependencies.

Enhancements:
- Switch the music player main entry point from DApplication to QGuiApplication combined with DGuiApplicationHelper APIs for single-instance and translation support.
- Remove DAboutDialog-related application metadata configuration that is no longer required.
- Update CMake configuration to drop Qt6::Widgets and Dtk6::Widget, linking against Qt6::Core and Dtk6::Gui instead.

Build:
- Adjust music-player target linking to remove Qt6::Widgets from target_link_libraries and depend on Dtk6::Gui instead of Dtk6::Widget.