### PR TITLE
refactor: rewrite waveform generation with swr_convert

### DIFF
--- a/src/libdmusic/core/audiodatadetector.cpp
+++ b/src/libdmusic/core/audiodatadetector.cpp
@@ -1,63 +1,65 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "audiodatadetector.h"
 
-#include <QTextCodec>
-#include <QLocale>
-#include <QTime>
-#include <QFileInfo>
-#include <QHash>
-#include <QBuffer>
-#include <QByteArray>
-#include <QProcess>
 #include <QDir>
-#include <QStandardPaths>
+#include <QFile>
 #include <QDebug>
 
-//#ifndef DISABLE_LIBAV
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+#include <libswresample/swresample.h>
 #ifdef __cplusplus
 }
-#endif // __cplusplus
-//#endif // DISABLE_LIBAV
+#endif
 
 #include "dynamiclibraries.h"
 #include "global.h"
 #include "util/log.h"
 
-typedef AVFormatContext *(*format_alloc_context_function)(void);
-typedef int (*format_open_input_function)(AVFormatContext **, const char *, AVInputFormat *, AVDictionary **);
-typedef void (*format_free_context_function)(AVFormatContext *);
-typedef int (*format_find_stream_info_function)(AVFormatContext *, AVDictionary **);
-typedef int (*find_best_stream_function)(AVFormatContext *,
-                                         enum AVMediaType,
-                                         int,
-                                         int,
-                                         AVCodec **,
-                                         int);
-typedef void (*format_close_input_function)(AVFormatContext **);
-typedef AVCodecContext *(*codec_alloc_context3_function)(const AVCodec *);
-typedef int (*codec_parameters_to_context_function)(AVCodecContext *,
-                                                    const AVCodecParameters *);
-typedef AVCodec *(*codec_find_decoder_function)(enum AVCodecID);
-typedef int (*codec_open2_function)(AVCodecContext *, const AVCodec *, AVDictionary **);
-typedef AVPacket *(*packet_alloc_function)(void);
-typedef AVFrame *(*frame_alloc_function)(void);
-typedef int (*read_frame_function)(AVFormatContext *, AVPacket *);
-typedef void (*packet_unref_function)(AVPacket *);
-typedef void (*frame_free_function)(AVFrame **);
-typedef void (*packet_free_function)(AVPacket **);
-typedef int (*codec_close_function)(AVCodecContext *);
-typedef int (*codec_send_packet_function)(AVCodecContext *, const AVPacket *);
-typedef int (*codec_receive_frame_function)(AVCodecContext *, AVFrame *);
-typedef void (*codec_free_context_function)(AVCodecContext **);
+// avformat
+typedef AVFormatContext *(*avformat_alloc_context_function)(void);
+typedef int (*avformat_open_input_function)(AVFormatContext **, const char *, AVInputFormat *, AVDictionary **);
+typedef void (*avformat_free_context_function)(AVFormatContext *);
+typedef int (*avformat_find_stream_info_function)(AVFormatContext *, AVDictionary **);
+typedef int (*av_find_best_stream_function)(AVFormatContext *, enum AVMediaType, int, int, AVCodec **, int);
+typedef void (*avformat_close_input_function)(AVFormatContext **);
+
+// avcodec
+typedef AVCodecContext *(*avcodec_alloc_context3_function)(const AVCodec *);
+typedef int (*avcodec_parameters_to_context_function)(AVCodecContext *, const AVCodecParameters *);
+typedef AVCodec *(*avcodec_find_decoder_function)(enum AVCodecID);
+typedef int (*avcodec_open2_function)(AVCodecContext *, const AVCodec *, AVDictionary **);
+typedef int (*avcodec_send_packet_function)(AVCodecContext *, const AVPacket *);
+typedef int (*avcodec_receive_frame_function)(AVCodecContext *, AVFrame *);
+typedef void (*avcodec_free_context_function)(AVCodecContext **);
+
+// avutil
+typedef AVPacket *(*av_packet_alloc_function)(void);
+typedef AVFrame *(*av_frame_alloc_function)(void);
+typedef int (*av_read_frame_function)(AVFormatContext *, AVPacket *);
+typedef void (*av_packet_unref_function)(AVPacket *);
+typedef void (*av_frame_free_function)(AVFrame **);
+typedef void (*av_packet_free_function)(AVPacket **);
+typedef int64_t (*av_rescale_rnd_function)(int64_t a, int64_t b, int64_t c, enum AVRounding);
+typedef int (*av_samples_alloc_function)(uint8_t **, int *, int, int, enum AVSampleFormat, int);
+typedef void (*av_freep_function)(void *);
+typedef void (*av_channel_layout_default_function)(AVChannelLayout *, int);
+
+// swresample
+typedef int (*swr_alloc_set_opts2_function)(SwrContext **,
+    const AVChannelLayout *, enum AVSampleFormat, int,
+    const AVChannelLayout *, enum AVSampleFormat, int,
+    int, void *);
+typedef int (*swr_init_function)(SwrContext *);
+typedef int (*swr_convert_function)(SwrContext *, uint8_t **, int, const uint8_t **, int);
+typedef int64_t (*swr_get_delay_function)(SwrContext *, int64_t);
+typedef void (*swr_free_function)(SwrContext **);
 
 AudioDataDetector::AudioDataDetector(QObject *parent)
     : QThread(parent)
