### PR TITLE
fix: adapt main.cpp for Windows environment setup

### DIFF
--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,17 +9,27 @@
 #include <QIcon>
 #include <QDBusInterface>
 #include <QDBusReply>
+#include <QFileInfo>
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <QSharedMemory>
+#endif
 
 #include <DLog>
 #include <DGuiApplicationHelper>
 #include <QGuiApplication>
 #include <QSurfaceFormat>
+#include <QWindow>
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef Q_OS_LINUX
 #include <signal.h>
 #include <unistd.h>
+#endif
 
 #include "config.h"
 
@@ -37,29 +46,63 @@ DGUI_USE_NAMESPACE;
 
 QScopedPointer<Presenter, QScopedPointerPodDeleter> presenter;
 
+#ifdef Q_OS_LINUX
 void sig_term_handler(int signum, siginfo_t *info, void *ptr)
 {
     qDebug() << "SIGTERM received.";
     presenter->saveDataToDB();
     exit(1);
 }
+#endif
 
 // 此文件是QML应用的启动文件，一般无需修改
 int main(int argc, char *argv[])
 {
     qCDebug(dmMusic) << "main start";
+#ifdef Q_OS_LINUX
     if (!QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")) {
         qCDebug(dmMusic) << "XDG_CURRENT_DESKTOP is not deepin";
 
         setenv("XDG_CURRENT_DESKTOP", "Deepin", 1);
     }
     setenv("PULSE_PROP_media.role", "music", 1);
+#endif
+
+#ifdef Q_OS_WIN
+    // Auto-set environment variables so deepin-music.exe can run directly
+    // without needing a launcher batch file
+    wchar_t exePath[MAX_PATH];
+    GetModuleFileNameW(NULL, exePath, MAX_PATH);
+    QString appDir = QFileInfo(QString::fromWCharArray(exePath)).absolutePath();
+    if (qgetenv("QT_PLUGIN_PATH").isEmpty()) {
+        qputenv("QT_PLUGIN_PATH", (appDir + "/plugins").toUtf8());
+    }
+    if (qgetenv("QT_QPA_PLATFORM_PLUGIN_PATH").isEmpty()) {
+        qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", (appDir + "/plugins/platforms").toUtf8());
+    }
+    if (qgetenv("QML2_IMPORT_PATH").isEmpty()) {
+        qputenv("QML2_IMPORT_PATH", (appDir + "/qml").toUtf8());
+    }
+    if (qgetenv("QT_QML_IMPORT_PATH").isEmpty()) {
+        qputenv("QT_QML_IMPORT_PATH", (appDir + "/qml").toUtf8());
+    }
+    if (qgetenv("DSG_DATA_DIRS").isEmpty()) {
+        qputenv("DSG_DATA_DIRS", (appDir + "/dsg").toUtf8());
+    }
+    // Add app directory to PATH for DLL resolution
+    QString currentPath = QString::fromLocal8Bit(qgetenv("PATH"));
+    if (!currentPath.contains(appDir)) {
+        qputenv("PATH", (appDir + ";" + currentPath).toUtf8());
+    }
+#endif
 
     DmGlobal::checkWaylandMode();
 
     QSurfaceFormat format;
+#ifdef Q_OS_LINUX
     format.setRenderableType(QSurfaceFormat::OpenGLES);
     format.setVersion(3, 2);
+#endif
     format.setDefaultFormat(format);
     // 1.可以使用自己创建的 QGuiApplication 对象；
     // 2.可以在创建 QGuiApplication 之前为程序设置一些属性（如使用
@@ -72,9 +115,14 @@ int main(int argc, char *argv[])
         qputenv("XDG_CURRENT_DESKTOP", "Deepin");
     }
     qputenv("D_POPUP_MODE", "embed");
+#ifdef Q_OS_WIN
+    qputenv("D_DTK_DISABLE_INWINDOWBLUR", "1");
+#endif
 
     QGuiApplication *app = new QGuiApplication(argc, argv);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     app->setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
     app->setOrganizationName("deepin");
     app->setApplicationName("deepin-music");
     // Version Time
@@ -102,6 +150,7 @@ int main(int argc, char *argv[])
         OpenFilePaths = strList;
     }
 
