### PR TITLE
fix(audioanalysis): reuse precomputed import hashes

### DIFF
--- a/src/libdmusic/core/audioanalysis.cpp
+++ b/src/libdmusic/core/audioanalysis.cpp
@@ -118,23 +118,27 @@ void AudioAnalysis::parseAudioBuffer(const DMusic::MediaMeta &meta)
     qCDebug(dmMusic) << "Audio buffer parsing completed for hash:" << meta.hash;
 }
 
-DMusic::MediaMeta AudioAnalysis::creatMediaMeta(const QString &path)
+DMusic::MediaMeta AudioAnalysis::creatMediaMeta(const QString &path,
+                                                const QString &precomputedHash)
 {
     qCDebug(dmMusic) << "Creating media metadata for path:" << path;
     DMusic::MediaMeta mediaMeta;
-    QFileInfo fileinfo(path);
-    while (fileinfo.isSymLink()) {  //to find final target
-        qCDebug(dmMusic) << "Following symlink from" << fileinfo.absoluteFilePath() << "to" << fileinfo.symLinkTarget();
-        fileinfo.setFile(fileinfo.symLinkTarget());
-    }
-    auto hash = Utils::filePathHash(fileinfo.absoluteFilePath());
-    mediaMeta.hash = hash;
+    mediaMeta.hash = precomputedHash;
     mediaMeta.localPath = path;
-    
+
+    if (mediaMeta.hash.isEmpty()) {
+        QFileInfo fileinfo(path);
+        while (fileinfo.isSymLink()) {  //to find final target
+            qCDebug(dmMusic) << "Following symlink from" << fileinfo.absoluteFilePath() << "to" << fileinfo.symLinkTarget();
+            fileinfo.setFile(fileinfo.symLinkTarget());
+        }
+        mediaMeta.hash = Utils::filePathHash(fileinfo.absoluteFilePath());
+    }
+
     if (!parseMetaFromLocalFile(mediaMeta)) {
         qCWarning(dmMusic) << "Failed to parse metadata from local file:" << path;
     } else {
-        qCDebug(dmMusic) << "Successfully created media metadata for:" << path << "hash:" << hash;
+        qCDebug(dmMusic) << "Successfully created media metadata for:" << path << "hash:" << mediaMeta.hash;
     }
 
     return mediaMeta;

--- a/src/libdmusic/core/audioanalysis.h
+++ b/src/libdmusic/core/audioanalysis.h
@@ -19,7 +19,8 @@ public:
 
     void parseAudioBuffer(const DMusic::MediaMeta &meta);
 
-    static DMusic::MediaMeta creatMediaMeta(const QString &path);
+    static DMusic::MediaMeta creatMediaMeta(const QString &path,
+                                            const QString &precomputedHash = QString());
     static void convertMetaCodec(DMusic::MediaMeta &meta, const QString &codecName);
     static bool parseMetaFromLocalFile(DMusic::MediaMeta &meta);
     static QStringList detectEncodings(const DMusic::MediaMeta &meta);

--- a/src/libdmusic/core/dboperate.cpp
+++ b/src/libdmusic/core/dboperate.cpp
@@ -97,7 +97,7 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
             } else if (!allMetaHashs.contains(mediaMeta.hash)) {
                 // 标记为正在导入，防止其他任务重复处理
                 m_importingHashes.insert(hash);
-                mediaMeta = AudioAnalysis::creatMediaMeta(filePath);
+                mediaMeta = AudioAnalysis::creatMediaMeta(filePath, hash);
                 if (mediaMeta.length > 0) {
                     mediaMeta.hasimage = false;
                     pendingCovers.append(mediaMeta);  // cover/lyrics extracted after loop
@@ -116,7 +116,7 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
             if (!allMetaHashs.contains(mediaMeta.hash)) {
                 // 标记为正在导入，防止其他任务重复处理
                 m_importingHashes.insert(hash);
-                mediaMeta = AudioAnalysis::creatMediaMeta(filePath);
+                mediaMeta = AudioAnalysis::creatMediaMeta(filePath, hash);
                 if (mediaMeta.length > 0) {
                     mediaMeta.hasimage = false;
                     pendingCovers.append(mediaMeta);  // cover/lyrics extracted after loop

--- a/tests/libdmusic-test/test_audioanalysis.cpp
+++ b/tests/libdmusic-test/test_audioanalysis.cpp
@@ -202,6 +202,16 @@ TEST(AudioAnalysisParseFileTest, creatMediaMetaBuildsHashAndFiletype)
     EXPECT_EQ(meta.filetype, "mp3");
 }
 
+TEST(AudioAnalysisParseFileTest, creatMediaMetaUsesPrecomputedHash)
+{
+    ASSERT_TRUE(QFile::exists(sampleMp3Path()));
+    const QString precomputedHash = "precomputed-hash";
+    const auto meta = AudioAnalysis::creatMediaMeta(sampleMp3Path(), precomputedHash);
+    EXPECT_EQ(meta.hash, precomputedHash);
+    EXPECT_EQ(meta.localPath, sampleMp3Path());
+    EXPECT_EQ(meta.filetype, "mp3");
+}
+
 TEST(AudioAnalysisParseFileTest, parseMetaCoverDoesNotCrash)
 {
     DMusic::MediaMeta meta;


### PR DESCRIPTION
Reuse hashes calculated by DBOperate during media metadata creation. 在创建媒体元数据时复用 DBOperate 已计算的 hash。

Log: 复用导入预计算文件哈希
Influence: 减少新增歌曲导入时的重复路径解析和 hash 计算。

## Summary by Sourcery

Reuse precomputed file hashes when creating media metadata to avoid redundant path resolution and hash calculation during audio import.

Bug Fixes:
- Ensure AudioAnalysis::creatMediaMeta can accept and prefer a precomputed hash while still computing a hash when none is provided.

Enhancements:
- Add optional hash parameter to media metadata creation and wire it through DBOperate to reuse import-time hashes.
- Extend audio analysis tests to cover usage of precomputed hashes when building media metadata.

Tests:
- Add unit test verifying that creatMediaMeta uses a provided precomputed hash and still parses media type correctly.