### PR TITLE
fix(utils): avoid regex creation in pinyin splitting

### DIFF
--- a/src/libdmusic/util/utils.cpp
+++ b/src/libdmusic/util/utils.cpp
@@ -13,7 +13,6 @@
 #include <QCryptographicHash>
 #include <QDebug>
 #include <QTextCodec>
-#include <QRegExp>
 
 #include <DPinyin>
 
@@ -32,15 +31,14 @@ bool Utils::isChinese(const QChar &c)
 static inline bool isAlphabeta(const QChar &c)
 {
     qCDebug(dmMusic) << "Checking if character is alphabeta:" << c;
-    QRegExp re("[A-Za-z]*");
-    return re.exactMatch(c);
+    return (c >= QLatin1Char('A') && c <= QLatin1Char('Z'))
+            || (c >= QLatin1Char('a') && c <= QLatin1Char('z'));
 }
 
 static inline bool isNumber(const QChar &c)
 {
     qCDebug(dmMusic) << "Checking if character is number:" << c;
-    QRegExp re("[0-9]*");
-    return re.exactMatch(c);
+    return c >= QLatin1Char('0') && c <= QLatin1Char('9');
 }
 
 static inline QString toChinese(const QString &c)

--- a/tests/libdmusic-test/test_utils.cpp
+++ b/tests/libdmusic-test/test_utils.cpp
@@ -327,16 +327,12 @@ TEST(UtilsArtistToVariantMapTest, mapsCoreFieldsAndNestedMusicinfos)
 // simpleChineseSplit : 中英混合分词，中文转拼音
 // 注意：依赖 Dtk::Core::Chinese2Pinyin，只断言可观察不变量
 // ============================================================================
-TEST(UtilsSimpleChineseSplitTest, handlesAsciiWithoutCrash)
+TEST(UtilsSimpleChineseSplitTest, preservesAsciiLetterAndDigitClassification)
 {
-    // 已知源码缺陷：simpleChineseSplit 的 isLastAlphabeta 更新位于
-    // if(isCurAlphabeta){...continue;} 之后，字母字符 continue 时跳过更新，
-    // 导致连续 ASCII 被拆成单字符 token（"hello" → ['h','e','l','l','o']）。
-    // 此处只验证不崩溃 + 拼接内容完整，不强断言聚合行为；待源码修复后启用强断言。
-    QString s = "hello";
+    // 此任务仅替换字符分类实现，不改变当前连续 ASCII 字母、数字和符号的分词结果。
+    QString s = "Ab12-";
     const QStringList result = Utils::simpleChineseSplit(s);
-    EXPECT_FALSE(result.isEmpty());
-    EXPECT_EQ(result.join(""), "hello");
+    EXPECT_EQ(result, QStringList({"A", "b", "1", "2", "-"}));
 }
 
 TEST(UtilsSimpleChineseSplitTest, convertsChineseToPinyin)


### PR DESCRIPTION
Replace per-character QRegExp matching with ASCII comparisons. 用 ASCII 范围判断替代逐字符 QRegExp 匹配。

Log: 优化拼音分词字符分类
Influence: 减少导入音乐时的字符分类开销，保持现有分词结果不变。

## Summary by Sourcery

Replace regex-based ASCII character classification in pinyin splitting utilities with direct ASCII range checks while keeping existing tokenization behavior unchanged.

Enhancements:
- Optimize ASCII letter and digit detection in simpleChineseSplit by using direct range comparisons instead of per-character QRegExp creation.

Tests:
- Adjust simpleChineseSplit tests to assert the current ASCII letter, digit, and symbol tokenization behavior is preserved.