### PR TITLE
fix: deep-bind VLC TagLib plugin and add audioDataReady signal

### DIFF
--- a/src/libdmusic/core/dynamiclibraries.cpp
+++ b/src/libdmusic/core/dynamiclibraries.cpp
@@ -4,6 +4,7 @@
 
 #include "dynamiclibraries.h"
 #include <QDir>
+#include <QFileInfo>
 #include <QLibrary>
 #include <QLibraryInfo>
 #include <QDebug>
@@ -124,6 +125,23 @@ bool DynamicLibraries::loadLibraries()
             qCCritical(dmMusic) << "Failed to load VLC core library:" << vlccoreLib.errorString();
             return false;
         }
+
+#ifdef Q_OS_LINUX
+        // VLC's TagLib plugin is linked to TagLib 1, while dmusic links to
+        // TagLib 2. Load the plugin with deep binding before libvlc starts
+        // loading metadata modules, so it uses its compatible TagLib symbols.
+        const QString taglibPluginPath = QFileInfo(strvlccore).dir().filePath(
+                    "vlc/plugins/meta_engine/libtaglib_plugin.so");
+        if (QFileInfo::exists(taglibPluginPath)) {
+            taglibPlugin.setFileName(taglibPluginPath);
+            taglibPlugin.setLoadHints(QLibrary::DeepBindHint | QLibrary::PreventUnloadHint);
+            if (!taglibPlugin.load()) {
+                qCCritical(dmMusic) << "Failed to deep-bind VLC TagLib plugin:"
+                                    << taglibPlugin.errorString();
+                return false;
+            }
+        }
+#endif
     } else {
         qCCritical(dmMusic) << "VLC core library path is not valid:" << strvlccore;
         return false;

--- a/src/libdmusic/core/dynamiclibraries.h
+++ b/src/libdmusic/core/dynamiclibraries.h
@@ -19,6 +19,7 @@ private:
     ~DynamicLibraries();
     bool loadLibraries();
     QLibrary vlccoreLib;
+    QLibrary taglibPlugin;
     QLibrary vlcLib;
     QLibrary avcodecLib;
     QLibrary avformateLib;

--- a/src/libdmusic/player/playerbase.h
+++ b/src/libdmusic/player/playerbase.h
@@ -7,6 +7,7 @@
 #define PLAYERBASE_H
 
 #include "global.h"
+#include <QByteArray>
 #include <QObject>
 
 using namespace DMusic;
@@ -58,6 +59,7 @@ signals:
     void end();
     void sigSendCdaStatus(int state);
     void signalMutedChanged();
+    void audioDataReady(const QByteArray &data);
 
 protected:
     MediaMeta            m_activeMeta;


### PR DESCRIPTION
On Linux, VLC's TagLib plugin links against TagLib 1 while dmusic uses TagLib 2. Load the plugin with deep binding before libvlc starts so it uses its own compatible TagLib symbols. Also add audioDataReady signal to PlayerBase for audio data output.

在 Linux 下，VLC 的 TagLib 插件链接 TagLib 1，而 dmusic 使用 TagLib 2。 在 libvlc 启动前以深度绑定方式加载该插件，使其使用自带的兼容 TagLib 符号。
同时在 PlayerBase 中新增 audioDataReady 信号用于音频数据输出。

Log: 修复 VLC TagLib 符号冲突并新增音频数据信号
Influence: 解决 Linux 下 VLC TagLib 插件与 dmusic TagLib 2 的符号冲突，避免元数据解析异常；新增音频数据输出信号供上层使用。

## Summary by Sourcery

Resolve VLC TagLib symbol conflicts on Linux and expose a new audio data output signal from the player base.

Bug Fixes:
- Ensure VLC's TagLib metadata plugin is preloaded with deep binding on Linux to avoid runtime symbol conflicts with dmusic's TagLib 2 usage.

Enhancements:
- Add an audioDataReady signal to PlayerBase to provide raw audio data to higher-level consumers.

Chores:
- Track the VLC TagLib plugin as a managed dynamic library alongside the VLC core library.