### PR TITLE
fix: adapt VLC player components for Windows platform

### DIFF
--- a/src/libdmusic/player/vlc/Instance.cpp
+++ b/src/libdmusic/player/vlc/Instance.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <QtCore/QDebug>
 #include <QtCore/QStringList>
+#include <QCoreApplication>
+#include <QDir>
 
 #include <vlc/vlc.h>
 
@@ -29,12 +30,20 @@ void logCallback(void *data,
     }
 
     char *result;
+#ifdef Q_OS_WIN
+    char buf[4096];
+    if (vsnprintf(buf, sizeof(buf), fmt, args) < 0) {
+        return;
+    }
+    QString message(buf);
+#else
     if (vasprintf(&result, fmt, args) < 0) {
         return; // LCOV_EXCL_LINE
     }
 
     QString message(result);
     free(result);
+#endif
 
     message.prepend("VlcInstance  libvlc: ");
     switch (level) {
@@ -82,15 +91,23 @@ VlcInstance::VlcInstance(const QStringList &args,
     vlc_set_app_id_function vlc_set_app_id = (vlc_set_app_id_function)DynamicLibraries::instance()->resolve("libvlc_set_app_id");
     vlc_log_set_function vlc_log_set = (vlc_log_set_function)DynamicLibraries::instance()->resolve("libvlc_log_set");
 
+#ifdef Q_OS_WIN
+    // Set VLC plugin path on Windows
+    QString pluginPath = QCoreApplication::applicationDirPath() + "/plugins/vlc";
+    if (QDir(pluginPath).exists()) {
+        qputenv("VLC_PLUGIN_PATH", pluginPath.toUtf8());
+        qCDebug(dmMusic) << "VLC plugin path set to:" << pluginPath;
+    }
+#endif
+
     _vlcInstance = vlc_new(0, nullptr);
     if (_vlcInstance) {
         qCDebug(dmMusic) << "VLC instance created successfully";
+        vlc_set_user_agent(_vlcInstance, DmGlobal::getAppName().toStdString().c_str(), "");//name
+        vlc_set_app_id(_vlcInstance, "", "", "deepin-music");//icon
     } else {
         qCCritical(dmMusic) << "Failed to create VLC instance";
     }
-
-    vlc_set_user_agent(_vlcInstance, DmGlobal::getAppName().toStdString().c_str(), "");//name
-    vlc_set_app_id(_vlcInstance, "", "", "deepin-music");//icon
 
     qRegisterMetaType<Vlc::Meta>("Vlc::Meta");
     qRegisterMetaType<Vlc::State>("Vlc::State");

--- a/src/libdmusic/player/vlc/MediaPlayer.cpp
+++ b/src/libdmusic/player/vlc/MediaPlayer.cpp
@@ -1,7 +1,10 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifdef Q_OS_WIN
+#include <winsock2.h>
+#endif
 
 #include <vlc/vlc.h>
 #include <vlc_common.h>
@@ -74,6 +77,14 @@ VlcMediaPlayer::VlcMediaPlayer(VlcInstance *instance)
     vlc_media_player_event_manager_function vlc_media_player_event_manager = (vlc_media_player_event_manager_function)DynamicLibraries::instance()->resolve("libvlc_media_player_event_manager");
     config_PutInt_func config_PutInt_fc = (config_PutInt_func)DynamicLibraries::instance()->resolve("config_PutInt");
     var_SetChecked_func var_SetChecked_fc = (var_SetChecked_func)DynamicLibraries::instance()->resolve("var_SetChecked");
+
+    if (!instance->core()) {
+        qCCritical(dmMusic) << "VlcMediaPlayer: VlcInstance core is null, cannot create media player";
+        _vlcMediaPlayer = nullptr;
+        _vlcEvents = nullptr;
+        _vlcEqualizer = nullptr;
+        return;
+    }
 
     _vlcMediaPlayer = vlc_media_player_new(instance->core());
     _vlcEvents = vlc_media_player_event_manager(_vlcMediaPlayer);

--- a/src/libdmusic/player/vlc/sdlplayer.cpp
+++ b/src/libdmusic/player/vlc/sdlplayer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "sdlplayer.h"
+#include <cmath>
 
 #ifdef __cplusplus
 extern "C" {
@@ -105,6 +106,7 @@ SdlPlayer::SdlPlayer(VlcInstance *instance)
     : VlcMediaPlayer(instance), m_loadSdlLibrary(false)
 {
     qCDebug(dmMusic) << "Initializing SDL player";
+#ifdef Q_OS_LINUX
     m_loadSdlLibrary = VlcDynamicInstance::VlcFunctionInstance()->loadSdlLibrary();
     if (m_loadSdlLibrary) {
         qCDebug(dmMusic) << "SDL library loaded successfully, initializing SDL audio";
@@ -116,8 +118,14 @@ SdlPlayer::SdlPlayer(VlcInstance *instance)
         if (Init(SDL_INIT_AUDIO) < 0) {
             qCWarning(dmMusic) << "SDL_Init(AUDIO) returned non-zero; continuing but audio may not work";
         }
-        vlc_audio_set_callbacks(_vlcMediaPlayer, libvlc_audio_play_cb, libvlc_audio_pause_cb, libvlc_audio_resume_cb, libvlc_audio_flush_cb, nullptr, this);
-        vlc_audio_set_format_callbacks(_vlcMediaPlayer, libvlc_audio_setup_cb, nullptr);
+        if (vlc_audio_set_callbacks && vlc_audio_set_format_callbacks) {
+            qCDebug(dmMusic) << "Registering audio callbacks on _vlcMediaPlayer:" << _vlcMediaPlayer;
+            vlc_audio_set_callbacks(_vlcMediaPlayer, libvlc_audio_play_cb, libvlc_audio_pause_cb, libvlc_audio_resume_cb, libvlc_audio_flush_cb, nullptr, this);
+            vlc_audio_set_format_callbacks(_vlcMediaPlayer, libvlc_audio_setup_cb, nullptr);
+            qCDebug(dmMusic) << "Audio callbacks registered successfully";
+        } else {
+            qCCritical(dmMusic) << "Failed to resolve audio callback functions";
+        }
 
         //设置日志回调等级
         LogSetPriority(SDL_LOG_CATEGORY_AUDIO, SDL_LOG_PRIORITY_ERROR);
@@ -132,11 +140,15 @@ SdlPlayer::SdlPlayer(VlcInstance *instance)
     } else {
         qCWarning(dmMusic) << "Failed to load SDL library";
     }
+#else
+    qCDebug(dmMusic) << "Windows platform: using VLC default audio output, skipping SDL initialization";
+#endif
 }
 
 SdlPlayer::~SdlPlayer()
 {
     qCDebug(dmMusic) << "Cleaning up SDL player";
+#ifdef Q_OS_LINUX
     if (m_loadSdlLibrary) {
         SDL_Quit_function Quit = (SDL_Quit_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_Quit");
         Quit();
@@ -145,6 +157,7 @@ SdlPlayer::~SdlPlayer()
         while (m_pCheckDataThread->isRunning()) {}
         qCDebug(dmMusic) << "Check data thread stopped";
     }
+#endif
 }
 
 void SdlPlayer::open(VlcMedia *media)
@@ -156,6 +169,7 @@ void SdlPlayer::open(VlcMedia *media)
         return;
     }
 
+#ifdef Q_OS_LINUX
     if (m_loadSdlLibrary) {
         qCDebug(dmMusic) << "Preparing SDL audio for new media";
         SDL_GetAudioStatus_function GetAudioStatus = (SDL_GetAudioStatus_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_GetAudioStatus");
@@ -189,9 +203,14 @@ void SdlPlayer::open(VlcMedia *media)
 
         m_sinkInputPath.clear();
     }
+#endif
 
     VlcMediaPlayer::open(media);
+    
+#ifdef Q_OS_LINUX
     g_playbackStatus = PLAYBACK_STATUS_INIT;
+#endif
+    
     qCDebug(dmMusic) << "Media opened successfully";
 }
 
@@ -202,13 +221,18 @@ void SdlPlayer::play()
         return;
     }
     qCDebug(dmMusic) << "Starting playback";
+#ifdef Q_OS_LINUX
+    setProgressTag(0); // resume - allow audio processing
+#endif
     VlcMediaPlayer::play();
+#ifdef Q_OS_LINUX
     if (m_loadSdlLibrary) {
         if (!m_pCheckDataThread->isRunning()) {
             m_pCheckDataThread->start();
             qCDebug(dmMusic) << "Started check data thread";
         }
     }
+#endif
 }
 
 void SdlPlayer::pause()
@@ -218,7 +242,8 @@ void SdlPlayer::pause()
         return;
     }
     qCDebug(dmMusic) << "Pausing playback";
