### PR TITLE
fix: QtPlayer volume setting - convert int to qreal

### DIFF
--- a/src/libdmusic/player/qtplayer.cpp
+++ b/src/libdmusic/player/qtplayer.cpp
@@ -200,7 +200,7 @@ void QtPlayer::setFadeInOutFactor(double fadeInOutFactor)
 {
     qCDebug(dmMusic) << "Set fade in/out factor";
     init();
-    m_audioOutput->setVolume(static_cast<int>(10 * fadeInOutFactor));
+    m_audioOutput->setVolume(qBound(0.0, static_cast<qreal>(m_volume) / 100.0 * fadeInOutFactor, 1.0));
 }
 
 void QtPlayer::setVolume(int volume)
@@ -209,7 +209,7 @@ void QtPlayer::setVolume(int volume)
     init();
     qCDebug(dmMusic) << "Setting volume to:" << volume;
     m_volume = volume;
-    m_audioOutput->setVolume(volume);
+    m_audioOutput->setVolume(volume / 100.0);
 }
 
 int QtPlayer::getVolume()


### PR DESCRIPTION
- Fix setFadeInOutFactor to use proper volume scaling (0.0-1.0 range)
- Fix setVolume to divide by 100.0 for correct volume level

## Summary by Sourcery

Bug Fixes:
- Correct QtPlayer volume and fade scaling to use the audio output's normalized 0.0–1.0 range.