@@ -87,82 +89,93 @@ void AudioDataDetector::run()
         qCWarning(dmMusic) << "Path is empty, aborting audio data detection";
         return;
     }
-    
-    format_alloc_context_function format_alloc_context = (format_alloc_context_function)DynamicLibraries::instance()->resolve("avformat_alloc_context", true);
-    format_open_input_function format_open_input = (format_open_input_function)DynamicLibraries::instance()->resolve("avformat_open_input", true);
-    format_free_context_function format_free_context = (format_free_context_function)DynamicLibraries::instance()->resolve("avformat_free_context", true);
-    format_find_stream_info_function format_find_stream_info = (format_find_stream_info_function)DynamicLibraries::instance()->resolve("avformat_find_stream_info", true);
-    find_best_stream_function find_best_stream = (find_best_stream_function)DynamicLibraries::instance()->resolve("av_find_best_stream", true);
-    format_close_input_function format_close_input = (format_close_input_function)DynamicLibraries::instance()->resolve("avformat_close_input", true);
-    codec_alloc_context3_function codec_alloc_context3 = (codec_alloc_context3_function)DynamicLibraries::instance()->resolve("avcodec_alloc_context3", true);
-    codec_parameters_to_context_function codec_parameters_to_context = (codec_parameters_to_context_function)DynamicLibraries::instance()->resolve("avcodec_parameters_to_context", true);
-    codec_find_decoder_function codec_find_decoder = (codec_find_decoder_function)DynamicLibraries::instance()->resolve("avcodec_find_decoder", true);
-    codec_open2_function codec_open2 = (codec_open2_function)DynamicLibraries::instance()->resolve("avcodec_open2", true);
-    packet_alloc_function packet_alloc = (packet_alloc_function)DynamicLibraries::instance()->resolve("av_packet_alloc", true);
-    frame_alloc_function frame_alloc = (frame_alloc_function)DynamicLibraries::instance()->resolve("av_frame_alloc", true);
-    read_frame_function read_frame = (read_frame_function)DynamicLibraries::instance()->resolve("av_read_frame", true);
 
