### PR TITLE
fix: hide prev/next page tooltip in lyric view

### DIFF
--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -136,7 +136,7 @@ TitleBar {
         height: width
         x: 240
         y: 7
-        visible: preMaskVisible
+        visible: preMaskVisible && !isLyricShow
         color: "transparent"
 
         MouseArea {
@@ -157,7 +157,7 @@ TitleBar {
         height: preMask.width
         x: 286
         y: 7
-        visible: nextMaskVisible
+        visible: nextMaskVisible && !isLyricShow
         color: "transparent"
 
         MouseArea {


### PR DESCRIPTION
fix: 修复歌词界面分页按钮 tooltip 仍然显示的问题

<img width="1086" height="719" src="https://github.com/user-attachments/assets/58bfd128-31c8-459f-ad9a-569f81ec8d57" />

## Summary by Sourcery

Bug Fixes:
- Hide previous and next page tooltip areas when lyrics view is active to avoid unintended tooltip display.