### PR TITLE
fix: improve search result UI and navigation

### DIFF
--- a/src/music-player/allItems/SortMenu.qml
+++ b/src/music-player/allItems/SortMenu.qml
@@ -13,8 +13,6 @@ ToolButton{
 
     id: sortBtn
     width: 54; height: 36
-    anchors.right: parent.right
-    anchors.verticalCenter: parent.verticalCenter
     indicator: ButtonIndicator {}
     icon.name: {
         if (sortPageHash === "artist" || sortPageHash === "artistResult") {

--- a/src/music-player/allItems/ToolButtonItem.qml
+++ b/src/music-player/allItems/ToolButtonItem.qml
@@ -79,6 +79,8 @@ Rectangle{
     }
     SortMenu{
         id: dataSort
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
         sortPageHash: pageHash
         pageSortType: sortType
         pageTitle: title

--- a/src/music-player/dialogs/SearchResultDialog.qml
+++ b/src/music-player/dialogs/SearchResultDialog.qml
@@ -18,6 +18,10 @@ Popup {
     id: searchResultRect
     width: 360
     height: (songList == null ? 0 : songList.length + artistModel.count + albumModel.count) * itemHeight + 110
+    leftPadding: 8
+    rightPadding: 8
+    topPadding: 8
+    bottomPadding: 8
 
     Column {
         width: parent.width
@@ -26,7 +30,9 @@ Popup {
         MenuSeparator {
             text: qsTr("Songs")
             anchors.left: parent.left
-            anchors.leftMargin: 30
+            anchors.leftMargin: 12
+            font.pixelSize: 14
+            font.bold: true
             visible: (songList == null || songList.length == 0) ? false : true
         }
 
@@ -38,7 +44,9 @@ Popup {
         MenuSeparator {
             text: qsTr("Artists")
             anchors.left: parent.left
-            anchors.leftMargin: 30
+            anchors.leftMargin: 12
+            font.pixelSize: 14
+            font.bold: true
             visible: artistModel.count === 0 ? false : true
         }
         Repeater {
@@ -49,7 +57,9 @@ Popup {
         MenuSeparator {
             text: qsTr("Albums")
             anchors.left: parent.left
-            anchors.leftMargin: 30
+            anchors.leftMargin: 12
+            font.pixelSize: 14
+            font.bold: true
             visible: albumModel.count === 0 ? false : true
         }
         Repeater {
@@ -64,6 +74,7 @@ Popup {
             id: itemRect
             width: parent.width
             height: itemHeight
+            radius: 6
             color: "#00000000"
             Row {
                 width: parent.width
@@ -85,11 +96,11 @@ Popup {
                     itemRect.color = palette.highlight
                 }
                 onExited: {
-                    itemRect.color = "transparent"
+                    itemRect.color = "#00000000"
                 }
                 onClicked: {
                     searchItemTriggered(songList[index], 0)
-                    searchResultRect.visible = false
+                    searchResultRect.close()
                 }
             }
         }
@@ -101,6 +112,7 @@ Popup {
             id: itemRect
             width: parent.width
             height: itemHeight
+            radius: 6
             color: "#00000000"
             Row {
                 width: parent.width
@@ -130,10 +142,9 @@ Popup {
                     itemRect.color = palette.highlight
                 }
                 onExited: {
-                    itemRect.color = "transparent"
+                    itemRect.color = "#00000000"
                 }
                 onClicked: {
-//                    console.log(model.type)
                     var type = 0
 
                     if (model.type === "artist")
@@ -142,7 +153,7 @@ Popup {
                         type = 2
 
                     searchItemTriggered(model.name, type)
-                    searchResultRect.visible = false
+                    searchResultRect.close()
                 }
             }
         }

--- a/src/music-player/mainwindow/SearchResultWindow.qml
+++ b/src/music-player/mainwindow/SearchResultWindow.qml
@@ -23,19 +23,22 @@ Rectangle {
     property ListModel albumsModel: ListModel{}
     property ListModel artistsModel: ListModel{}
     property int curIndex: tabArea.currentIndex
-    signal itemDoubleClicked(var artistData)
+    property int switchType: globalVariant.globalSwitchButtonStatus
+    property string selectedArtistName: ""
+    property string selectedAlbumName: ""
+    signal itemDoubleClicked(var data)
     property var artistData
 
     Component {
         id: artistSublistView
         ArtistSublistView {
-            artistData:searchRootRect.artistData
+            artistData: searchRootRect.artistData
         }
     }
     Component {
         id: albumSublistView
         AlbumSublistView {
-            albumData:searchRootRect.artistData
+            albumData: searchRootRect.artistData
         }
     }
 
@@ -56,224 +59,266 @@ Rectangle {
         }
     }
 
-    Rectangle {
-        width: parent.width
-        height: parent.height
-        color: "transparent"
+    StackView {
+        id: navigationStackView
+        anchors.fill: parent
         visible: curIndex < 0 ? false : true
-        ColumnLayout {
-            width: parent.width
-            height: parent.height
 
-            Rectangle {
-                id: headArea
-                width: parent.width - 40
-                height: 72
-                Layout.leftMargin: 20
-                Layout.rightMargin: 20
-                color: "transparent"
+        initialItem: Rectangle {
+            width: navigationStackView.width
+            height: navigationStackView.height
+            color: "transparent"
+            ColumnLayout {
+                width: parent.width
+                height: parent.height
 
-                Row {
-                    anchors.fill: parent
-                    topPadding: 17
-                    spacing: 10
-                    FloatingButton {
-                        id: playAllBtn
-                        width: 28; height: 28
-                        icon.name: "headline_play_all"
-                        icon.width: 28
-                        icon.height: 28
-                        ToolTip {
-                            visible: playAllBtn.hovered
-                            text: qsTr("Play All")
-                        }
-                        onClicked: {
-                            Presenter.playPlaylist("musicResult");
-                        }
-                    }
-                    Label {
-                        id: buttonLable
-                        text: qsTr("Search Results")
-                        font: DTK.fontManager.t4
-                    }
-                    Label {
-                        font: DTK.fontManager.t8
-                        text: albumsModel.count !== 1 ? qsTr("%1 albums - %2 songs").arg(albumsModel.count).arg(songsModel.count) :
-                                                        (songsModel.count === 1 ? qsTr("1 album - 1 song") : qsTr("%1 album - %2 songs").arg(albumsModel.count).arg(songsModel.count))
-                        anchors.verticalCenter: buttonLable.verticalCenter
-                    }
-                }
-            }
-
-            RowLayout {
-                id: headerLayout
-                Layout.rightMargin: 40
-                TabBar {
-                    id: tabArea
+                Rectangle {
+                    id: headArea
                     width: parent.width - 40
-                    height: parent.height - headArea.height
+                    height: 72
                     Layout.leftMargin: 20
                     Layout.rightMargin: 20
-                    currentIndex: 0
+                    color: "transparent"
 
-                    TabButton {
-                        text: qsTr("Music")
-                        width: 82
-                    }
-                    TabButton {
-                        text: qsTr("Album")
-                        width: 82
-                    }
-                    TabButton {
-                        text: qsTr("Artist")
-                        width: 82
-                    }
-                }
-                Item { Layout.fillWidth: true }
-                SortMenu {
-                    id: allMusicSortMenu
-                    visible: tabArea.currentIndex === 0
-                    sortPageHash: "musicResult"
-                    Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-                    pageSortType: 0
-                }
-                SortMenu {
-                    id: albumMusicSortMenu
-                    visible: tabArea.currentIndex === 1
-                    sortPageHash: "albumResult"
-                    Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-                    pageSortType: 0
-                }
-                SortMenu {
-                    id: artistMusicSortMenu
-                    visible: tabArea.currentIndex === 2
-                    sortPageHash: "artistResult"
-                    Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-                    pageSortType: 0
-                }
-
-                Component.onCompleted: {
-                    var musicSortType = Presenter.playlistSortType("musicResult")
-                    var artistSortType = Presenter.playlistSortType("artistResult")
-                    var albumSortType = Presenter.playlistSortType("albumResult")
-
-                    switch(musicSortType) {
-                    case 10:
-                        allMusicSortMenu.pageSortType = 0
-                        break
-                    case 11:
-                        allMusicSortMenu.pageSortType = 1
-                        break
-                    case 12:
-                        allMusicSortMenu.pageSortType = 2
-                        break
-                    case 13:
-                        allMusicSortMenu.pageSortType = 3
-                        break
-                    default:
-                        allMusicSortMenu.pageSortType = -1
-                    }
-
-                    switch(albumSortType) {
-                    case 10:
-                        albumMusicSortMenu.pageSortType = 0
-                        break
-                    case 13:
-                        albumMusicSortMenu.pageSortType = 1
-                        break
-                    default:
-                        albumMusicSortMenu.pageSortType = -1
-                    }
-
-                    switch(artistSortType) {
-                    case 10:
-                        artistMusicSortMenu.pageSortType = 0
-                        break
-                    case 12:
-                        artistMusicSortMenu.pageSortType = 2
-                        break
-                    default:
-                        artistMusicSortMenu.pageSortType = -1
-                    }
-                }
-            }
-
-            StackLayout {
-                id: myStackView
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                Layout.leftMargin: 20
-                Layout.rightMargin: 20
-                clip: true
-                visible: curIndex < 0 ? false : true
-                currentIndex: tabArea.currentIndex
-
-                AllMusicListView {
-                    id: allMusicList
-                    width: parent.width
-                    height: parent.height
-                    mediaModel: songsModel
-                    viewListHash: "musicResult"
-                }
-                GridView {
-                    id: artistView
-                    width: Math.floor(parent.width / 196) * 196;
-                    height: parent.height
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.top: parent.top; anchors.topMargin: 34
-                    anchors.leftMargin: (parent.width - width) / 2
-                    anchors.rightMargin: (parent.width - width) / 2
-                    cellWidth: 196; cellHeight: 196
-                    ScrollBar.vertical: ScrollBar {}
-                    clip: true
-                    model: artistsModel
-                    delegate: ArtistGridDelegate{
-                        id: musicSingerGridItem
-                        onItemDoubleClicked: {
-                            searchRootRect.itemDoubleClicked(artistData);
+                    Row {
+                        anchors.fill: parent
+                        topPadding: 17
+                        spacing: 10
+                        FloatingButton {
+                            id: playAllBtn
+                            width: 28; height: 28
+                            icon.name: "headline_play_all"
+                            icon.width: 28
+                            icon.height: 28
+                            ToolTip {
+                                visible: playAllBtn.hovered
+                                text: qsTr("Play All")
+                            }
+                            onClicked: {
+                                Presenter.playPlaylist("musicResult");
+                            }
+                        }
+                        Label {
+                            id: buttonLable
+                            text: qsTr("Search Results")
+                            font: DTK.fontManager.t4
+                        }
+                        Label {
+                            font: DTK.fontManager.t8
+                            text: albumsModel.count !== 1 ? qsTr("%1 albums - %2 songs").arg(albumsModel.count).arg(songsModel.count) :
+                                                            (songsModel.count === 1 ? qsTr("1 album - 1 song") : qsTr("%1 album - %2 songs").arg(albumsModel.count).arg(songsModel.count))
+                            anchors.verticalCenter: buttonLable.verticalCenter
                         }
                     }
-                    onWidthChanged: {
-                        var w =  Math.floor(tabArea.width / 196) * 196;
-                        var m = (tabArea.width - w) / 2;
-                        anchors.leftMargin = m;
-                        anchors.rightMargin = m;
-                    }
                 }
-                GridView {
-                    id: albumGridView
-                    width: Math.floor(parent.width / 201) * 201;
-                    height: parent.height
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.top: parent.top; anchors.topMargin: 5
-                    anchors.leftMargin: (parent.width - width) / 2
-                    anchors.rightMargin: (parent.width - width) / 2
-                    cellWidth: 201; cellHeight: 228
-                    ScrollBar.vertical: ScrollBar {}
-                    clip: true
-                    model: albumsModel
-                    delegate: AlbumGridDelegate{
-                        id: itemDelegate
-                        playing: (globalVariant.curPlayingStatus === DmGlobal.Playing) ? true : false
-                        onItemDoubleClicked: {
-                            console.log("onItemDoubleClicked: " + albumData);
-                            searchRootRect.itemDoubleClicked(albumData);
+
+                RowLayout {
+                    id: headerLayout
+                    Layout.rightMargin: 40
+                    TabBar {
+                        id: tabArea
+                        width: parent.width - 40
+                        height: parent.height - headArea.height
+                        Layout.leftMargin: 20
+                        Layout.rightMargin: 20
+                        currentIndex: 0
+
+                        TabButton {
+                            text: qsTr("Music")
+                            width: 82
+                        }
+                        TabButton {
+                            text: qsTr("Album")
+                            width: 82
+                        }
+                        TabButton {
+                            text: qsTr("Artist")
+                            width: 82
                         }
                     }
-                    onWidthChanged: {
-                        var w =  Math.floor(tabArea.width / 201) * 201;
-                        var m = (tabArea.width - w) / 2;
-                        anchors.leftMargin = m;
-                        anchors.rightMargin = m;
+                    Item { Layout.fillWidth: true }
+                    SortMenu {
+                        id: allMusicSortMenu
+                        visible: tabArea.currentIndex === 0
+                        sortPageHash: "musicResult"
+                        Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                        pageSortType: 0
+                    }
+                    SortMenu {
+                        id: albumMusicSortMenu
+                        visible: tabArea.currentIndex === 1
+                        sortPageHash: "albumResult"
+                        Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                        pageSortType: 0
+                    }
+                    SortMenu {
+                        id: artistMusicSortMenu
+                        visible: tabArea.currentIndex === 2
+                        sortPageHash: "artistResult"
+                        Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                        pageSortType: 0
+                    }
+
+                    Component.onCompleted: {
+                        var musicSortType = Presenter.playlistSortType("musicResult")
+                        var artistSortType = Presenter.playlistSortType("artistResult")
+                        var albumSortType = Presenter.playlistSortType("albumResult")
+
+                        switch(musicSortType) {
+                        case 10:
+                            allMusicSortMenu.pageSortType = 0
+                            break
+                        case 11:
+                            allMusicSortMenu.pageSortType = 1
+                            break
+                        case 12:
+                            allMusicSortMenu.pageSortType = 2
+                            break
+                        case 13:
+                            allMusicSortMenu.pageSortType = 3
+                            break
+                        default:
+                            allMusicSortMenu.pageSortType = -1
+                        }
+
+                        switch(albumSortType) {
+                        case 10:
+                            albumMusicSortMenu.pageSortType = 0
+                            break
+                        case 13:
+                            albumMusicSortMenu.pageSortType = 1
+                            break
+                        default:
+                            albumMusicSortMenu.pageSortType = -1
+                        }
+
+                        switch(artistSortType) {
+                        case 10:
+                            artistMusicSortMenu.pageSortType = 0
+                            break
+                        case 12:
+                            artistMusicSortMenu.pageSortType = 2
+                            break
+                        default:
+                            artistMusicSortMenu.pageSortType = -1
+                        }
+                    }
+                }
+
+                StackLayout {
+                    id: myStackView
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    clip: true
+                    visible: curIndex < 0 ? false : true
+                    currentIndex: tabArea.currentIndex
+
+                    AllMusicListView {
+                        id: allMusicList
+                        mediaModel: songsModel
+                        viewListHash: "musicResult"
+                    }
+                    Item {
+                        GridView {
+                            id: artistView
+                            width: Math.floor(parent.width / 208) * 208
+                            height: parent.height
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            anchors.top: parent.top
+                            anchors.topMargin: 5
+                            cellWidth: 208
+                            cellHeight: 230
+                            ScrollBar.vertical: ScrollBar {}
+                            clip: true
+                            model: artistsModel
+                            delegate: ArtistGridDelegate{
+                                id: musicSingerGridItem
+                                onItemDoubleClicked: {
+                                    searchRootRect.itemDoubleClicked(artistData);
+                                }
+                            }
+                        }
+                    }
+                    Item {
+                        GridView {
+                            id: albumGridView
+                            width: Math.floor(parent.width / 208) * 208
+                            height: parent.height
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            anchors.top: parent.top
+                            anchors.topMargin: 5
+                            cellWidth: 208
+                            cellHeight: 242
+                            ScrollBar.vertical: ScrollBar {}
+                            clip: true
+                            model: albumsModel
+                            delegate: AlbumGridDelegate{
+                                id: itemDelegate
+                                playing: (globalVariant.curPlayingStatus === DmGlobal.Playing) ? true : false
+                                onItemDoubleClicked: {
+                                    searchRootRect.itemDoubleClicked(albumData);
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
+
+        popEnter: Transition {
+            NumberAnimation { property: "scale"; from: 0.8; to: 1; duration: 300; easing.type: Easing.InOutQuad }
+            NumberAnimation { property: "opacity"; from: 0.0; to: 1.0; duration: 300; easing.type: Easing.InOutQuad }
+        }
+
+        popExit: Transition {
+            NumberAnimation { property: "scale"; from: 1; to: 0.8; duration: 300; easing.type: Easing.InOutQuad }
+            NumberAnimation { property: "opacity"; from: 1.0; to: 0.0; duration: 200; easing.type: Easing.OutExpo }
+        }
+
+        pushEnter: Transition {
+            NumberAnimation { property: "scale"; from: 1.2; to: 1; duration: 300; easing.type: Easing.InOutQuad }
+            NumberAnimation { property: "opacity"; from: 0.0; to: 1.0; duration: 300; easing.type: Easing.InOutQuad }
+        }
+
+        pushExit: Transition {
+            NumberAnimation { property: "opacity"; from: 1.0; to: 0.0; duration: 200; easing.type: Easing.OutExpo }
+        }
     }
 
-    onItemDoubleClicked: {
-        searchRootRect.artistData = artistData
+    onItemDoubleClicked: function(data) {
+        searchRootRect.artistData = data
+        if (data.name !== undefined) {
+            selectedArtistName = data.name
+            selectedAlbumName = data.name
+        }
         globalVariant.globalSwitchButtonStatus = 2;
+    }
+
+    onSwitchTypeChanged: {
+        if (switchType === 1) {
+            navigationStackView.pop(navigationStackView.initialItem);
+        } else if (switchType === 2) {
+            if (tabArea.currentIndex === 2) {
+                var artistItem = navigationStackView.find(function(item) { return item.objectName === "artistSublist" })
+                if (artistItem !== null) {
+                    navigationStackView.pop(artistItem);
+                    return;
+                }
+                navigationStackView.push(artistSublistView);
+            } else if (tabArea.currentIndex === 1) {
+                var albumItem = navigationStackView.find(function(item) { return item.objectName === "albumSublist" })
+                if (albumItem !== null) {
+                    navigationStackView.pop(albumItem);
+                    return;
+                }
+                navigationStackView.push(albumSublistView);
+            }
+        }
+    }
+
+    function returnUpperlevelView() {
+        globalVariant.globalSwitchButtonStatus = 0;
+        navigationStackView.pop(navigationStackView.initialItem);
     }
 
     function updateSearchResultInfo(text, type) {
@@ -406,11 +451,15 @@ Rectangle {
 
     Connections {
         target: artistMoreMenu
-        onViewArtistDatails: { itemDoubleClicked(artistData);}
+        function onViewArtistDatails(artistData) { searchRootRect.itemDoubleClicked(artistData); }
     }
     Connections {
         target: albumMoreMenu
-        onViewAlbumDatails: { itemDoubleClicked(artistData);}
+        function onViewAlbumDatails(albumData) { searchRootRect.itemDoubleClicked(albumData); }
+    }
+    Connections {
+        target: globalVariant
+        function onReturnUpperlevelView() { searchRootRect.returnUpperlevelView(); }
     }
     Component.onCompleted: {
         updateSearchResultInfo(pattern, curIndex)

--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -309,7 +309,7 @@ TitleBar {
             }
             SearchResultDialog {
                 id: searchResDlg
-                width: 360
+                width: 360 //searchEdit.width
                 x: searchEdit.x - (width - searchEdit.width) / 2
                 y: 50
 


### PR DESCRIPTION
- Unify artist/album grid cell sizes (208x230/242) with library views
- Add StackView navigation for artist/album detail view from search results
- Fix search popup width to match search box
- Add rounded corners (radius: 6) to search popup items
- Adjust section labels position and font size in search popup
- Fix SortMenu anchors warning by moving anchors to ToolButtonItem
- Remove unused code and fix indentation

改进搜索结果界面和导航

- 统一艺人/专辑网格单元格大小（208x230/242）与资料库视图一致
- 添加 StackView 导航支持从搜索结果跳转到艺人/专辑详情
- 修复搜索弹窗宽度与搜索框一致
- 为搜索弹窗列表项添加圆角（radius: 6）
- 调整搜索弹窗中分组标签位置和字体大小
- 通过将 anchors 移到 ToolButtonItem 修复 SortMenu 的 anchors 警告
- 移除未使用代码并修复缩进

## Summary by Sourcery

Improve search results UI layout and add navigation from search results to artist/album detail views.

New Features:
- Add StackView-based navigation from search results to artist and album sublist views with animated transitions.
- Support returning to the upper-level view from global navigation state changes.

Bug Fixes:
- Fix SortMenu anchor warnings by moving anchors from SortMenu to ToolButtonItem.
- Ensure search result dialog items reset to a fully transparent background when not hovered.
- Close the search result dialog via the popup close method instead of toggling visibility to avoid inconsistent state.

Enhancements:
- Unify artist and album grid cell sizes and layout with library views in the search results page.
- Add padding, rounded corners, and adjusted section label styling to the search result popup for better readability.
- Initialize search result sort menus from saved sort types for music, album, and artist tabs.
- Wire artist and album context menu actions to reuse the common itemDoubleClicked handler.
- Align search result dialog width logic with the search box for future consistency.