-    setProgressTag(0); //first start
+#ifdef Q_OS_LINUX
+    setProgressTag(1); // pause - stop audio processing
 
     if (m_loadSdlLibrary) {
         SDL_GetAudioStatus_function GetAudioStatus = (SDL_GetAudioStatus_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_GetAudioStatus");
@@ -228,6 +253,7 @@ void SdlPlayer::pause()
             qCDebug(dmMusic) << "Audio paused";
         }
     }
+#endif
 
     VlcMediaPlayer::pause();
 }
@@ -240,6 +266,7 @@ void SdlPlayer::resume()
     }
     qCDebug(dmMusic) << "Resuming playback";
     VlcMediaPlayer::resume();
+#ifdef Q_OS_LINUX
     if (m_loadSdlLibrary) {
         SDL_GetAudioStatus_function GetAudioStatus = (SDL_GetAudioStatus_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_GetAudioStatus");
         SDL_PauseAudio_function PauseAudio = (SDL_PauseAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_PauseAudio");
@@ -259,6 +286,7 @@ void SdlPlayer::resume()
             qCDebug(dmMusic) << "Audio resumed";
         }
     }
+#endif
 }
 
 void SdlPlayer::stop()
@@ -269,6 +297,7 @@ void SdlPlayer::stop()
     }
     qCDebug(dmMusic) << "Stopping playback";
     VlcMediaPlayer::stop();