+#ifdef Q_OS_LINUX
     if (!DGuiApplicationHelper::setSingleInstance("deepinmusic")) {
         qCDebug(dmMusic) << "another deepin music has started";
         QDBusInterface speechbus("org.mpris.MediaPlayer2.DeepinMusic",
@@ -127,6 +176,22 @@ int main(int argc, char *argv[])
         qCDebug(dmMusic) << "another deepin music has started, return";
         return 0;
     }
+#endif
+
+#ifdef Q_OS_WIN
+    // Windows 单实例实现：使用命名互斥量
+    HANDLE hMutex = CreateMutexW(NULL, TRUE, L"deepin-music-single-instance");
+    if (GetLastError() == ERROR_ALREADY_EXISTS) {
+        qCDebug(dmMusic) << "another deepin music has started on Windows";
+        // 尝试激活现有窗口
+        HWND existingWindow = FindWindowW(NULL, L"Music");
+        if (existingWindow) {
+            SetForegroundWindow(existingWindow);
+            ShowWindow(existingWindow, SW_RESTORE);
+        }
+        return 0;
+    }
+#endif
 
     DmGlobal::initPlaybackEngineType();
     app->setQuitOnLastWindowClosed(false);
@@ -156,6 +221,11 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("ShortcutDialg", &shortcut);
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
     engine.rootObjects()[0]->installEventFilter(&eventsFilter);
+#ifdef Q_OS_WIN
+    if (auto *window = qobject_cast<QWindow*>(engine.rootObjects()[0])) {
+        window->setIcon(QIcon(":/dsg/img/deepin-music.svg"));
+    }
+#endif
     if (engine.rootObjects().isEmpty()) {
         qCDebug(dmMusic) << "engine.rootObjects().isEmpty(), return -1";
         return -1;
@@ -168,12 +238,14 @@ int main(int argc, char *argv[])
 
     QObject::connect(&engine, &QQmlApplicationEngine::quit, presenter.data(), &Presenter::saveDataToDB);
 
+#ifdef Q_OS_LINUX
     // 捕获强制退出信号，保存数据到数据库
     static struct sigaction _sigact;
     memset(&_sigact, 0, sizeof(_sigact));
     _sigact.sa_sigaction = sig_term_handler;
     _sigact.sa_flags = SA_SIGINFO;
     sigaction(SIGTERM, &_sigact, NULL);
+#endif
 
     return app->exec();
 }


### PR DESCRIPTION
- Auto-set environment variables (QT_PLUGIN_PATH, PATH, etc.) on Windows
- Conditionalize Linux-specific code (XDG_CURRENT_DESKTOP, signal handlers)
- Add QWindow icon setup for Windows
- Disable in-window blur on Windows (D_DTK_DISABLE_INWINDOWBLUR)
- Conditionalize setSingleInstance and SIGTERM handler for Linux
- Add Windows single-instance guard using named mutex
- Comment out hardcoded SourceHanSansSC font family in QML to avoid missing font issues on MSYS2

fix: 适配 main.cpp 以支持 Windows 环境配置

- 在 Windows 上自动设置环境变量（QT_PLUGIN_PATH、PATH 等）
- 将 Linux 特定代码条件化（XDG_CURRENT_DESKTOP、信号处理器）
- 在 Windows 上添加 QWindow 图标设置
- 在 Windows 上禁用窗口内模糊（D_DTK_DISABLE_INWINDOWBLUR）
- 将 setSingleInstance 和 SIGTERM 处理器条件化为仅 Linux
- 使用命名互斥量实现 Windows 单实例检测
- 注释掉 QML 中硬编码的 SourceHanSansSC 字体，解决 MSYS2 上字体缺失问题

## Summary by Sourcery

Adapt the music player main entry point for cross-platform support, adding Windows-specific setup while guarding Linux-only behavior.

New Features:
- Add Windows-specific environment setup for Qt plugins, QML imports, and DSG data directories to allow running without an external launcher.
- Introduce a Windows single-instance mechanism based on a named mutex to prevent multiple player instances.
- Set the main QML window icon explicitly on Windows and disable in-window blur via an environment flag.

Bug Fixes:
- Avoid hardcoded Linux signal handlers and XDG environment usage on non-Linux platforms by wrapping them in Linux-specific guards.
- Ensure the application honors single-instance behavior only on supported platforms by conditionalizing the existing Linux-only implementation.

Enhancements:
- Make OpenGL ES surface format configuration conditional on Linux builds to better align with platform capabilities.
- Update SPDX copyright header years to cover 2023–2026.