### PR TITLE
feat: add MSYS2 build compatibility and debug CLI flag

### DIFF
--- a/src/libdmusic/core/dynamiclibraries.cpp
+++ b/src/libdmusic/core/dynamiclibraries.cpp
@@ -26,6 +26,8 @@ DynamicLibraries::DynamicLibraries()
         DmGlobal::setPlaybackEngineType(0);
     } else {
         qCDebug(dmMusic) << "Successfully initialized dynamic libraries";
+        // 加载成功时设置引擎类型为 VLC
+        DmGlobal::setPlaybackEngineType(1);
     }
 }
 

--- a/src/music-player/effect/shaderimageview.cpp
+++ b/src/music-player/effect/shaderimageview.cpp
@@ -62,6 +62,23 @@ void ShaderImageView::setPresenter(const QVariant &presenter)
     qCDebug(dmMusic) << "ShaderImageView setPresenter: presenterChanged";
 }
 
+void ShaderImageView::refreshCover()
+{
+    Presenter *pres = NULL;
+    if (m_pPresenter.canConvert<Presenter *>()) {
+        pres = m_pPresenter.value<Presenter *>();
+        if (pres) {
+            QImage img = pres->getActivateMetImage();
+            if (!img.isNull()) {
+                pres->setEffectImage(img);
+                if (window() && isComponentComplete()) {
+                    update();
+                }
+            }
+        }
+    }
+}
+
 
 
 void ShaderImageView::paint(QPainter *painter)

--- a/src/music-player/effect/shaderimageview.h
+++ b/src/music-player/effect/shaderimageview.h
@@ -27,6 +27,7 @@ public:
     void setSource(const QString &source);
     QVariant presenter() const;
     void setPresenter(const QVariant &presenter);
+    Q_INVOKABLE void refreshCover();
 private:
     QString m_source;
     QVariant m_pPresenter;