+#ifdef Q_OS_LINUX
     if (m_loadSdlLibrary) {
         cleanMemCache();
         SDL_PauseAudio_function PauseAudio = (SDL_PauseAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_PauseAudio");
@@ -292,40 +321,59 @@ void SdlPlayer::stop()
             qCDebug(dmMusic) << "Closed audio device";
         }
     }
+#endif
 }
 
 int SdlPlayer::getVolume()
 {
+#ifdef Q_OS_LINUX
     return m_loadSdlLibrary ? m_volume : VlcMediaPlayer::getVolume();
+#else
+    return VlcMediaPlayer::getVolume();
+#endif
 }
 
 bool SdlPlayer::getMute()
 {
+#ifdef Q_OS_LINUX
     return m_loadSdlLibrary ? m_mute : VlcMediaPlayer::getMute();
+#else
+    return VlcMediaPlayer::getMute();
+#endif
 }
 
 void SdlPlayer::setTime(qint64 time)
 {
     VlcMediaPlayer::setTime(time);
+#ifdef Q_OS_LINUX
     cleanMemCache(); //clear data when seek
+#endif
 }
 
 void SdlPlayer::setVolume(int volume)
 {
+#ifdef Q_OS_LINUX
     if (m_loadSdlLibrary) {
         m_volume = volume;
     } else {
         VlcMediaPlayer::setVolume(volume);
     }
+#else
+    VlcMediaPlayer::setVolume(volume);
+#endif
 }
 
 void SdlPlayer::setMute(bool mute)
 {
+#ifdef Q_OS_LINUX
     if (m_loadSdlLibrary)
         m_mute = mute;
     else {
         VlcMediaPlayer::setMute(mute);
     }
+#else
+    VlcMediaPlayer::setMute(mute);
+#endif
 }
 
 void SdlPlayer::checkDataZero()