-    packet_unref_function packet_unref = (packet_unref_function)DynamicLibraries::instance()->resolve("av_packet_unref", true);
-    frame_free_function frame_free = (frame_free_function)DynamicLibraries::instance()->resolve("av_frame_free", true);
-    packet_free_function packet_free = (packet_free_function)DynamicLibraries::instance()->resolve("av_packet_free", true);
-    codec_close_function codec_close = (codec_close_function)DynamicLibraries::instance()->resolve("avcodec_close", true);
-    codec_free_context_function codec_free_context = (codec_free_context_function)DynamicLibraries::instance()->resolve("avcodec_free_context", true);
-    codec_send_packet_function codec_send_packet = (codec_send_packet_function)DynamicLibraries::instance()->resolve("avcodec_send_packet", true);
-    codec_receive_frame_function codec_receive_frame = (codec_receive_frame_function)DynamicLibraries::instance()->resolve("avcodec_receive_frame", true);
+    auto fn_avformat_alloc_context = reinterpret_cast<avformat_alloc_context_function>(DynamicLibraries::instance()->resolve("avformat_alloc_context", true));
+    auto fn_avformat_open_input = reinterpret_cast<avformat_open_input_function>(DynamicLibraries::instance()->resolve("avformat_open_input", true));
+    auto fn_avformat_free_context = reinterpret_cast<avformat_free_context_function>(DynamicLibraries::instance()->resolve("avformat_free_context", true));
+    auto fn_avformat_find_stream_info = reinterpret_cast<avformat_find_stream_info_function>(DynamicLibraries::instance()->resolve("avformat_find_stream_info", true));
+    auto fn_av_find_best_stream = reinterpret_cast<av_find_best_stream_function>(DynamicLibraries::instance()->resolve("av_find_best_stream", true));
+    auto fn_avformat_close_input = reinterpret_cast<avformat_close_input_function>(DynamicLibraries::instance()->resolve("avformat_close_input", true));
+    auto fn_avcodec_alloc_context3 = reinterpret_cast<avcodec_alloc_context3_function>(DynamicLibraries::instance()->resolve("avcodec_alloc_context3", true));
+    auto fn_avcodec_parameters_to_context = reinterpret_cast<avcodec_parameters_to_context_function>(DynamicLibraries::instance()->resolve("avcodec_parameters_to_context", true));
+    auto fn_avcodec_find_decoder = reinterpret_cast<avcodec_find_decoder_function>(DynamicLibraries::instance()->resolve("avcodec_find_decoder", true));
+    auto fn_avcodec_open2 = reinterpret_cast<avcodec_open2_function>(DynamicLibraries::instance()->resolve("avcodec_open2", true));
+    auto fn_avcodec_send_packet = reinterpret_cast<avcodec_send_packet_function>(DynamicLibraries::instance()->resolve("avcodec_send_packet", true));
+    auto fn_avcodec_receive_frame = reinterpret_cast<avcodec_receive_frame_function>(DynamicLibraries::instance()->resolve("avcodec_receive_frame", true));
+    auto fn_avcodec_free_context = reinterpret_cast<avcodec_free_context_function>(DynamicLibraries::instance()->resolve("avcodec_free_context", true));
+    auto fn_av_packet_alloc = reinterpret_cast<av_packet_alloc_function>(DynamicLibraries::instance()->resolve("av_packet_alloc", true));
+    auto fn_av_frame_alloc = reinterpret_cast<av_frame_alloc_function>(DynamicLibraries::instance()->resolve("av_frame_alloc", true));
+    auto fn_av_read_frame = reinterpret_cast<av_read_frame_function>(DynamicLibraries::instance()->resolve("av_read_frame", true));
+    auto fn_av_packet_unref = reinterpret_cast<av_packet_unref_function>(DynamicLibraries::instance()->resolve("av_packet_unref", true));
+    auto fn_av_frame_free = reinterpret_cast<av_frame_free_function>(DynamicLibraries::instance()->resolve("av_frame_free", true));
+    auto fn_av_packet_free = reinterpret_cast<av_packet_free_function>(DynamicLibraries::instance()->resolve("av_packet_free", true));
+    auto fn_av_rescale_rnd = reinterpret_cast<av_rescale_rnd_function>(DynamicLibraries::instance()->resolve("av_rescale_rnd", true));
+    auto fn_av_samples_alloc = reinterpret_cast<av_samples_alloc_function>(DynamicLibraries::instance()->resolve("av_samples_alloc", true));
+    auto fn_av_freep = reinterpret_cast<av_freep_function>(DynamicLibraries::instance()->resolve("av_freep", true));
+    auto fn_av_channel_layout_default = reinterpret_cast<av_channel_layout_default_function>(DynamicLibraries::instance()->resolve("av_channel_layout_default", true));
+    auto fn_swr_alloc_set_opts2 = reinterpret_cast<swr_alloc_set_opts2_function>(DynamicLibraries::instance()->resolve("swr_alloc_set_opts2", true));
+    auto fn_swr_init = reinterpret_cast<swr_init_function>(DynamicLibraries::instance()->resolve("swr_init", true));
+    auto fn_swr_convert = reinterpret_cast<swr_convert_function>(DynamicLibraries::instance()->resolve("swr_convert", true));
+    auto fn_swr_get_delay = reinterpret_cast<swr_get_delay_function>(DynamicLibraries::instance()->resolve("swr_get_delay", true));
+    auto fn_swr_free = reinterpret_cast<swr_free_function>(DynamicLibraries::instance()->resolve("swr_free", true));
 
