### PR TITLE
fix: improve VLC engine detection and null safety

### DIFF
--- a/src/libdmusic/core/dynamiclibraries.cpp
+++ b/src/libdmusic/core/dynamiclibraries.cpp
@@ -37,6 +37,8 @@ DynamicLibraries::DynamicLibraries()
         DmGlobal::setPlaybackEngineType(0);
     } else {
         qCDebug(dmMusic) << "Successfully initialized dynamic libraries";
+        // 加载成功时设置引擎类型为 VLC
+        DmGlobal::setPlaybackEngineType(1);
     }
 }
 

--- a/src/libdmusic/global.cpp
+++ b/src/libdmusic/global.cpp
@@ -4,6 +4,7 @@
 
 #include "global.h"
 #include "util/log.h"
+#include "core/dynamiclibraries.h"
 
 #include <QVariantMap>
 #include <QProcessEnvironment>
@@ -240,21 +241,10 @@ void DmGlobal::initPlaybackEngineType()
 {
     qCDebug(dmMusic) << "Initializing playback engine";
     engineType = 0;
-#ifdef Q_OS_WIN
-    if (libExist("libvlc") && libExist("avcodec-62")) {
-        engineType = 1;
-        qCInfo(dmMusic) << "Windows: VLC playback engine initialized successfully";
-    } else {
-        qCInfo(dmMusic) << "Windows: VLC not available, using QtPlayer engine";
-    }
-#else
-    if (libExist("libvlc.so") && libExist("libavcodec.so")) {
-        engineType = 1;
-        qCInfo(dmMusic) << "VLC playback engine initialized successfully";
-    } else {
-        qCWarning(dmMusic) << "Failed to initialize VLC playback engine, falling back to default";
-    }
-#endif
+    // 触发 DynamicLibraries 单例初始化，它会加载 VLC 库并设置 engineType
+    // 这样避免了重复加载库的开销
+    DynamicLibraries::instance();
+    qCInfo(dmMusic) << "Playback engine type initialized to:" << engineType;
 }
 
 void DmGlobal::setPlaybackEngineType(int type)

