### PR TITLE
fix: add Windows dialog flags, centering, and QML compatibility fixes

### DIFF
--- a/src/music-player/allItems/ArrowRectangle.qml
+++ b/src/music-player/allItems/ArrowRectangle.qml
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.11
+import org.deepin.dtk 1.0
 
 Rectangle {
     property real rectRadius: 8
@@ -22,7 +23,7 @@ Rectangle {
             width: parent.width
             height: parent.height - triangleHeight
             radius: rectRadius
-            color: palette.highlight
+            color: DTK.palette.highlight
         }
         Canvas {
             id: triangleCanvas

--- a/src/music-player/dialogs/CDRemovedDialog.qml
+++ b/src/music-player/dialogs/CDRemovedDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,6 +15,14 @@ DialogWindow {
     modality: Qt.ApplicationModal
     color: Qt.rgba(247,247,247,0.80);
     icon: globalVariant.appIconName
+    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
+
+    onVisibleChanged: {
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
+    }
 
     header: DialogTitleBar {
         enableInWindowBlendBlur: false

--- a/src/music-player/dialogs/CloseConfirmDialog.qml
+++ b/src/music-player/dialogs/CloseConfirmDialog.qml
@@ -19,9 +19,17 @@ DialogWindow {
     height: 230
     modality: Qt.ApplicationModal
     icon: globalVariant.appIconName
+    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
 
     header: DialogTitleBar {
         enableInWindowBlendBlur: false
+    }
+
+    onVisibleChanged: {
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
     }
 
     Column {

--- a/src/music-player/dialogs/DeleteLocalDialog.qml
+++ b/src/music-player/dialogs/DeleteLocalDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,10 +13,19 @@ DialogWindow {
     property var deleteHashList: []
     property string listHash: ""
     property string musicTitle: ""
-    minimumWidth: 400
+    width: 400
     modality: Qt.ApplicationModal
 //    color: Qt.rgba(247,247,247,0.80);
     icon: globalVariant.appIconName
+    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint) : undefined
+
+    onVisibleChanged: {
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
+    }
+
     header: DialogTitleBar {
         enableInWindowBlendBlur: false
     }

--- a/src/music-player/dialogs/DeleteSonglistDialog.qml
+++ b/src/music-player/dialogs/DeleteSonglistDialog.qml
@@ -19,6 +19,14 @@ DialogWindow {
     height: deleteSongsLabel.height + 110
     modality: Qt.ApplicationModal
     icon: globalVariant.appIconName
+    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint) : undefined
+
+    onVisibleChanged: {
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
+    }
 
     header: DialogTitleBar {
         enableInWindowBlendBlur: false

--- a/src/music-player/dialogs/EqualizerDialog.qml
+++ b/src/music-player/dialogs/EqualizerDialog.qml
@@ -10,6 +10,7 @@ import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
 
 DialogWindow {
+    id: equalizerDialog
     property ListModel comBoxModel: ListModel {
         ListElement { text: qsTr("Custom") }
         ListElement { text: qsTr("Monophony") }
@@ -74,6 +75,7 @@ DialogWindow {
     minimumHeight: 426
     maximumWidth: 572
     maximumHeight: 426
+    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
     header: DialogTitleBar {
         enableInWindowBlendBlur: false
     }
@@ -433,6 +435,11 @@ DialogWindow {
     }
 
     onVisibleChanged: {
+        // Center window on screen
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
         dataLoad()
 
         selectComBox.currentIndex = Qt.binding(function(){return curEQ})

--- a/src/music-player/dialogs/ImportFailedDialog.qml
+++ b/src/music-player/dialogs/ImportFailedDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,13 @@ DialogWindow {
     minimumHeight: 160
     modality: Qt.ApplicationModal
     icon: globalVariant.appIconName
+
+    onVisibleChanged: {
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
+    }
 
     ColumnLayout {
         anchors.fill: parent

--- a/src/music-player/dialogs/MusicInfoDialog.qml
+++ b/src/music-player/dialogs/MusicInfoDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,15 @@ DialogWindow {
 
     width: 386
     height: 468
+    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
+
+    onVisibleChanged: {
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
+    }
+
     header: DialogTitleBar {
         enableInWindowBlendBlur: false
         content: Loader {
@@ -59,7 +68,7 @@ DialogWindow {
                 id: musicImage
                 Layout.alignment: Qt.AlignHCenter
                 sourceSize: Qt.size(118, 118)
-                source: musicData === undefined ? " " : "file:///" + musicData.coverUrl  //imgSourcePath
+                source: musicData === undefined || !musicData.coverUrl ? "" : "file:///" + musicData.coverUrl
                 cache: false
             }
         }

--- a/src/music-player/dialogs/SettingsDialog.qml
+++ b/src/music-player/dialogs/SettingsDialog.qml
@@ -24,6 +24,13 @@ Settings.SettingsDialog {
     config: SettingsConfig {}
     flags: Qt.WindowCloseButtonHint | Qt.WindowStaysOnTopHint
 
+    onVisibleChanged: {
+        if (visible && Qt.platform.os === "windows") {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
+    }
+
     groups: [  // 创建配置组，管理配置子组和Options
         Settings.SettingsGroup {
             key: "Basic"
@@ -437,7 +444,7 @@ Settings.SettingsDialog {
         updateInfos()
     }
 
-    property var duplicatDlg :DialogWindow {
+    property var duplicatDlg : DialogWindow {
         property int curId: 0
         property int duplicatId: 0
         property string newValue: ""
@@ -449,6 +456,13 @@ Settings.SettingsDialog {
         modality: Qt.ApplicationModal
 //        color: Qt.rgba(247,247,247,0.80);
         icon: globalVariant.appIconName
+
+        onVisibleChanged: {
+            if (visible && Qt.platform.os === "windows") {
+                x = (Screen.width - width) / 2
+                y = (Screen.height - height) / 2
+            }
+        }
 
         onClosing: {
             if (!replaceFlag) {

--- a/src/music-player/lyric/LyricRect.qml
+++ b/src/music-player/lyric/LyricRect.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -85,15 +85,15 @@ Rectangle {
 
         Rectangle {
             id: lyricItemRect
-            width: parent.width
+            width: parent ? parent.width : 0
             height: itemHeight
             color: "#00000000"
 
             Text {
                 id: txtLyric;
-                width: parent.width
-                anchors.left: parent.left
-                anchors.verticalCenter: parent.verticalCenter
+                width: parent ? parent.width : 0
+                anchors.left: parent ? parent.left : undefined
+                anchors.verticalCenter: parent ? parent.verticalCenter : undefined
 
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 
@@ -158,7 +158,7 @@ Rectangle {
                         }
                     }
                 }
-                font.family: "SourceHanSansSC"
+                //font.family: "SourceHanSansSC"
                 font.pixelSize: lyricItemRect.ListView.isCurrentItem ? 18 : 14
 
                 font.weight: lyricItemRect.ListView.isCurrentItem ? Font.DemiBold : Font.Medium

--- a/src/music-player/lyric/ShaderView.qml
+++ b/src/music-player/lyric/ShaderView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -44,12 +44,10 @@ Item {
     Component {
         id: effectLineView;
         Item {
-            anchors.fill: parent
             EffectLine {
                 id: around
                 width: parent.width
                 height: parent.height
-                anchors.centerIn: parent
                 Circular_img {
                     id:circular_img
                     anchors.centerIn: around
@@ -62,13 +60,10 @@ Item {
     Component {
         id: effectLightWaveView;
         Item {
-            anchors.fill: parent
-
             EffectLightWave {
                 id: around
                 width: parent.width
                 height: parent.height
-                anchors.centerIn: parent
                 Circular_img {
                     id:circular_img
                     anchors.centerIn: around
@@ -81,12 +76,10 @@ Item {
     Component {
         id: effectSunView;
         Item {
-            anchors.fill: parent
             EffectSun {
                 id: around
                 width: parent.width
                 height: parent.height
-                anchors.centerIn: parent
 
                 Circular_img {
                     id:circular_img
@@ -100,12 +93,10 @@ Item {
     Component {
         id: effectWaterWaveView;
         Item {
-            anchors.fill: parent
             EffectWaterWave {
                 id: around
                 width: parent.width
                 height: parent.height
-                anchors.centerIn: parent
                 Circular_img {
                     id:circular_img
                     anchors.centerIn: around
@@ -118,12 +109,10 @@ Item {
     Component {
         id: effectParticleView;
         Item {
-            anchors.fill: parent
             EffectParticle {
                 id: around
                 width: parent.width
                 height: parent.height
-                anchors.centerIn: parent
                 Circular_img {
                     id:circular_img
                     anchors.centerIn: around
@@ -137,12 +126,10 @@ Item {
         id: commView
         Item {
             id: commItem
-            anchors.fill: parent
             Rectangle {
                 id: around
                 width: parent.width
                 height: parent.height
-                anchors.centerIn: parent
                 color: "transparent"
                 Circular_img {
                     id:circular_img

--- a/src/music-player/mainwindow/MainWindow.qml
+++ b/src/music-player/mainwindow/MainWindow.qml
@@ -35,7 +35,7 @@ ApplicationWindow {
     DWindow.alphaBufferSize: 8
     DWindow.enableBlurWindow: true
     color: "transparent"
-    flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
+    flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | (Qt.platform.os === "windows" ? Qt.FramelessWindowHint : Qt.WindowTitleHint)
     header: WindowTitlebar { id: musicTitle }
     background: Rectangle {
         anchors.fill: parent
@@ -455,5 +455,10 @@ ApplicationWindow {
         Presenter.raiseRequested.connect(onRaiseRequested)
         globalVariant.devicePixelRatio = Screen.devicePixelRatio
         EventsFilter.keyFiltered.connect(onKeyFiltered)
+        // Center window on screen
+        if (Screen.width > 0 && Screen.height > 0) {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        }
     }
 }

--- a/src/music-player/mainwindow/Toolbar.qml
+++ b/src/music-player/mainwindow/Toolbar.qml
@@ -181,7 +181,7 @@ ToolFloatingPanel {
                     font.pixelSize: 12
                     color: DTK.themeType === ApplicationHelper.DarkType ? Qt.rgba(247, 247, 247, 0.7) : Qt.rgba(0, 0, 0, 0.7)
                     font {
-                        family: "SourceHanSansSC, SourceHanSansSC-Normal"
+                        //family: "SourceHanSansSC, SourceHanSansSC-Normal"
                         pixelSize: 12
                         weight: Font.Medium
                     }

--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -6,6 +6,7 @@ import QtQuick
 import QtQuick.Window
 import QtQuick.Layouts
 import org.deepin.dtk 1.0
+import org.deepin.dtk 1.0 as D
 import "../dialogs"
 
 TitleBar {
@@ -24,9 +25,34 @@ TitleBar {
     Loader { id: settingDlgLoader }
 
     id: titleBar
-    icon.name: globalVariant.appIconName
-    icon.opacity: opat
     hoverEnabled: true
+
+    // App icon - use Image on Windows since DCI icon theme may not have app icon
+    Loader {
+        id: iconLoader
+        anchors.verticalCenter: parent.verticalCenter
+        x: 10
+        sourceComponent: Qt.platform.os === "windows" ? fallbackIcon : dciIcon
+        Component {
+            id: dciIcon
+            D.DciIcon {
+                name: globalVariant.appIconName
+                sourceSize { width: 24; height: 24 }
+                opacity: opat
+                palette: D.DTK.makeIconPalette(titleBar.palette)
+                mode: titleBar.D.ColorSelector.controlState
+                theme: titleBar.D.ColorSelector.controlTheme
+            }
+        }
+        Component {
+            id: fallbackIcon
+            Image {
+                width: 24; height: 24
+                source: "qrc:/dsg/img/deepin-music.svg"
+                opacity: opat
+            }
+        }
+    }
     ActionButton {
         icon.name: "go_down"
         icon.width: 12
@@ -86,14 +112,21 @@ TitleBar {
             aboutDialog: AboutDialog {
                 modality: Qt.WindowModal
                 productName: qsTr("Music")
-                productIcon: globalVariant.appIconName
+                productIcon: Qt.platform.os === "windows" ? "qrc:/dsg/img/deepin-music.svg" : globalVariant.appIconName
                 description: qsTr("Music is a local music player with beautiful design and simple functions.")
                 version: qsTr("Version:") + "%1".arg(Qt.application.version)
                 companyLogo: globalVariant.appIconName
                 websiteName: DTK.deepinWebsiteName
                 websiteLink: DTK.deepinWebsiteLink
+                flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.FramelessWindowHint) : undefined
                 header: DialogTitleBar {
                     enableInWindowBlendBlur: false
+                }
+                onVisibleChanged: {
+                    if (visible && Qt.platform.os === "windows") {
+                        x = (Screen.width - width) / 2
+                        y = (Screen.height - height) / 2
+                    }
                 }
             }
         }

--- a/src/music-player/musicmousemenu/MusicMoreMenu.qml
+++ b/src/music-player/musicmousemenu/MusicMoreMenu.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,7 +14,7 @@ Menu{
     property var mediaData
     property var encodings: []
     property bool isPlaying: (globalVariant.curPlayingStatus === DmGlobal.Playing) ? true : false
-    property bool activeMeta: (globalVariant.curPlayingHash === mediaData.hash) ? true : false;
+    property bool activeMeta: (mediaData && globalVariant.curPlayingHash === mediaData.hash) ? true : false;
     property int itemIndex: -1  //判断当前菜单属于哪个列表项，用于控制菜单按钮的显隐
 
 

--- a/src/music-player/playlist/CurrentFloatingPanel.qml
+++ b/src/music-player/playlist/CurrentFloatingPanel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // TODO: 兼容使用，BackdropBlitter 正常后替换
@@ -34,7 +34,7 @@ D.Control {
             sourceItem: parent
         }
         Loader {
-            active: Window.window && Window.window.color.a < 1
+            active: !!(Window.window && Window.window.color.a < 1 && blur.content)
             anchors.fill: parent
             sourceComponent: D.ItemViewport {
                 anchors.fill: parent


### PR DESCRIPTION
- Add Qt.FramelessWindowHint and centering for all dialogs on Windows
- Fix ArrowRectangle, WaveformRect palette access (palette -> DTK.palette)
- Add null safety checks in MusicMoreMenu, CurrentFloatingPanel, LyricRect
- Remove redundant anchors.fill/anchors.centerIn in ShaderView
- Add DciIcon fallback for Windows in WindowTitlebar
- Update AboutDialog for Windows compatibility
- Center MainWindow on screen on Windows

fix: 添加 Windows 对话框标志、居中及 QML 兼容性修复

- 为所有对话框在 Windows 上添加 Qt.FramelessWindowHint 和居中
- 修复 ArrowRectangle、WaveformRect 调色板访问（palette -> DTK.palette）
- 在 MusicMoreMenu、CurrentFloatingPanel、LyricRect 中添加空值安全检查
- 移除 ShaderView 中冗余的 anchors.fill/anchors.centerIn
- 在 WindowTitlebar 中为 Windows 添加 DciIcon 回退
- 更新 AboutDialog 以兼容 Windows
- 在 Windows 上将主窗口居中显示

## Summary by Sourcery

Improve Windows-specific dialog behavior, window centering, and QML compatibility across the music player UI.

New Features:
- Provide a Windows-specific app icon fallback in the main window title bar and About dialog.
- Center the main window and key dialogs on screen when running on Windows.

Bug Fixes:
- Fix palette usage in ArrowRectangle and WaveformRect to use DTK palettes for consistent theming.
- Add null-safety checks for media data in MusicMoreMenu and blur content in CurrentFloatingPanel to prevent runtime issues.
- Guard LyricRect layout bindings against missing parents and avoid invalid font configurations.
- Handle missing cover URLs in MusicInfoDialog to avoid broken image sources.

Enhancements:
- Apply Windows-appropriate window flags, including frameless and fixed-size hints, to dialogs for better integration.
- Simplify ShaderView layout by removing redundant anchors on effect components.
- Update font usage in toolbar and lyric views to rely on defaults instead of hard-coded families.