### PR TITLE
fix: adapt dynamic library loading for Windows (MSYS2/MinGW)

### DIFF
--- a/src/libdmusic/global.cpp
+++ b/src/libdmusic/global.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +11,7 @@
 #include <QDir>
 #include <QDebug>
 #include <QLibrary>
+#include <QCoreApplication>
 
 #include <DStandardPaths>
 
@@ -155,26 +155,47 @@ bool DmGlobal::isWaylandMode()
 QString DmGlobal::libPath(const QString &strlib)
 {
     QDir dir;
-    QString path = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
-    dir.setPath(path);
-    QStringList list = dir.entryList(QStringList() << (strlib + "*"), QDir::NoDotAndDotDot | QDir::Files);
+    QStringList searchPaths;
+    
+#ifdef Q_OS_WIN
+    // Windows 下先查找应用程序所在目录
+    searchPaths << QCoreApplication::applicationDirPath();
+#endif
+    
+    searchPaths << QLibraryInfo::path(QLibraryInfo::LibrariesPath);
+    
     QString libPath;
     
-    qCDebug(dmMusic) << "Searching for library:" << strlib << "in path:" << path;
+    qCDebug(dmMusic) << "Searching for library:" << strlib << "in paths:" << searchPaths;
     
-    if (list.contains(strlib)) {
-        libPath = path + "/" + strlib;
-        qCDebug(dmMusic) << "Found exact library match:" << libPath;
-    } else {
-        list.sort();
-        for (int i = list.size() - 1; i >= 0; i--) {
-            if (list[i].contains(".so")) {
-                libPath = path + "/" + list[i];
-                qCDebug(dmMusic) << "Found compatible library:" << libPath;
-                break;
+    for (const QString &path : searchPaths) {
+        dir.setPath(path);
+        if (!dir.exists()) {
+            continue;
+        }
+        
+        QStringList list = dir.entryList(QStringList() << (strlib + "*"), QDir::NoDotAndDotDot | QDir::Files);
+        
+        if (list.contains(strlib)) {
+            libPath = path + "/" + strlib;
+            qCDebug(dmMusic) << "Found exact library match:" << libPath;
+            return libPath;
+        } else {
+            list.sort();
+            for (int i = list.size() - 1; i >= 0; i--) {
+#ifdef Q_OS_WIN
+                if (list[i].contains(".dll")) {
+#else
+                if (list[i].contains(".so")) {
+#endif
+                    libPath = path + "/" + list[i];
+                    qCDebug(dmMusic) << "Found compatible library:" << libPath;
+                    return libPath;
+                }
             }
         }
     }
+    
     if (libPath.isEmpty()) {
         qCWarning(dmMusic) << "Library not found in standard paths, using default:" << strlib;
         libPath = strlib;
@@ -187,10 +208,14 @@ bool DmGlobal::libExist(const QString &strlib)
 {
     // find all library paths by QLibrary
     QString libName;
+#ifdef Q_OS_WIN
+    libName = strlib;
+#else
     if (strlib.contains(".so"))
         libName = strlib.mid(0, strlib.indexOf(".so"));
     else
         libName = strlib;
+#endif
         
     qCDebug(dmMusic) << "Checking existence of library:" << libName;
     
@@ -215,12 +240,21 @@ void DmGlobal::initPlaybackEngineType()
 {
     qCDebug(dmMusic) << "Initializing playback engine";
     engineType = 0;
+#ifdef Q_OS_WIN
+    if (libExist("libvlc") && libExist("avcodec-62")) {
+        engineType = 1;
+        qCInfo(dmMusic) << "Windows: VLC playback engine initialized successfully";
+    } else {
+        qCInfo(dmMusic) << "Windows: VLC not available, using QtPlayer engine";
+    }
+#else
     if (libExist("libvlc.so") && libExist("libavcodec.so")) {
         engineType = 1;
         qCInfo(dmMusic) << "VLC playback engine initialized successfully";
     } else {
         qCWarning(dmMusic) << "Failed to initialize VLC playback engine, falling back to default";
     }
+#endif
 }
 
 void DmGlobal::setPlaybackEngineType(int type)


### PR DESCRIPTION
- Add Windows DLL names (libvlc.dll, avcodec-62, avformat-62, avutil-60)
- Add avutil library loading support
- Fix VLC library path correction on Windows (avoid loading vlccore)
- Improve library search to support multiple paths and .dll suffix
- Add application directory as first search path on Windows
- Update libExist() for Windows compatibility

fix: 适配动态库加载以支持 Windows（MSYS2/MinGW）

- 添加 Windows DLL 名称（libvlc.dll、avcodec-62、avformat-62、avutil-60）
- 添加 avutil 库加载支持
- 修正 Windows 上 VLC 库路径（避免加载 vlccore）
- 改进库搜索以支持多路径和 .dll 后缀
- 在 Windows 上将应用程序目录作为首选搜索路径
- 更新 libExist() 以兼容 Windows

## Summary by Sourcery

Adapt dynamic library loading to correctly support VLC/FFmpeg on Windows (MSYS2/MinGW) while keeping Linux behavior intact.

New Features:
- Add dynamic loading support for avutil and swresample libraries alongside existing VLC/FFmpeg libraries.
- Enable VLC playback engine initialization on Windows using native DLL names and paths.

Bug Fixes:
- Correct VLC library path resolution on Windows to avoid accidentally loading libvlccore instead of libvlc.
- Fix library existence checks and name handling so they work properly with Windows DLLs as well as Linux shared objects.

Enhancements:
- Improve cross-platform library search to handle multiple lookup paths, including the application directory on Windows, and platform-specific file suffixes.
- Extend FFmpeg symbol resolution to try avcodec, avformat, avutil, and swresample in order, with clearer logging of resolution failures and successes.