--- a/src/libdmusic/player/vlcplayer.cpp
+++ b/src/libdmusic/player/vlcplayer.cpp
@@ -145,6 +145,7 @@ void VlcPlayer::startCdaThread()
     QTimer::singleShot(1000, this, [ = ]() {
         qCDebug(dmMusic) << __func__ << "timer timeout.";
         init();
+        if (!m_qvplayer) return;
         qCDebug(dmMusic) << "init cda thread.";
         //初始化mediaplayer
         m_pCdaThread->setMediaPlayerPointer(m_qvplayer->core());
@@ -159,7 +160,9 @@ void VlcPlayer::play()
 {
     qCDebug(dmMusic) << "Starting playback";
     init();
-    m_qvplayer->play();
+    if (m_qvplayer) {
+        m_qvplayer->play();
+    }
 }
 
 void VlcPlayer::pause()
@@ -208,6 +211,7 @@ void VlcPlayer::stop()
 int VlcPlayer::length()
 {
     init();
+    if (!m_qvplayer) return 0;
     int len = m_qvplayer->length();
     qCDebug(dmMusic) << "Track length:" << len << "ms";
     return len;
@@ -216,6 +220,7 @@ int VlcPlayer::length()
 void VlcPlayer::setTime(qint64 time)
 {
     init();
+    if (!m_qvplayer) return;
     qCDebug(dmMusic) << "Setting playback position to:" << time << "ms";
     m_qvplayer->setTime(time);
 }
@@ -223,6 +228,7 @@ void VlcPlayer::setTime(qint64 time)
 qint64 VlcPlayer::time()
 {
     init();
+    if (!m_qvplayer) return 0;
     qint64 pos = m_qvplayer->time();
     qCDebug(dmMusic) << "Current playback position:" << pos << "ms";
     return pos;
@@ -232,6 +238,7 @@ void VlcPlayer::setMediaMeta(MediaMeta meta)
 {
     qCInfo(dmMusic) << "Setting media meta - Title:" << meta.title << "Path:" << meta.localPath;
     init();
+    if (!m_qvplayer) return;
     m_activeMeta = meta;
     m_qvmedia->initMedia(meta.localPath, meta.mmType == DmGlobal::MimeTypeCDA ? false : true, m_qvinstance, meta.track);
     m_qvplayer->open(m_qvmedia);
@@ -245,6 +252,7 @@ void VlcPlayer::setMediaMeta(MediaMeta meta)
 void VlcPlayer::setFadeInOutFactor(double fadeInOutFactor)
 {
     init();
+    if (!m_qvplayer) return;
     m_qvplayer->equalizer()->blockSignals(true);
     setPreamplification(static_cast<float>(12 * fadeInOutFactor));
     m_qvplayer->equalizer()->blockSignals(false);
@@ -253,6 +261,7 @@ void VlcPlayer::setFadeInOutFactor(double fadeInOutFactor)
 void VlcPlayer::setEqualizerEnabled(bool enabled)
 {
     init();
+    if (!m_qvplayer) return;
     qCInfo(dmMusic) << "Setting equalizer enabled:" << enabled;
     m_qvplayer->equalizer()->setEnabled(enabled);
 }
@@ -260,6 +269,7 @@ void VlcPlayer::setEqualizerEnabled(bool enabled)
 void VlcPlayer::loadFromPreset(uint index)
 {
     init();
+    if (!m_qvplayer) return;
     qCDebug(dmMusic) << "Loading equalizer preset:" << index;
     m_qvplayer->equalizer()->loadFromPreset(index);
 }
@@ -267,24 +277,28 @@ void VlcPlayer::loadFromPreset(uint index)
 void VlcPlayer::setPreamplification(float value)
 {
     init();
+    if (!m_qvplayer) return;
     m_qvplayer->equalizer()->setPreamplification(value);
 }
 
 void VlcPlayer::setAmplificationForBandAt(float amp, uint bandIndex)
 {
     init();
+    if (!m_qvplayer) return;
     m_qvplayer->equalizer()->setAmplificationForBandAt(amp, bandIndex);
 }
 
 float VlcPlayer::amplificationForBandAt(uint bandIndex)
 {
     init();
+    if (!m_qvplayer) return 0.0f;
     return m_qvplayer->equalizer()->amplificationForBandAt(bandIndex);
 }
 
 float VlcPlayer::preamplification()
 {
     init();
+    if (!m_qvplayer) return 0.0f;
     return m_qvplayer->equalizer()->preamplification();
 }
 
@@ -316,6 +330,7 @@ void VlcPlayer::setMute(bool value)
 void VlcPlayer::initCddaTrack()
 {
     init();
+    if (!m_qvplayer) return;
     qCDebug(dmMusic) << "Initializing CDDA track";
     m_qvplayer->initCddaTrack();
 }
@@ -323,6 +338,7 @@ void VlcPlayer::initCddaTrack()
 void VlcPlayer::setEqualizer(bool enabled, int curIndex, QList<int> indexbaud)
 {
     init();
+    if (!m_qvplayer) return;
     qCInfo(dmMusic) << "Configuring equalizer - Enabled:" << enabled << "Index:" << curIndex;
     if (enabled) {
         //非自定义模式时


### PR DESCRIPTION
- Add null pointer safety guards for m_qvplayer in all VLC player methods
- Replace inline VLC library detection with DynamicLibraries singleton
- Set playback engine type to VLC when dynamic libraries load successfully

fix: 优化VLC引擎检测和空值安全

- 在所有VLC播放器方法中为m_qvplayer添加空指针安全保护
- 使用DynamicLibraries单例替换内联VLC库检测
- 当动态库加载成功时设置播放引擎类型为VLC

## Summary by Sourcery

Improve VLC engine initialization and make player operations safe when VLC is unavailable.

Bug Fixes:
- Prevent VLC player operations from dereferencing an unavailable player instance by adding safe fallback behavior across playback, media, and equalizer methods.

Enhancements:
- Centralize VLC availability detection and playback engine initialization through the DynamicLibraries singleton.
- Set the playback engine to VLC when its dynamic libraries initialize successfully.