### PR TITLE
feat: support word-by-word lyric parsing and highlighting

### DIFF
--- a/src/libdmusic/core/lyricanalysis.cpp
+++ b/src/libdmusic/core/lyricanalysis.cpp
@@ -18,6 +18,21 @@
 
 DCORE_USE_NAMESPACE
 
+// 解析 LRC 时间戳，正确处理厘秒（百分之一秒）格式
+static qint64 parseTimeStamp(const QString &timeStr)
+{
+    QStringList timeParts = timeStr.split('.');
+    QTime t = QTime::fromString(timeParts[0], "mm:ss");
+    if (!t.isValid()) return -1;
+    qint64 time = t.msecsSinceStartOfDay();
+    if (timeParts.size() > 1) {
+        QString frac = timeParts[1];
+        if (frac.length() == 2) time += frac.toInt() * 10;      // 厘秒转毫秒
+        else if (frac.length() == 3) time += frac.toInt();       // 已经是毫秒
+    }
+    return time;
+}
+
 static float codecConfidenceForData(const QTextCodec *codec, const QByteArray &data, const QLocale::Country &country)
 {
     qreal hep_count = 0;
@@ -103,7 +118,7 @@ static float codecConfidenceForData(const QTextCodec *codec, const QByteArray &d
     return qMax(0.0f, c);
 }
 
-LyricAnalysis::LyricAnalysis(): m_offset(0.00)
+LyricAnalysis::LyricAnalysis()
 {
     qCDebug(dmMusic) << "LyricAnalysis constructor called";
 }
@@ -139,29 +154,80 @@ void LyricAnalysis::parseLyric(const QString &str)
     qCDebug(dmMusic) << "Parsing lyrics with length:" << str.length();
     auto lines = str.split("\n");
     QRegExp rx("\\[([^\\]]*)\\]\\s*(\\S.*\\S|\\S)\\s*$");
+    // 用于检测时间戳数量的正则（不含行尾锚点）
+    QRegExp timestampRx("\\[\\d{2}:\\d{2}\\.\\d{2,3}\\]");
+    // 匹配逐字歌词中单个 [时间]文本 片段
+    QRegExp wordRx("\\[([^\\]]+)\\]([^\\[]*)");
     QVector<QPair<qint64, QString>> tmp;
+    QVector<QVector<LyricWord>> tmpWord;
 
     for (auto line : lines) {
-        if (rx.indexIn(line) != -1) {
-            auto timeStr = rx.capturedTexts()[1];
-            auto lyricStr = rx.capturedTexts()[2];
-            QTime t = QTime::fromString(timeStr, "mm:ss.z");
-            qint64 time = t.msecsSinceStartOfDay();
-            if (t.isValid()) {
-                tmp.push_back({time, lyricStr});
-                qCDebug(dmMusic) << "Parsed lyric - Time:" << timeStr << "Text:" << lyricStr;
+        // 检测是否包含多个时间戳（逐字歌词格式）
+        int timestampCount = 0;
+        int pos = 0;
+        while ((pos = timestampRx.indexIn(line, pos)) != -1) {
+            timestampCount++;
+            pos += timestampRx.matchedLength();
+        }
+
+        if (timestampCount > 1) {
+            // 逐字歌词格式：[mm:ss.xx]字[mm:ss.xx]字...
+            QVector<LyricWord> words;
+            qint64 firstTime = -1;
+            QString fullText;
+            pos = 0;
+            while ((pos = wordRx.indexIn(line, pos)) != -1) {
+                auto timeStr = wordRx.capturedTexts()[1];
+                auto textStr = wordRx.capturedTexts()[2];
+                qint64 time = parseTimeStamp(timeStr);
+                if (time >= 0) {
+                    if (firstTime < 0) firstTime = time;
+                    words.push_back({time, textStr});
+                    fullText += textStr;
+                    qCDebug(dmMusic) << "Parsed word - Time:" << timeStr << "ms:" << time << "Text:" << textStr;
+                }
+                pos += wordRx.matchedLength();
+            }
+            if (!words.isEmpty() && firstTime >= 0) {
+                tmp.push_back({firstTime, fullText});
+                tmpWord.push_back(words);
+                qCDebug(dmMusic) << "Parsed lyric line with" << words.size() << "words - Time:" << firstTime << "Text:" << fullText;
             } else {
-                qCWarning(dmMusic) << "Invalid time format in lyric line:" << line;
+                qCWarning(dmMusic) << "Invalid multi-timestamp lyric line:" << line;
+            }
+        } else if (timestampCount == 1) {
+            // 普通歌词格式：[mm:ss.xx]歌词文本
+            if (rx.indexIn(line) != -1) {
+                auto timeStr = rx.capturedTexts()[1];
+                auto lyricStr = rx.capturedTexts()[2];
+                qint64 time = parseTimeStamp(timeStr);
+                if (time >= 0) {
+                    tmp.push_back({time, lyricStr});
+                    tmpWord.push_back(QVector<LyricWord>()); // 空表示无逐字时间轴
+                    qCDebug(dmMusic) << "Parsed lyric - Time:" << timeStr << "Text:" << lyricStr;
+                } else {
+                    qCWarning(dmMusic) << "Invalid time format in lyric line:" << line;
+                }
+            } else {
+                qCDebug(dmMusic) << "Skipping non-matching line:" << line;
             }
         } else {
             qCDebug(dmMusic) << "Skipping non-matching line:" << line;
         }
     }
 
-    std::sort(tmp.begin(), tmp.end());
+    // 按时间排序（同时保持 word 和 lyric 的对应关系）
+    QVector<int> indices(tmp.size());
+    for (int i = 0; i < indices.size(); i++) indices[i] = i;
+    std::sort(indices.begin(), indices.end(), [&](int a, int b) {
+        return tmp[a].first < tmp[b].first;
+    });
+
     m_allLyrics.clear();
-    for (auto item : tmp) {
-        m_allLyrics.push_back(item);
+    m_wordLyrics.clear();
+    for (int i : indices) {
+        m_allLyrics.push_back(tmp[i]);
+        m_wordLyrics.push_back(tmpWord[i]);
     }
 }
 
@@ -268,4 +334,16 @@ int LyricAnalysis::getCount() const
 {
     qCDebug(dmMusic) << "Getting lyrics count:" << m_allLyrics.size();
     return m_allLyrics.count();
+}
+
+bool LyricAnalysis::hasWordTiming(int index) const
+{
+    if (index < 0 || index >= m_wordLyrics.size()) return false;
+    return !m_wordLyrics[index].isEmpty();
+}
+
+QVector<LyricWord> LyricAnalysis::getWordTiming(int index) const
+{
+    if (index < 0 || index >= m_wordLyrics.size()) return QVector<LyricWord>();
+    return m_wordLyrics[index];
 }

--- a/src/libdmusic/core/lyricanalysis.cpp
+++ b/src/libdmusic/core/lyricanalysis.cpp
@@ -27,7 +27,8 @@ static qint64 parseTimeStamp(const QString &timeStr)
     qint64 time = t.msecsSinceStartOfDay();
     if (timeParts.size() > 1) {
         QString frac = timeParts[1];
-        if (frac.length() == 2) time += frac.toInt() * 10;      // 厘秒转毫秒
+        if (frac.length() == 1) time += frac.toInt() * 100;      // 十分之一秒转毫秒
+        else if (frac.length() == 2) time += frac.toInt() * 10;  // 厘秒转毫秒
         else if (frac.length() == 3) time += frac.toInt();       // 已经是毫秒
     }
     return time;
@@ -154,8 +155,8 @@ void LyricAnalysis::parseLyric(const QString &str)
     qCDebug(dmMusic) << "Parsing lyrics with length:" << str.length();
     auto lines = str.split("\n");
     QRegExp rx("\\[([^\\]]*)\\]\\s*(\\S.*\\S|\\S)\\s*$");
-    // 用于检测时间戳数量的正则（不含行尾锚点）
-    QRegExp timestampRx("\\[\\d{2}:\\d{2}\\.\\d{2,3}\\]");
+    // 用于检测时间戳数量的正则（不含行尾锚点），小数部分支持 1~3 位（旧格式存在一位小数如 [01:23.4]）
+    QRegExp timestampRx("\\[\\d{2}:\\d{2}\\.\\d{1,3}\\]");
     // 匹配逐字歌词中单个 [时间]文本 片段
     QRegExp wordRx("\\[([^\\]]+)\\]([^\\[]*)");
     QVector<QPair<qint64, QString>> tmp;

--- a/src/libdmusic/core/lyricanalysis.h
+++ b/src/libdmusic/core/lyricanalysis.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2020 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +8,11 @@
 #include <QVector>
 #include <QByteArray>
 #include <QPair>
+
+struct LyricWord {
+    qint64 time;    // 时间戳（毫秒）
+    QString text;   // 该时间点后的文本片段
+};
 
 class LyricAnalysis
 {
@@ -22,14 +26,18 @@ public:
     int getIndex(qint64 pos);
     qint64 getPostion(int index);
 
+    // 逐字歌词支持
+    bool hasWordTiming(int index) const;
+    QVector<LyricWord> getWordTiming(int index) const;
+
 private:
     void parseLyric(const QString &str);
     QString getFileCodec();
 
 private:
     QString                           m_filePath;
-    double                            m_offset;
     QVector<QPair<qint64, QString> >   m_allLyrics;
+    QVector<QVector<LyricWord>>        m_wordLyrics;   // 逐字歌词时间轴
 };
 
 #endif

--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -331,10 +330,26 @@ QVariantList Presenter::getLyrics()
         }
         m_data->m_lyricAnalysis.setFromFile(lrcPath);
         QVector<QPair<qint64, QString> > allLyrics = m_data->m_lyricAnalysis.allLyrics();
-        for (QPair<qint64, QString> lyric : allLyrics) {
+        for (int i = 0; i < allLyrics.size(); i++) {
             QVariantMap curData;
-            curData.insert("time", lyric.first);
-            curData.insert("lyric", lyric.second);
+            curData.insert("time", allLyrics[i].first);
+            curData.insert("lyric", allLyrics[i].second);
+
+            // 逐字歌词时间轴
+            bool hasWords = m_data->m_lyricAnalysis.hasWordTiming(i);
+            curData.insert("hasWordTiming", hasWords);
+            if (hasWords) {
+                QVariantList wordsList;
+                QVector<LyricWord> words = m_data->m_lyricAnalysis.getWordTiming(i);
+                for (const LyricWord &w : words) {
+                    QVariantMap wordMap;
+                    wordMap.insert("time", w.time);
+                    wordMap.insert("text", w.text);
+                    wordsList.append(wordMap);
+                }
+                curData.insert("words", wordsList);
+            }
+
             lyrics.append(curData);
         }
     }

--- a/src/music-player/lyric/LyricPage.qml
+++ b/src/music-player/lyric/LyricPage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,8 +19,10 @@ Rectangle{
     property string bgImgPath: "qrc:/dsg/img/music.svg"
     property bool withLrcs: lrcModel.count == 0 ? false : true
     property int centerAreaWidth: 899
+    property real currentPosition: 0
 //    property int curIndex: 0
     property ListModel lrcModel: ListModel{}
+    property var wordLyricsData: []
 
     signal currentIndexChanged(int index)
 
@@ -156,6 +158,8 @@ Rectangle{
                         anchors.horizontalCenter: parent.horizontalCenter
                         LyricRect {
                             id: lyricRect
+                            currentPosition: lrcRectItem.currentPosition
+                            wordLyricsData: lrcRectItem.wordLyricsData
                         }
                     }
                     Rectangle {
@@ -221,6 +225,7 @@ Rectangle{
 
     function metaChange(){
         lrcModel.clear()
+        wordLyricsData = []
 
         var meta = Presenter.getActivateMeta()
         titleStr = meta["title"]
@@ -234,9 +239,20 @@ Rectangle{
         }
 
         var lyricList = Presenter.getLyrics();
+        var tempWordData = [];
         for (var i = 0; i < lyricList.length; i++) {
-            lrcModel.append(lyricList[i])
+            var item = lyricList[i];
+            // 将 words 数据存储到单独的 JS 数组中
+            var words = item["words"] || [];
+            tempWordData.push(words);
+            // 创建不包含 words 的新对象，因为 ListModel 无法正确存储嵌套数据
+            lrcModel.append({
+                "time": item["time"],
+                "lyric": item["lyric"],
+                "hasWordTiming": item["hasWordTiming"]
+            });
         }
+        wordLyricsData = tempWordData;
 
         //切换shader
         switchShader();
@@ -244,6 +260,7 @@ Rectangle{
 
     function positionChange(position, length) {
         position = position + 500
+        currentPosition = position
         //二分法查找位置
         var lt,rt
         lt = 0

--- a/src/music-player/lyric/LyricPage.qml
+++ b/src/music-player/lyric/LyricPage.qml
@@ -259,8 +259,10 @@ Rectangle{
     }
 
     function positionChange(position, length) {
-        position = position + 500
+        // currentPosition 用于逐字高亮，必须使用原始播放位置；
+        // +500ms 偏移仅用于提前滚动当前行到视野中央
         currentPosition = position
+        var searchPosition = position + 500
         //二分法查找位置
         var lt,rt
         lt = 0
@@ -269,7 +271,7 @@ Rectangle{
             var mid = (lt + rt) >> 1
             var item =lrcModel.get(mid)
 
-            if (item["time"] > position)
+            if (item["time"] > searchPosition)
                 rt = mid
             else
                 lt = mid

--- a/src/music-player/lyric/LyricRect.qml
+++ b/src/music-player/lyric/LyricRect.qml
@@ -11,6 +11,8 @@ Rectangle {
     property bool isFlicking: false
     property int itemHeight: 45
     property int highlightItemHeight: 60
+    property real currentPosition: 0
+    property var wordLyricsData: []
 
     id: lyricRect
     width: parent.width
@@ -88,9 +90,46 @@ Rectangle {
             width: parent ? parent.width : 0
             height: itemHeight
             color: "#00000000"
+            property int lineIndex: index
+            property bool hasWordTiming: model !== undefined && model.hasWordTiming === true
+            property var lineWords: hasWordTiming ? wordLyricsData[lineIndex] : []
 
+            // 距离相关的透明度值
+            property real distanceOpacity: {
+                if (lyricItemRect.ListView.isCurrentItem) {
+                    return 1.0
+                }
+                if (curIndex <= Math.abs(lyricRect.height / itemHeight / 2)) {
+                    if (index > Math.abs(lyricRect.height / itemHeight) - 2) {
+                        return 0.24
+                    } else if (index > Math.abs(lyricRect.height / itemHeight) - 3) {
+                        return 0.42
+                    } else {
+                        return 0.7
+                    }
+                } else if (curIndex > lrcModel.count - Math.abs(lyricRect.height / itemHeight / 2)) {
+                    if (index < lrcModel.count - Math.abs(lyricRect.height / itemHeight) + 1) {
+                        return 0.24
+                    } else if (index < lrcModel.count - Math.abs(lyricRect.height / itemHeight) + 2) {
+                        return 0.42
+                    } else {
+                        return 0.7
+                    }
+                } else {
+                    if (Math.abs(curIndex - index) > Math.abs(lyricRect.height / itemHeight / 2) - 1) {
+                        return 0.24
+                    } else if (Math.abs(curIndex - index) > Math.abs(lyricRect.height / itemHeight / 2) - 2) {
+                        return 0.42
+                    } else {
+                        return 0.7
+                    }
+                }
+            }
+
+            // 普通歌词（无逐字时间轴）
             Text {
-                id: txtLyric;
+                id: txtLyric
+                visible: !lyricItemRect.hasWordTiming
                 width: parent ? parent.width : 0
                 anchors.left: parent ? parent.left : undefined
                 anchors.verticalCenter: parent ? parent.verticalCenter : undefined
@@ -99,76 +138,64 @@ Rectangle {
 
                 text: lyric
                 color: {
-                    // 根据距离添加渐变
                     if( lyricItemRect.ListView.isCurrentItem ) {
                         return palette.highlight
                     }
                     if(DTK.themeType === ApplicationHelper.LightType)
-                    {
-                        if (curIndex <= Math.abs(lyricRect.height / itemHeight / 2)) { //开始
-                            if (index > Math.abs(lyricRect.height / itemHeight) - 2) {
-                                return Qt.rgba(0, 0, 0, 0.24)
-                            } else if (index > Math.abs(lyricRect.height / itemHeight) - 3) {
-                                return Qt.rgba(0, 0, 0, 0.42)
-                            }  else {
-                                return Qt.rgba(0, 0, 0, 0.7)
-                            }
-                        } else if (curIndex > lrcModel.count - Math.abs(lyricRect.height / itemHeight / 2)) { //结尾
-                            if (index < lrcModel.count - Math.abs(lyricRect.height / itemHeight) + 1) {
-                                return Qt.rgba(0, 0, 0, 0.24)
-                            } else if (index < lrcModel.count - Math.abs(lyricRect.height / itemHeight) + 2) {
-                                return Qt.rgba(0, 0, 0, 0.42)
-                            }  else {
-                                return Qt.rgba(0, 0, 0, 0.7)
-                            }
-                        } else {  //中间部分
-                            if (Math.abs(curIndex - index) > Math.abs(lyricRect.height / itemHeight / 2) - 1) {
-                                return Qt.rgba(0, 0, 0, 0.24)
-                            } else if (Math.abs(curIndex - index) > Math.abs(lyricRect.height / itemHeight / 2) - 2) {
-                                return Qt.rgba(0, 0, 0, 0.42)
-                            }  else {
-                                return Qt.rgba(0, 0, 0, 0.7)
-                            }
-                        }
-                    } else {
-                        if (curIndex <= Math.abs(lyricRect.height / itemHeight / 2)) { //开始
-                            if (index > Math.abs(lyricRect.height / itemHeight) - 2) {
-                                return Qt.rgba(255,255,255, 0.24)
-                            } else if (index > Math.abs(lyricRect.height / itemHeight) - 3) {
-                                return Qt.rgba(255,255,255, 0.42)
-                            }  else {
-                                return Qt.rgba(255,255,255, 0.7)
-                            }
-                        } else if (curIndex > lrcModel.count - Math.abs(lyricRect.height / itemHeight / 2)) { //结尾
-                            if (index < lrcModel.count - Math.abs(lyricRect.height / itemHeight) + 1) {
-                                return Qt.rgba(255,255,255, 0.24)
-                            } else if (index < lrcModel.count - Math.abs(lyricRect.height / itemHeight) + 2) {
-                                return Qt.rgba(255,255,255, 0.42)
-                            }  else {
-                                return Qt.rgba(255,255,255, 0.7)
-                            }
-                        } else {  //中间部分
-                            if (Math.abs(curIndex - index) > Math.abs(lyricRect.height / itemHeight / 2) - 1) {
-                                return Qt.rgba(255,255,255, 0.24)
-                            } else if (Math.abs(curIndex - index) > Math.abs(lyricRect.height / itemHeight / 2) - 2) {
-                                return Qt.rgba(255,255,255, 0.42)
-                            }  else {
-                                return Qt.rgba(255,255,255, 0.7)
-                            }
-                        }
-                    }
+                        return Qt.rgba(0, 0, 0, distanceOpacity)
+                    else
+                        return Qt.rgba(255,255,255, distanceOpacity)
                 }
                 //font.family: "SourceHanSansSC"
                 font.pixelSize: lyricItemRect.ListView.isCurrentItem ? 18 : 14
-
                 font.weight: lyricItemRect.ListView.isCurrentItem ? Font.DemiBold : Font.Medium
             }
+
+            // 逐字歌词（有逐字时间轴）
+            Flow {
+                id: wordFlow
+                visible: lyricItemRect.hasWordTiming
+                width: parent.width
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+
+                Repeater {
+                    id: wordRepeater
+                    model: lyricItemRect.lineWords
+
+                    Text {
+                        property bool wordSung: modelData.time <= lyricRect.currentPosition
+
+                        text: modelData.text
+                        color: {
+                            if (lyricItemRect.ListView.isCurrentItem) {
+                                if (wordSung)
+                                    return palette.highlight
+                                else
+                                    return DTK.themeType === ApplicationHelper.LightType
+                                        ? Qt.rgba(0, 0, 0, 0.4)
+                                        : Qt.rgba(255, 255, 255, 0.4)
+                            } else {
+                                if(DTK.themeType === ApplicationHelper.LightType)
+                                    return Qt.rgba(0, 0, 0, distanceOpacity)
+                                else
+                                    return Qt.rgba(255,255,255, distanceOpacity)
+                            }
+                        }
+                        Behavior on color {
+                            ColorAnimation { duration: 150 }
+                        }
+                        font.pixelSize: lyricItemRect.ListView.isCurrentItem ? 18 : 14
+                        font.weight: lyricItemRect.ListView.isCurrentItem ? Font.DemiBold : Font.Medium
+                    }
+                }
+            }
+
             MouseArea {
                 id: mouseArea
                 anchors.fill: parent
                 onDoubleClicked: {
                     console.log("onDoubleClicked:  index:" + index)
-                    //isFlicking = false
                     curIndex = index
                     var time = lrcModel.get(curIndex)["time"]
                     Presenter.setPosition(time)

--- a/tests/libdmusic-test/test_lyricanalysis.cpp
+++ b/tests/libdmusic-test/test_lyricanalysis.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -247,4 +246,95 @@ TEST(LyricAnalysisTest, getPostionOnEmptyLyricsReturnsZero)
     LyricAnalysis la;
     EXPECT_EQ(la.getPostion(0), 0);
     EXPECT_EQ(la.getPostion(999), 0);
+}
+
+// ============================================================================
+// 逐字歌词（多时间戳格式）解析
+// ============================================================================
+TEST(LyricAnalysisTest, parsesMultiTimestampLyrics)
+{
+    TempLrcFile tempLrc("[00:27.94]持[00:28.26]有[00:28.54]一[00:28.77]半[00:31.03]\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    ASSERT_EQ(la.getCount(), 1);
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("持有一半"));
+    EXPECT_TRUE(la.hasWordTiming(0));
+    EXPECT_EQ(la.getWordTiming(0).size(), 5);
+}
+
+TEST(LyricAnalysisTest, wordTimingHasCorrectTimes)
+{
+    TempLrcFile tempLrc("[00:27.94]持[00:28.26]有[00:28.54]一[00:28.77]半[00:31.03]\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    auto words = la.getWordTiming(0);
+    ASSERT_EQ(words.size(), 5);
+    EXPECT_EQ(words[0].time, 27940);
+    EXPECT_EQ(words[0].text, QStringLiteral("持"));
+    EXPECT_EQ(words[1].time, 28260);
+    EXPECT_EQ(words[1].text, QStringLiteral("有"));
+    EXPECT_EQ(words[2].time, 28540);
+    EXPECT_EQ(words[2].text, QStringLiteral("一"));
+    EXPECT_EQ(words[3].time, 28770);
+    EXPECT_EQ(words[3].text, QStringLiteral("半"));
+    EXPECT_EQ(words[4].time, 31030);
+    EXPECT_EQ(words[4].text, QStringLiteral(""));
+}
+
+TEST(LyricAnalysisTest, simpleLyricsHaveNoWordTiming)
+{
+    TempLrcFile tempLrc("[00:01.20]first line\n[00:03.50]second line\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    EXPECT_FALSE(la.hasWordTiming(0));
+    EXPECT_FALSE(la.hasWordTiming(1));
+    EXPECT_TRUE(la.getWordTiming(0).isEmpty());
+}
+
+TEST(LyricAnalysisTest, mixedFormatLyrics)
+{
+    // 混合格式：普通歌词 + 逐字歌词
+    TempLrcFile tempLrc(
+        "[00:01.00]普通歌词\n"
+        "[00:05.00]逐[00:05.20]字[00:05.40]歌[00:05.60]词\n"
+        "[00:10.00]另一行普通歌词\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    ASSERT_EQ(la.getCount(), 3);
+
+    // 第一行：普通歌词
+    EXPECT_FALSE(la.hasWordTiming(0));
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("普通歌词"));
+
+    // 第二行：逐字歌词
+    EXPECT_TRUE(la.hasWordTiming(1));
+    EXPECT_EQ(la.getLineAt(1), QStringLiteral("逐字歌词"));
+    EXPECT_EQ(la.getWordTiming(1).size(), 4);
+
+    // 第三行：普通歌词
+    EXPECT_FALSE(la.hasWordTiming(2));
+    EXPECT_EQ(la.getLineAt(2), QStringLiteral("另一行普通歌词"));
+}
+
+TEST(LyricAnalysisTest, multiTimestampSortedByFirstTime)
+{
+    // 多行逐字歌词，按首时间排序
+    TempLrcFile tempLrc(
+        "[00:10.00]第[00:10.20]二[00:10.40]行\n"
+        "[00:05.00]第[00:05.20]一[00:05.40]行\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+    ASSERT_EQ(la.getCount(), 2);
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("第一行"));
+    EXPECT_EQ(la.getLineAt(1), QStringLiteral("第二行"));
+    EXPECT_LE(la.getPostion(0), la.getPostion(1));
+}
+
+TEST(LyricAnalysisTest, wordTimingInvalidIndexReturnsEmpty)
+{
+    LyricAnalysis la;
+    EXPECT_TRUE(la.getWordTiming(-1).isEmpty());
+    EXPECT_TRUE(la.getWordTiming(999).isEmpty());
+    EXPECT_FALSE(la.hasWordTiming(-1));
+    EXPECT_FALSE(la.hasWordTiming(999));
 }


### PR DESCRIPTION
- Add LyricWord struct for per-word timing data
- Parser supports LRC word-by-word format (e.g. [00:27.94]持[00:28.26]有)
- Fix centisecond parsing to correctly convert 1/100s to milliseconds
- LyricPage/LyricRect add word-by-word rendering with per-word highlight
- Presenter passes word timing data to QML layer
- Add related unit tests

feat: 支持逐字歌词解析与高亮显示

- 新增 LyricWord 结构体，用于存储逐字歌词的时间轴数据
- 解析器支持 LRC 逐字格式（如 [00:27.94]持[00:28.26]有）
- 修复厘秒解析，正确将百分之一秒转换为毫秒
- LyricPage/LyricRect 添加逐字歌词渲染逻辑，支持逐字高亮
- Presenter 传递逐字歌词数据到 QML 层
- 添加相关单元测试

<img width="2166" height="1432" src="https://github.com/user-attachments/assets/e3cbdd95-4a90-4a26-88f4-7c766cdbd77d" />

## Summary by Sourcery

Add end-to-end support for parsing and highlighting word-timed lyrics while preserving standard lyric handling.

New Features:
- Support parsing lyric lines with per-word timestamps and expose their timing data to the presentation layer.
- Render per-word lyric highlighting in the QML lyric view based on playback position.

Bug Fixes:
- Correct conversion of LRC fractional timestamps from centiseconds to milliseconds.

Tests:
- Add unit coverage for per-word parsing, timestamp conversion, mixed lyric formats, ordering, and invalid timing indexes.