@@ -393,6 +441,10 @@ void SdlPlayer::libvlc_audio_play_cb(void *data, const void *samples, unsigned c
     QByteArray ba(curSamples, static_cast<int>(size));
     QMutexLocker locker(&vlc_mutex);
     sdlMediaPlayer->_data.append(ba);
+    locker.unlock();
+
+    QByteArray pcmData(static_cast<const char *>(samples), static_cast<int>(count * srcChannels * bytesPerSample));
+    emit sdlMediaPlayer->audioDataReady(pcmData);
 }
 
 void SdlPlayer::libvlc_audio_pause_cb(void *data, int64_t pts)
@@ -429,7 +481,6 @@ int SdlPlayer::libvlc_audio_setup_cb(void **data, char *format, unsigned *rate, 
     SDL_Delay_function Delay = (SDL_Delay_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_Delay");
     SDL_OpenAudio_function OpenAudio = (SDL_OpenAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_OpenAudio");
     SDL_CloseAudio_function CloseAudio = (SDL_CloseAudio_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSdlSymbol("SDL_CloseAudio");
-    av_log2_function Log2 = (av_log2_function)VlcDynamicInstance::VlcFunctionInstance()->resolveSymbol("av_log2", true);
 
     // 防御性编程：先检查data指针有效性，再解引用
     if (!data) {
@@ -458,7 +509,7 @@ int SdlPlayer::libvlc_audio_setup_cb(void **data, char *format, unsigned *rate, 
     desiredAS.format = format_from_vlc_to_SDL(format);
     desiredAS.channels = static_cast<uint8_t>(sdlMediaPlayer->_channels);
     desiredAS.silence = 0;
-    desiredAS.samples = FFMAX(AUDIO_MIN_BUFFER_SIZE, 2 << Log2(desiredAS.freq / AUDIO_MAX_CALLBACKS_PER_SEC));
+    desiredAS.samples = qMax(AUDIO_MIN_BUFFER_SIZE, 2 << static_cast<int>(std::log2(desiredAS.freq / AUDIO_MAX_CALLBACKS_PER_SEC)));
     desiredAS.callback = SDL_audio_cbk;
     desiredAS.userdata = sdlMediaPlayer;
 

--- a/src/libdmusic/player/vlc/sdlplayer.h
+++ b/src/libdmusic/player/vlc/sdlplayer.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -115,6 +114,9 @@ public slots:
         \brief set progress flag when play
     */
     void setProgressTag(int prog = -1);
+
+signals:
+    void audioDataReady(const QByteArray &data);
 
 private:
     static void libvlc_audio_play_cb(void *data, const void *samples,

--- a/src/libdmusic/player/vlcplayer.cpp
+++ b/src/libdmusic/player/vlcplayer.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -50,6 +49,12 @@ void VlcPlayer::init()
     if (m_qvinstance == nullptr) {
         qCDebug(dmMusic) << "Creating VLC instance and initializing components";
         m_qvinstance = new VlcInstance(VlcCommon::args(), nullptr);
+        if (!m_qvinstance->core()) {
+            qCCritical(dmMusic) << "VLC instance core is null, cannot create media player";
+            delete m_qvinstance;
+            m_qvinstance = nullptr;
+            return;
+        }
         m_qvinstance->version();
         m_qvplayer = new SdlPlayer(m_qvinstance);
         m_qvplayer->equalizer()->setPreamplification(12);
@@ -84,6 +89,7 @@ void VlcPlayer::init()
             qCDebug(dmMusic) << "Current track playback ended";
             emit end();
         });
+        connect(m_qvplayer, &SdlPlayer::audioDataReady, this, &PlayerBase::audioDataReady);
         initCdaThread();
     }
 }
@@ -231,7 +237,9 @@ void VlcPlayer::setMediaMeta(MediaMeta meta)
     m_qvplayer->open(m_qvmedia);
     m_qvplayer->setCurMeta(meta);
     emit metaChanged();
+#ifdef Q_OS_LINUX
     malloc_trim(0);
+#endif
 }
 
 void VlcPlayer::setFadeInOutFactor(double fadeInOutFactor)
@@ -285,7 +293,9 @@ void VlcPlayer::setVolume(int volume)
     init();
     qCDebug(dmMusic) << "Setting volume to:" << volume;
     m_volume = volume;
-    m_qvplayer->setVolume(volume);
+    if (m_qvplayer) {
+        m_qvplayer->setVolume(volume);
+    }
 }
 
 int VlcPlayer::getVolume()
@@ -298,7 +308,9 @@ void VlcPlayer::setMute(bool value)
 {
     init();
     qCDebug(dmMusic) << "Setting mute state to:" << value;
-    m_qvplayer->setMute(value);
+    if (m_qvplayer) {
+        m_qvplayer->setMute(value);
+    }
 }
 
 void VlcPlayer::initCddaTrack()
@@ -349,6 +361,10 @@ QList<MediaMeta> VlcPlayer::getCdaMetaInfo()
 
 bool VlcPlayer::getMute()
 {
+    if (!m_qvplayer) {
+        qCWarning(dmMusic) << "VLC player not initialized, returning default mute state";
+        return false;
+    }
     bool muted = m_qvplayer->getMute();
     qCDebug(dmMusic) << "Current mute state:" << muted;
     return muted;


### PR DESCRIPTION
- Replace vasprintf with vsnprintf for Windows compatibility (Instance.cpp)
- Add VLC plugin path setup on Windows
- Add winsock2.h include for Windows (MediaPlayer.cpp)
- Add instance core null check before creating media player
- Conditionalize SDL initialization and callbacks for Linux only
- Replace av_log2 with std::log2 for portability
- Add null safety checks for m_qvplayer operations
- Conditionalize malloc_trim call for Linux only

fix: 适配 VLC 播放器组件以支持 Windows 平台

- 使用 vsnprintf 替代 vasprintf 以兼容 Windows（Instance.cpp）
- 在 Windows 上添加 VLC 插件路径设置
- 在 Windows 上添加 winsock2.h 包含（MediaPlayer.cpp）
- 在创建媒体播放器前添加实例核心空值检查
- 将 SDL 初始化和回调条件化为仅 Linux
- 使用 std::log2 替代 av_log2 以提高可移植性
- 为 m_qvplayer 操作添加空值安全检查
- 将 malloc_trim 调用条件化为仅 Linux

## Summary by Sourcery

Adapt VLC-based music player components for cross-platform support with improved Windows compatibility and safer initialization.

New Features:
- Expose an audioDataReady signal from SdlPlayer and forward it from VlcPlayer to PlayerBase for PCM audio data handling.
- Configure VLC plugin search path on Windows using the application directory.

Bug Fixes:
- Guard media player creation against a null VLC instance core to avoid crashes.
- Add null-safety checks around m_qvplayer usage when setting volume and mute and when querying mute state.
- Ensure Windows builds include winsock2 before VLC headers to resolve networking-related compilation or runtime issues.
- Replace vasprintf with vsnprintf on Windows and av_log2 with std::log2 to fix portability and build issues across platforms.

Enhancements:
- Limit SDL-based audio initialization, callbacks, and related logic to Linux, using VLC default audio output on other platforms.
- Improve SDL audio callback robustness by checking resolved function pointers, emitting audio data, and adjusting progress tags for play/pause states.
- Apply Linux-only guards around malloc_trim and SDL-specific cache cleanup to avoid non-portable calls.
- Update SPDX copyright headers for VLC-related player components.