### PR TITLE
chore: Update version to 7.0.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+deepin-music (7.0.62) unstable; urgency=medium
+
+  * chore: Update version to 7.0.62
+  * fix: constrain equalizer slider widths and adjust left padding for better layout
+  * chore: update copyright year in CloseConfirmDialog
+  * fix: improve dialog layout responsiveness
+  * feat: improve search result UI and fix playlist button tooltip
+  * fix(CI): broken cppcheck
+  * fix: favorite icon turns white when list item is selected
+  * Revert "feat(shell): add DDE Shell music control widget"
+  * feat(shell): add DDE Shell music control widget
+  * test(libdmusic): raise line coverage above 80%
+  * fix(player): stop player when manual navigation has no playable metas
+  * fix: add X-Deepin-Singleton flag to desktop file
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:15:58 +0800
+
 deepin-music (7.0.61) unstable; urgency=medium
 
   * fix(player): coalesce rapid manual track switches and cancel stale fades

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.61.1
+  version: 7.0.62.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- update version to 7.0.62

log: update version to 7.0.62

## Summary by Sourcery

Chores:
- Update linglong.yaml to reference deepin-music version 7.0.62.1.