--- a/src/music-player/lyric/effectpublic/Circular_img.qml
+++ b/src/music-player/lyric/effectpublic/Circular_img.qml
@@ -36,6 +36,12 @@ Rectangle {
                 smooth: true
                 presenter: Presenter
 
+                Connections {
+                    target: Presenter
+                    function onMetaChanged() {
+                        _image.refreshCover()
+                    }
+                }
             }
         FastBlur {
             anchors.top: _image.top; anchors.topMargin: 3

--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -10,6 +10,13 @@
 #include <QIcon>
 #include <QDBusInterface>
 #include <QDBusReply>
+#include <QFileInfo>
+#include <QLoggingCategory>
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <QSharedMemory>
+#endif
 
 #include <DLog>
 #include <DGuiApplicationHelper>
@@ -21,6 +28,8 @@
 #include <string.h>
 #include <signal.h>
 #include <unistd.h>
+#include <QSocketNotifier>
+#endif
 
 #include "config.h"
 
@@ -37,11 +46,18 @@ DGUI_USE_NAMESPACE;
 
 QScopedPointer<Presenter, QScopedPointerPodDeleter> presenter;
 
+#ifdef Q_OS_LINUX
+static volatile sig_atomic_t s_sigTermReceived = 0;
+static int s_sigTermPipe[2] = {-1, -1};
+
 void sig_term_handler(int signum, siginfo_t *info, void *ptr)
 {
-    qDebug() << "SIGTERM received.";
-    presenter->saveDataToDB();
-    exit(1);
+    s_sigTermReceived = 1;
+    char c = 1;
+    // write() is async-signal-safe per POSIX
+    if (s_sigTermPipe[1] != -1) {
+        write(s_sigTermPipe[1], &c, sizeof(c));
+    }
 }
 
 // 此文件是QML应用的启动文件，一般无需修改
@@ -87,15 +103,24 @@ int main(int argc, char *argv[])
     parser.setApplicationDescription("Deepin music player.");
     parser.addHelpOption();
     parser.addVersionOption();
+    parser.addOption({{"d", "debug"}, "Enable debug log output"});
     parser.addPositionalArgument("file", "Music file path");
     parser.process(*app);
+
+    // 默认屏蔽 debug 级别日志，--debug 时启用
+    if (!parser.isSet("debug")) {
+        QLoggingCategory::setFilterRules(QStringLiteral("deepin.music.debug=false\n"
+                                                        "deepin.music.warning=true\n"
+                                                        "deepin.music.critical=true\n"
+                                                        "deepin.music.fatal=true"));
+    }
 
     // handle open file
     QStringList OpenFilePaths = parser.positionalArguments();
     if (!OpenFilePaths.isEmpty()) {
         qCDebug(dmMusic) << "OpenFilePaths: " << OpenFilePaths;
         QStringList strList;
-        for (QString str : OpenFilePaths) {
+        for (const QString &str : OpenFilePaths) {
             QUrl url = QUrl::fromLocalFile(QDir::current().absoluteFilePath(str));
             strList.append(url.toLocalFile().isEmpty() ? str : url.toLocalFile());
         }
@@ -169,11 +194,25 @@ int main(int argc, char *argv[])
     QObject::connect(&engine, &QQmlApplicationEngine::quit, presenter.data(), &Presenter::saveDataToDB);
 
     // 捕获强制退出信号，保存数据到数据库
-    static struct sigaction _sigact;
-    memset(&_sigact, 0, sizeof(_sigact));
-    _sigact.sa_sigaction = sig_term_handler;
-    _sigact.sa_flags = SA_SIGINFO;
-    sigaction(SIGTERM, &_sigact, NULL);
+    // 使用管道机制确保信号处理的安全性：signal handler 仅写入管道，
+    // 主线程通过 QSocketNotifier 监听管道读端，在事件循环中安全处理退出
+    if (pipe(s_sigTermPipe) == 0) {
+        static struct sigaction _sigact;
+        memset(&_sigact, 0, sizeof(_sigact));
+        _sigact.sa_sigaction = sig_term_handler;
+        _sigact.sa_flags = SA_SIGINFO;
+        sigaction(SIGTERM, &_sigact, NULL);
+
+        auto *notifier = new QSocketNotifier(s_sigTermPipe[0], QSocketNotifier::Read, app);
+        QObject::connect(notifier, &QSocketNotifier::activated, [&]() {
+            qCInfo(dmMusic) << "SIGTERM received, saving data and exiting...";
+            char c;
+            read(s_sigTermPipe[0], &c, sizeof(c));
+            presenter->saveDataToDB();
+            app->quit();
+        });
+    }
+#endif
 
     return app->exec();
 }


### PR DESCRIPTION
- Rewrite SIGTERM signal handling with pipe+SocketNotifier for thread safety
- Add --debug CLI flag to enable debug log output, disabled by default
- Add VLC library path configuration for MSYS2 environment
- Add refreshCover() to ShaderImageView for cover art updates
- Update Circular_img.qml for cover art refresh on metadata changes

新增 MSYS2 构建兼容性和调试 CLI 标志

- 使用管道+SocketNotifier 重写 SIGTERM 信号处理确保线程安全
- 添加 --debug CLI 标志启用调试日志输出，默认禁用
- 为 MSYS2 环境添加 VLC 库路径配置
- 为 ShaderImageView 添加 refreshCover() 用于封面图更新
- 更新 Circular_img.qml 以在元数据变化时刷新封面图

## Summary by Sourcery

Add a debug CLI flag, improve SIGTERM handling, and support VLC/MSYS2 playback engine configuration while refreshing cover art on metadata changes.

New Features:
- Introduce a --debug CLI flag to enable debug log output for the music player.
- Expose a QML-invokable refreshCover() method on ShaderImageView to refresh cover art from the presenter when metadata changes.

Enhancements:
- Refactor SIGTERM handling on Linux to use a pipe and QSocketNotifier for safe data saving and graceful application exit.
- Set the playback engine type to VLC upon successful dynamic library initialization.
- Trigger cover art refresh in Circular_img.qml when Presenter metadata changes.