-    AVFormatContext *pFormatCtx = format_alloc_context();
-    int ret = format_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr);
+    if (!fn_swr_alloc_set_opts2 || !fn_swr_init || !fn_swr_convert || !fn_av_rescale_rnd
+        || !fn_av_samples_alloc || !fn_av_freep || !fn_av_channel_layout_default) {
+        qCCritical(dmMusic) << "Failed to resolve swresample functions, cannot generate waveform";
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
 
+    AVFormatContext *pFormatCtx = fn_avformat_alloc_context();
+    int ret = fn_avformat_open_input(&pFormatCtx, path.toStdString().c_str(), nullptr, nullptr);
     if (pFormatCtx == nullptr || ret != 0) {
         qCCritical(dmMusic) << "Failed to open input format context for file:" << path << "error code:" << ret;
-        format_free_context(pFormatCtx);
+        fn_avformat_free_context(pFormatCtx);
         m_curPath.clear();
         m_curHash.clear();
         return;
     }
 
     qCDebug(dmMusic) << "Successfully opened format context for file:" << path;
-    ret = format_find_stream_info(pFormatCtx, nullptr);
+
+    ret = fn_avformat_find_stream_info(pFormatCtx, nullptr);
     if (ret < 0) {
         qCWarning(dmMusic) << "Failed to find stream info for file:" << path << "error code:" << ret;
     }
 
-    int audio_stream_index = -1;
-    audio_stream_index = find_best_stream(pFormatCtx, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
-    if (audio_stream_index < 0) {
+    int audioIdx = fn_av_find_best_stream(pFormatCtx, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
+    if (audioIdx < 0) {
         qCWarning(dmMusic) << "No audio stream found in file:" << path;
-        format_close_input(&pFormatCtx);
-        format_free_context(pFormatCtx);
+        fn_avformat_close_input(&pFormatCtx);
+        fn_avformat_free_context(pFormatCtx);
         m_curPath.clear();
         m_curHash.clear();
         return;
     }
 
-    qCDebug(dmMusic) << "Found audio stream at index:" << audio_stream_index << "for file:" << path;
+    qCDebug(dmMusic) << "Found audio stream at index:" << audioIdx << "for file:" << path;
 
-    AVStream *in_stream = pFormatCtx->streams[audio_stream_index];
-    AVCodecParameters *in_codecpar = in_stream->codecpar;
+    AVCodecParameters *codecpar = pFormatCtx->streams[audioIdx]->codecpar;
+    AVCodecContext *codecCtx = fn_avcodec_alloc_context3(nullptr);
+    fn_avcodec_parameters_to_context(codecCtx, codecpar);
 
-    AVCodecContext *pCodecCtx = codec_alloc_context3(nullptr);
-    codec_parameters_to_context(pCodecCtx, in_codecpar);
-
-    AVCodec *pCodec = codec_find_decoder(pCodecCtx->codec_id);
-    if (pCodec == nullptr) {
-        qCCritical(dmMusic) << "Failed to find decoder for codec ID:" << pCodecCtx->codec_id << "in file:" << path;
-        codec_free_context(&pCodecCtx);
-        format_close_input(&pFormatCtx);
-        format_free_context(pFormatCtx);
+    const AVCodec *codec = fn_avcodec_find_decoder(codecCtx->codec_id);
+    if (!codec) {
+        qCCritical(dmMusic) << "Failed to find decoder for codec ID:" << codecCtx->codec_id << "in file:" << path;
+        fn_avcodec_free_context(&codecCtx);
+        fn_avformat_close_input(&pFormatCtx);
+        fn_avformat_free_context(pFormatCtx);
         m_curPath.clear();
         m_curHash.clear();
         return;
     }
-    
-    ret = codec_open2(pCodecCtx, pCodec, nullptr);
-    if (ret < 0) {
-        qCCritical(dmMusic) << "Failed to open codec for file:" << path << "error code:" << ret;
-        codec_free_context(&pCodecCtx);
-        format_close_input(&pFormatCtx);
-        format_free_context(pFormatCtx);
+
+    if (fn_avcodec_open2(codecCtx, codec, nullptr) < 0) {
+        qCCritical(dmMusic) << "Failed to open codec for file:" << path;
+        fn_avcodec_free_context(&codecCtx);
+        fn_avformat_close_input(&pFormatCtx);
+        fn_avformat_free_context(pFormatCtx);
         m_curPath.clear();
         m_curHash.clear();
         return;
@@ -170,63 +183,98 @@ void AudioDataDetector::run()
 
     qCDebug(dmMusic) << "Successfully initialized codec for file:" << path;
 
-    AVPacket *packet = packet_alloc();
-    AVFrame *frame = frame_alloc();
+    AVChannelLayout outLayout;
+    fn_av_channel_layout_default(&outLayout, 1);
+
+    SwrContext *swr = nullptr;
+    if (fn_swr_alloc_set_opts2(&swr,
+            &outLayout, AV_SAMPLE_FMT_FLT, 44100,
+            &codecCtx->ch_layout, codecCtx->sample_fmt, codecCtx->sample_rate,
+            0, nullptr) < 0
+        || fn_swr_init(swr) < 0) {
+        qCCritical(dmMusic) << "Failed to init SwrContext for:" << path;
+        if (swr) fn_swr_free(&swr);
+        fn_avcodec_free_context(&codecCtx);
+        fn_avformat_close_input(&pFormatCtx);
+        fn_avformat_free_context(pFormatCtx);
+        m_curPath.clear();
+        m_curHash.clear();
+        return;
+    }
+
+    AVPacket *packet = fn_av_packet_alloc();
+    AVFrame *frame = fn_av_frame_alloc();
 
     QVector<float> curData;
+    const int grainSize = 256;
+    float currentPeak = 0;
+    int count = 0;
 
-    while (read_frame(pFormatCtx, packet) >= 0) {
-        if (m_stopFlag && curData.size() > 100) {
+    while (fn_av_read_frame(pFormatCtx, packet) >= 0) {
+        if (m_stopFlag && curData.size() > 10) {
             qCDebug(dmMusic) << "Stop flag detected, cleaning up resources for file:" << path;
-            packet_unref(packet);
-            packet_free(&packet);
-            frame_free(&frame);
-            codec_close(pCodecCtx);
-            codec_free_context(&pCodecCtx);
-            format_close_input(&pFormatCtx);
-            format_free_context(pFormatCtx);
-            resample(curData, hash, true);//刷新波浪条
+            fn_av_packet_unref(packet);
+            fn_av_packet_free(&packet);
+            fn_av_frame_free(&frame);
+            fn_swr_free(&swr);
+            fn_avcodec_free_context(&codecCtx);
+            fn_avformat_close_input(&pFormatCtx);
+            fn_avformat_free_context(pFormatCtx);
+            if (currentPeak > 0) curData.append(currentPeak);
+            resample(curData, hash, true);
             m_stopFlag = false;
             m_curPath.clear();
             m_curHash.clear();
             qCDebug(dmMusic) << "Successfully stopped detection for file:" << path;
             return;
         }
-        
-        if (packet->stream_index == audio_stream_index) {
-            int state;
-            state = codec_send_packet(pCodecCtx, packet);
-            if (state != 0) {
-                continue;
-            }
-            
-            state = codec_receive_frame(pCodecCtx, frame);
-            if (state == 0) {
 
-                quint8 *ptr = frame->extended_data[0];
-                if (path.endsWith(".ape") || path.endsWith(".APE")) {
-                    for (int i = 0; (i + 1) < frame->linesize[0]; i++) {
-                        auto  valDate = ((ptr[i]) << 16 | (ptr[i + 1]));
-                        curData.append(static_cast<float>(valDate) + QRandomGenerator::global()->generate());
-                }
-                } else {
-                    for (int i = 0; (i + 1) < frame->linesize[0]; i += 1024) {
-                        auto  valDate = ((ptr[i]) << 16 | (ptr[i + 1]));
-                        curData.append(valDate);
-                    }
-                }
-            }
+        if (packet->stream_index != audioIdx) {
+            fn_av_packet_unref(packet);
+            continue;
         }
 
-        packet_unref(packet);
+        if (fn_avcodec_send_packet(codecCtx, packet) != 0) {
+            fn_av_packet_unref(packet);
+            continue;
+        }
+
+        while (fn_avcodec_receive_frame(codecCtx, frame) == 0) {
+            int out_samples = fn_av_rescale_rnd(
+                fn_swr_get_delay(swr, frame->sample_rate) + frame->nb_samples,
+                44100, frame->sample_rate, AV_ROUND_UP);
+
+            uint8_t *out_data = nullptr;
+            fn_av_samples_alloc(&out_data, nullptr, 1, out_samples, AV_SAMPLE_FMT_FLT, 0);
+
+            int converted = fn_swr_convert(swr, &out_data, out_samples,
+                (const uint8_t **)frame->data, frame->nb_samples);
+
+            float *floatData = reinterpret_cast<float *>(out_data);
+            for (int i = 0; i < converted; ++i) {
+                float absSample = qAbs(floatData[i]);
+                if (absSample > currentPeak) currentPeak = absSample;
+                if (++count >= grainSize) {
+                    curData.append(currentPeak);
+                    currentPeak = 0;
+                    count = 0;
+                }
+            }
+            fn_av_freep(&out_data);
+        }
+        fn_av_packet_unref(packet);
     }
-    
-    packet_free(&packet);
-    frame_free(&frame);
-    codec_close(pCodecCtx);
-    codec_free_context(&pCodecCtx);
-    format_close_input(&pFormatCtx);
-    format_free_context(pFormatCtx);
+
+    if (currentPeak > 0) curData.append(currentPeak);
+
+    fn_av_packet_free(&packet);
+    fn_av_frame_free(&frame);
+    fn_swr_free(&swr);
+    fn_avcodec_free_context(&codecCtx);
+    fn_avformat_close_input(&pFormatCtx);
+    fn_avformat_free_context(pFormatCtx);
+
+    qCInfo(dmMusic) << "Waveform detection completed for:" << path << "grains:" << curData.size();
     resample(curData, hash);
 }
 
@@ -267,7 +315,7 @@ void AudioDataDetector::onClearBufferDetector()
 void AudioDataDetector::resample(const QVector<float> &buffer, const QString &hash, bool forceQuit)
 {
     qCDebug(dmMusic) << "Resampling audio data for hash:" << hash << "buffer size:" << buffer.size() << "forceQuit:" << forceQuit;
-    
+
     if (buffer.isEmpty()) {
         qCWarning(dmMusic) << "Buffer is empty, cannot resample for hash:" << hash;
         qDebug() << __FUNCTION__ << "buffer size ==" << buffer.size();
@@ -283,59 +331,53 @@ void AudioDataDetector::resample(const QVector<float> &buffer, const QString &ha
         qCDebug(dmMusic) << "Buffer size is small, using original buffer for hash:" << hash;
     } else {
         int num = buffer.size() / 1000;
-        float t_curValue = 0;
         for (int i = 0; i < buffer.size(); i += num) {
-            if (i % num == 0) {
-                t_buffer.append(buffer[i]);
-            }
+            t_buffer.append(buffer[i]);
         }
-        t_buffer.append(t_curValue);
         qCDebug(dmMusic) << "Downsampled buffer from" << buffer.size() << "to" << t_buffer.size() << "for hash:" << hash;
     }
 
-
     if (!t_buffer.isEmpty()) {
         qCDebug(dmMusic) << "Normalizing buffer data for hash:" << hash << "original size:" << t_buffer.size();
-        auto max = *(std::max_element(std::begin(t_buffer), std::end(t_buffer)));
+        float maxAbs = 0;
         for (int i = 0; i < t_buffer.size(); ++i) {
-            float ft = t_buffer[i] / max;
-            ft *= 1000;
-            mappingbuf.append(ft);
-            s_buffer.append(qAbs(t_buffer[i] / max));
+            float absVal = qAbs(t_buffer[i]);
+            if (absVal > maxAbs) maxAbs = absVal;
+        }
+        if (maxAbs > 0) {
+            for (int i = 0; i < t_buffer.size(); ++i) {
+                float normalizedValue = qAbs(t_buffer[i]) / maxAbs;
+                mappingbuf.append(normalizedValue * 1000);
+                s_buffer.append(normalizedValue);
+            }
+        } else {
+            mappingbuf.fill(0, t_buffer.size());
+            s_buffer.fill(0, t_buffer.size());
         }
         qCDebug(dmMusic) << "Normalized buffer data for hash:" << hash;
     }
 
     if (!forceQuit) {
-        QString userCachePath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
-        QString path = userCachePath + "/wave/";
-
-        QDir dir(path);
+        QString dirPath = DmGlobal::cachePath() + "/wave/";
+        QDir dir(dirPath);
         if (!dir.exists()) {
-            qCDebug(dmMusic) << "Creating wave cache directory:" << path;
-            dir.mkdir(path);
+            qCDebug(dmMusic) << "Creating wave cache directory:" << dirPath;
+            dir.mkdir(dirPath);
         }
-        path += QString("%1.dat").arg(hash);
-        qCDebug(dmMusic) << "Writing wave cache to path:" << path;
-        //write cache
-        char *buf = new char[mappingbuf.size() * 4 ];
-        memset(buf, 0, mappingbuf.size() * 4);
-        FILE *fp = fopen(path.toUtf8().data(), "w+");
-        if (fp != nullptr) {
+        QString filePath = dirPath + QString("%1.dat").arg(hash);
+        qCDebug(dmMusic) << "Writing wave cache to path:" << filePath;
+        QFile file(filePath);
+        if (file.open(QIODevice::WriteOnly)) {
             for (int i = 0; i < mappingbuf.size(); i++) {
                 float ss = mappingbuf[i];
-                memcpy(buf + i * 4, &ss, 4);
+                file.write((const char *)&ss, 4);
             }
-
-            fwrite(buf, 4, mappingbuf.size(),  fp);
-            qCInfo(dmMusic) << "Successfully saved audio wave cache for hash:" << hash << "to:" << path;
+            file.close();
+            qCInfo(dmMusic) << "Successfully saved audio wave cache for hash:" << hash << "to:" << filePath;
         } else {
-            qCCritical(dmMusic) << "Failed to write audio wave cache file for hash:" << hash << "path:" << path;
+            qCCritical(dmMusic) << "Failed to write audio wave cache file for hash:" << hash << "path:" << filePath;
             qWarning() << "can not write cache file " << hash << " failed";
         }
-        if (fp)
-            fclose(fp);
-        delete []buf;
     } else {
         qCDebug(dmMusic) << "Force quit mode, skipping cache write for hash:" << hash;
     }
@@ -351,7 +393,7 @@ bool AudioDataDetector::queryCacheExisted(const QString &hash)
         qCDebug(dmMusic) << "Cache file not found and engine type is not FFmpeg, using default data:" << path;
         path = ":/data/default_music.dat";
     }
-    
+
     QFile file(path);
     if (!file.open(QFile::ReadOnly)) {
         qCWarning(dmMusic) << "Failed to open cache file for hash:" << hash << "path:" << path;
@@ -365,16 +407,18 @@ bool AudioDataDetector::queryCacheExisted(const QString &hash)
     qCDebug(dmMusic) << "Found valid cache file for hash:" << hash << "path:" << path << "size:" << file.size();
 
     QVector<float> f_buffer;
-
-    //读取二进制数据
     while (!file.atEnd()) {
         float ss;
-        file.read((char *)&ss, 4);
-        f_buffer << qAbs(ss * 1.0 / 1000);
+        qint64 bytesRead = file.read((char *)&ss, 4);
+        if (bytesRead == 4) {
+            f_buffer << ss / 1000;
+        } else {
+            qCWarning(dmMusic) << "Incomplete float read from wave cache, expected 4 bytes, got" << bytesRead << "for hash:" << hash;
+            break;
+        }
     }
-
     file.close();
-    
+
     qCInfo(dmMusic) << "Successfully loaded audio buffer from cache for hash:" << hash << "buffer size:" << f_buffer.size();
     Q_EMIT audioBuffer(f_buffer, hash);
     return true;

--- a/src/libdmusic/core/dynamiclibraries.cpp
+++ b/src/libdmusic/core/dynamiclibraries.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,10 +11,21 @@
 #include "global.h"
 #include "util/log.h"
 
+#ifdef Q_OS_WIN
+static const QString libvlccoreStr = "libvlccore";
+static const QString libvlcStr = "libvlc";
+static const QString libavcodecStr = "avcodec-62";
+static const QString libavformateStr = "avformat-62";
+static const QString libavutilStr = "avutil-60";
+static const QString libswresampleStr = "swresample-6";
+#else
 static const QString libvlccoreStr = "libvlccore.so";
 static const QString libvlcStr = "libvlc.so";
 static const QString libavcodecStr = "libavcodec.so";
 static const QString libavformateStr = "libavformat.so";
+static const QString libavutilStr = "libavutil.so";
+static const QString libswresampleStr = "libswresample.so";
+#endif
 
 DynamicLibraries::DynamicLibraries()
 {
@@ -36,6 +46,8 @@ DynamicLibraries::~DynamicLibraries()
     vlcLib.unload();
     avcodecLib.unload();
     avformateLib.unload();
+    avutilLib.unload();
+    swresampleLib.unload();
 }
 
 DynamicLibraries *DynamicLibraries::instance()
@@ -56,18 +68,31 @@ QFunctionPointer DynamicLibraries::resolve(const char *symbol, bool ffmpeg)
     if (ffmpeg) {
         qCDebug(dmMusic) << "Resolving ffmpeg symbol:" << symbol;
         QFunctionPointer fgp = avcodecLib.resolve(symbol);
+        if (fgp) {
+            qCDebug(dmMusic) << "[ffmpeg] Resolved from avcodec:" << symbol;
+        }
         if (!fgp) {
-            qCWarning(dmMusic) << "[ffmpeg] Failed to resolve function:" << symbol;
             fgp = avformateLib.resolve(symbol);
-            if (!fgp) {
-                //never get here if obey the rule
-                qCWarning(dmMusic) << "[ffmpeg] resolve function:" << symbol;
-            } else {
-                qCDebug(dmMusic) << "[ffmpeg] Successfully resolved function from avformat:" << symbol;
+            if (fgp) {
+                qCDebug(dmMusic) << "[ffmpeg] Resolved from avformat:" << symbol;
             }
         }
+        if (!fgp) {
+            fgp = avutilLib.resolve(symbol);
+            if (fgp) {
+                qCDebug(dmMusic) << "[ffmpeg] Resolved from avutil:" << symbol;
+            }
+        }
+        if (!fgp) {
+            fgp = swresampleLib.resolve(symbol);
+            if (fgp) {
+                qCDebug(dmMusic) << "[ffmpeg] Resolved from swresample:" << symbol;
+            }
+        }
+        if (!fgp) {
+            qCWarning(dmMusic) << "[ffmpeg] Failed to resolve function:" << symbol;
+        }
         m_funMap[symbol] = fgp;
-        qCDebug(dmMusic) << "Successfully resolved ffmpeg function:" << symbol;
         return fgp;
     }
     //resolve function
@@ -106,6 +131,14 @@ bool DynamicLibraries::loadLibraries()
 
     QString strlibvlc = DmGlobal::libPath(libvlcStr);
     qCDebug(dmMusic) << "Loading VLC library from:" << strlibvlc;
+#ifdef Q_OS_WIN
+    // Make sure we load libvlc.dll, not libvlccore.dll
+    if (strlibvlc.contains("vlccore")) {
+        qCWarning(dmMusic) << "VLC library path contains vlccore, trying exact match";
+        strlibvlc = strlibvlc.left(strlibvlc.lastIndexOf("/")) + "/libvlc.dll";
+        qCDebug(dmMusic) << "Corrected VLC library path to:" << strlibvlc;
+    }
+#endif
     if (QLibrary::isLibrary(strlibvlc)) {
         vlcLib.setFileName(strlibvlc);
         if (!vlcLib.load()) {
@@ -142,6 +175,35 @@ bool DynamicLibraries::loadLibraries()
         qCCritical(dmMusic) << "avformat library path is not valid:" << strlibformate;
         return false;
     }
+
+    QString strlibutil = DmGlobal::libPath(libavutilStr);
+    qCDebug(dmMusic) << "Loading avutil library from:" << strlibutil;
+    if (QLibrary::isLibrary(strlibutil)) {
+        avutilLib.setFileName(strlibutil);
+        if (!avutilLib.load()) {
+            qCCritical(dmMusic) << "Failed to load avutil library:" << avutilLib.errorString();
+            return false;
+        }
+    } else {
+        qCCritical(dmMusic) << "avutil library path is not valid:" << strlibutil;
+        return false;
+    }
+
     qCDebug(dmMusic) << "Successfully loaded all required libraries";
+
+    QString strlibswresample = DmGlobal::libPath(libswresampleStr);
+    qCDebug(dmMusic) << "Loading swresample library from:" << strlibswresample;
+    if (QLibrary::isLibrary(strlibswresample)) {
+        swresampleLib.setFileName(strlibswresample);
+        if (!swresampleLib.load()) {
+            qCWarning(dmMusic) << "Failed to load swresample library:" << swresampleLib.errorString();
+            qCWarning(dmMusic) << "Waveform generation will not be available";
+        } else {
+            qCDebug(dmMusic) << "Successfully loaded swresample library";
+        }
+    } else {
+        qCWarning(dmMusic) << "swresample library path is not valid:" << strlibswresample;
+    }
+
     return true;
 }

--- a/src/libdmusic/core/dynamiclibraries.h
+++ b/src/libdmusic/core/dynamiclibraries.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,6 +22,8 @@ private:
     QLibrary vlcLib;
     QLibrary avcodecLib;
     QLibrary avformateLib;
+    QLibrary avutilLib;
+    QLibrary swresampleLib;
 
     QMap<QString, QFunctionPointer> m_funMap;
 };

--- a/src/music-player/toolbar/WaveformRect.qml
+++ b/src/music-player/toolbar/WaveformRect.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -119,12 +119,12 @@ Rectangle {
                 id: timeLabel
                 width: timeText.width > 50 ? timeText.width + 10 : 50
                 height: 25
-                fillColor: palette.highlight
+                fillColor: DTK.palette.highlight
                 Text {
                     id: timeText
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: mousePressed ?  dragTime : currentTime
-                    color: palette.highlightedText
+                    color: DTK.palette.highlightedText
                     font: DTK.fontManager.t8
                     verticalAlignment: Text.AlignHCenter
                 }
@@ -138,7 +138,7 @@ Rectangle {
             Triangle {
                 width: 10
                 height: 10
-                fillColor: palette.highlight
+                fillColor: DTK.palette.highlight
                 anchors.horizontalCenter: parent.horizontalCenter
             }
         }


### PR DESCRIPTION
- Convert audio to mono float 44100Hz via SwrContext, detect peaks per 256-sample grain
- Adapt to FFmpeg 7.x new channel layout API (swr_alloc_set_opts2 / ch_layout)
- Dynamically load libswresample and add symbol resolution
- Unify waveform cache path to DmGlobal::cachePath()
- Fix normalization to handle negative values correctly with manual maxAbs
- Replace FILE*/fwrite with QFile for cache I/O
- Simplify downsample loop, add bytesRead validation on cache read
- Organize typedefs by library (avformat/avcodec/avutil/swresample)
- Fix WaveformRect palette access (palette -> DTK.palette)

refactor: 使用 swr_convert 重写波形生成逻辑

- 使用 SwrContext 将音频统一转为 mono float 44100Hz，按 256 采样粒度取峰值
- 适配 FFmpeg 7.x 新版 channel layout API（swr_alloc_set_opts2 / ch_layout）
- 动态加载 libswresample 库并添加符号解析
- 波形缓存路径统一使用 DmGlobal::cachePath()
- 归一化改为手动计算 maxAbs，正确处理负值
- 文件 I/O 从 FILE*/fwrite 统一为 QFile
- 简化降采样循环，增加缓存读取校验
- typedef 按 avformat/avcodec/avutil/swresample 分组整理
- 修复 WaveformRect 调色板访问（palette -> DTK.palette）


修改后的波形图就比较符合真正的波形图了

<img width="1268" height="548" src="https://github.com/user-attachments/assets/bf0cb461-fc7c-40d3-a69b-4b66e7201bfc" />


验证方法：`ffmpeg -i input.mp3 -filter_complex "showwavespic=s=640x240" -frames:v 1 output.png`

## Summary by Sourcery

Refactor audio waveform generation to use FFmpeg’s swresample for mono float 44.1kHz peak detection and improve cache handling and visuals.

New Features:
- Generate audio waveforms by converting all input audio to mono float 44100Hz using SwrContext and detecting peaks per fixed sample grain.

Bug Fixes:
- Normalize waveform amplitudes using absolute maximum values so negative samples are handled correctly.
- Fix waveform cache loading by validating read sizes and using the raw cached values instead of re-applying absolute scaling.
- Correct QML waveform time label and marker colors to use DTK.palette instead of the generic palette.

Enhancements:
- Dynamically load libavutil and libswresample and extend FFmpeg symbol resolution across avcodec, avformat, avutil, and swresample.
- Adapt audio channel layout handling to FFmpeg 7.x APIs including AVChannelLayout and swr_alloc_set_opts2.
- Simplify waveform downsampling and normalization logic to produce more accurate, visually representative waveforms.
- Switch waveform cache I/O from C stdio (FILE*/fwrite) to QFile and unify cache directory to DmGlobal::cachePath().
- Improve logging and early-exit behavior when FFmpeg or swresample functions cannot be resolved or waveform generation is unavailable.

Chores:
- Update SPDX copyright year ranges across affected source files.