### PR TITLE
fix(core): move media analysis off import worker

### DIFF
--- a/src/libdmusic/CMakeLists.txt
+++ b/src/libdmusic/CMakeLists.txt
@@ -3,7 +3,7 @@ project(libdmusic)
 set(CMD_NAME dmusic)
 add_definitions(-DLIBDMUSIC_LIBRARY -DVLCQT_CORE_LIBRARY)
 
-set(QT_MODULES Core Multimedia DBus Sql Core5Compat Concurrent)
+set(QT_MODULES Core Multimedia DBus Sql Core5Compat)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
@@ -75,7 +75,7 @@ target_link_libraries(${CMD_NAME} ${TARGET_LIBS} PkgConfig::TAGLIB PkgConfig::DT
 if(LINUX)
   target_link_libraries(${CMD_NAME} PkgConfig::MPRIS)
 endif()
-target_link_libraries(${CMD_NAME} Qt6::Core Qt6::Multimedia Qt6::DBus Qt6::Sql Qt6::Core5Compat Qt6::Concurrent)
+target_link_libraries(${CMD_NAME} Qt6::Core Qt6::Multimedia Qt6::DBus Qt6::Sql Qt6::Core5Compat)
 
 # qt5_use_modules(${CMD_NAME} )
 

--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -25,6 +25,7 @@
 #include "audioanalysis.h"
 #include "utils.h"
 #include "dboperate.h"
+#include "mediametaworker.h"
 #include "musicsettings.h"
 #include "util/log.h"
 
@@ -151,6 +152,12 @@ public:
         m_dbOperate = new DBOperate(supportedSuffixs);
         m_workerThread = new QThread(m_parent);
         m_dbOperate->moveToThread(m_workerThread);
+        m_mediaMetaWorker = new MediaMetaWorker;
+        m_mediaMetaThread = new QThread(m_parent);
+        m_mediaMetaWorker->moveToThread(m_mediaMetaThread);
+        m_metaUpsertTimer = new QTimer(m_parent);
+        m_metaUpsertTimer->setSingleShot(true);
+        m_metaUpsertTimer->setInterval(1000);
         qCDebug(dmMusic) << "DataManagerPrivate initialized with current playlist:" << m_currentHash;
     }
     ~DataManagerPrivate()
@@ -164,6 +171,10 @@ public:
         if (m_workerStopped) return;
         m_workerStopped = true;
 
+        if (m_metaUpsertTimer) {
+            m_metaUpsertTimer->stop();
+        }
+
         if (m_dbOperate) {
             // 让 m_dbOperate 在自己 affinity 的 worker 线程里析构。
             //    deleteLater 在 worker 的事件循环里 post 一个 DeferredDelete 事件；
@@ -172,17 +183,22 @@ public:
             m_dbOperate->deleteLater();
             m_dbOperate = nullptr;
         }
-        // 请求事件循环退出 + 等线程真的结束。保持 DBOperate->DataManager 连接到
-        // worker 停止后，再排空主线程上已 posted 的封面回填事件。
         if (m_workerThread) {
             m_workerThread->quit();
             m_workerThread->wait();
             delete m_workerThread;
             m_workerThread = nullptr;
         }
-        // Worker 已停，排空主线程上此前已 posted 给 DataManager 的 metacall
-        // （如 signalMetaCoverReady/signalCoverBatchFinished）。此时 m_parent 仍有效，
-        // slot 可安全更新 m_importedMetas，随后 DataManager 析构会统一保存。
+        if (m_mediaMetaWorker) {
+            m_mediaMetaWorker->deleteLater();
+            m_mediaMetaWorker = nullptr;
+        }
+        if (m_mediaMetaThread) {
+            m_mediaMetaThread->quit();
+            m_mediaMetaThread->wait();
+            delete m_mediaMetaThread;
+            m_mediaMetaThread = nullptr;
+        }
         QCoreApplication::sendPostedEvents(m_parent, 0);
     }
 private:
@@ -190,6 +206,9 @@ private:
     DataManager                      *m_parent;
     QThread                          *m_workerThread     = nullptr;
     DBOperate                        *m_dbOperate        = nullptr;
+    QThread                          *m_mediaMetaThread      = nullptr;
+    MediaMetaWorker                      *m_mediaMetaWorker      = nullptr;
+    QTimer                           *m_metaUpsertTimer = nullptr;
     MusicSettings                    *m_settings         = nullptr;
     bool                               m_workerStopped    = false;
     QSqlDatabase                      m_database;
@@ -213,16 +232,21 @@ DataManager::DataManager(QStringList supportedSuffixs, QObject *parent, const QS
     : QObject(parent), m_data(new DataManagerPrivate(supportedSuffixs, this, dbPath))
 {
     qCDebug(dmMusic) << "Initializing DataManager with supported suffixes:" << supportedSuffixs;
+    qRegisterMetaType<DMusic::MediaMeta>("DMusic::MediaMeta");
+    qRegisterMetaType<QList<DMusic::MediaMeta>>("QList<DMusic::MediaMeta>");
     initPlaylist();
 
     connect(this, &DataManager::signalImportMetas, m_data->m_dbOperate, &DBOperate::slotImportMetas, Qt::QueuedConnection);
     connect(m_data->m_dbOperate, &DBOperate::signalAddOneMeta, this, &DataManager::slotAddOneMeta, Qt::QueuedConnection);
     connect(m_data->m_dbOperate, &DBOperate::signalImportFinished, this, &DataManager::signalImportFinished, Qt::QueuedConnection);
-    connect(m_data->m_dbOperate, &DBOperate::signalCoverBatchFinished, this, &DataManager::slotCoverBatchFinished, Qt::QueuedConnection);
-    connect(m_data->m_dbOperate, &DBOperate::signalMetaCoverReady, this, &DataManager::slotMetaCoverReady, Qt::QueuedConnection);
+    connect(m_data->m_dbOperate, &DBOperate::signalMetaBatchFinished, this, &DataManager::slotMetaBatchFinished, Qt::QueuedConnection);
+    connect(m_data->m_dbOperate, &DBOperate::signalEnqueueMetaTasks, m_data->m_mediaMetaWorker, &MediaMetaWorker::enqueueMetas, Qt::QueuedConnection);
+    connect(m_data->m_mediaMetaWorker, &MediaMetaWorker::signalMetaAnalysisReady, this, &DataManager::slotMetaAnalysisReady, Qt::QueuedConnection);
+    connect(m_data->m_metaUpsertTimer, &QTimer::timeout, this, &DataManager::slotMetaBatchFinished);
     connect(this, &DataManager::signalClearImportingHash, m_data->m_dbOperate, &DBOperate::slotClearImportingHash, Qt::QueuedConnection);
 
     m_data->m_workerThread->start();
+    m_data->m_mediaMetaThread->start();
     qCDebug(dmMusic) << "DataManager initialized with worker thread";
 }
 
@@ -2470,7 +2494,7 @@ void DataManager::slotAddOneMeta(QStringList playlistHashs, MediaMeta meta)
     emit signalAddOneMeta(playlistHashs, curMeta, true);
 }
 
-void DataManager::slotMetaCoverReady(DMusic::MediaMeta meta)
+void DataManager::slotMetaAnalysisReady(DMusic::MediaMeta meta)
 {
     int index = metaIndexFromHash(meta.hash);
     if (index < 0) return;
@@ -2480,14 +2504,19 @@ void DataManager::slotMetaCoverReady(DMusic::MediaMeta meta)
     m_data->m_allMetas[index].hasimage = meta.hasimage;
     m_data->m_allMetas[index].lyricPath = meta.lyricPath;
 
-    // 2. m_importedMetas (upsertMetasDB reads it; sync or it writes stale hasimage/coverUrl)
+    // 2. m_importedMetas (upsertMetasDB reads it; append if base import already flushed)
+    bool importedMetaSynced = false;
     for (auto &im : m_data->m_importedMetas) {
         if (im.hash == meta.hash) {
             im.coverUrl = meta.coverUrl;
             im.hasimage = meta.hasimage;
             im.lyricPath = meta.lyricPath;
+            importedMetaSynced = true;
             break;
         }
+    }
+    if (!importedMetaSynced) {
+        m_data->m_importedMetas.append(m_data->m_allMetas[index]);
     }
 
     // 3. album/artist musicinfos copy (no top-level coverUrl field; UI derives from musicinfos)
@@ -2503,15 +2532,16 @@ void DataManager::slotMetaCoverReady(DMusic::MediaMeta meta)
     }
 
     m_data->m_dirty = true;  // hasimage/coverUrl/lyricPath affect DB row
-    emit signalMetaCoverReady(m_data->m_allMetas[index]);
+    if (m_data->m_metaUpsertTimer && !m_data->m_metaUpsertTimer->isActive()) {
+        m_data->m_metaUpsertTimer->start();
+    }
+    emit signalMetaAnalysisReady(m_data->m_allMetas[index]);
 }
 
-void DataManager::slotCoverBatchFinished()
+void DataManager::slotMetaBatchFinished()
 {
-    // 导入成功提示已在 signalImportFinished 发出；这里仅在封面/歌词补齐后
-    // 增量落库，避免 musicNew 先写入 stale coverUrl/hasimage/lyricPath。
     upsertMetasDB();
-    emit signalCoverBatchFinished();
+    emit signalMetaBatchFinished();
 }
 
 void DataManager::slotLazyLoadDatabase()

--- a/src/libdmusic/core/datamanager.h
+++ b/src/libdmusic/core/datamanager.h
@@ -73,8 +73,8 @@ public:
 public slots:
     void slotAddOneMeta(QStringList playlistHashs, DMusic::MediaMeta meta);
     void slotLazyLoadDatabase();
-    void slotMetaCoverReady(DMusic::MediaMeta meta);
-    void slotCoverBatchFinished();
+    void slotMetaAnalysisReady(DMusic::MediaMeta meta);
+    void slotMetaBatchFinished();
 
 signals:
     void signalImportMetas(const QStringList &urls, const QSet<QString> &metaHashs, bool importPlayFlag,
@@ -83,8 +83,8 @@ signals:
     void signalAddOneMeta(QStringList playlistHashs, DMusic::MediaMeta meta, const bool &addToPlay);
     void signalAddMetaFinished(QStringList playlistHashs);
     void signalImportFinished(QStringList playlistHashs, int failCount, int sucessCount, int existCount, QString mediaHash);
-    void signalCoverBatchFinished();
-    void signalMetaCoverReady(DMusic::MediaMeta meta);
+    void signalMetaBatchFinished();
+    void signalMetaAnalysisReady(DMusic::MediaMeta meta);
     void signalDeleteOneMeta(QStringList playlistHashs, QString hash, const bool &addToPlay);
     void signalDeleteFinished(QStringList playlistHashs);
     void signalUpdatedMetaCodec(DMusic::MediaMeta meta, QString preAlbum, QString preArtist);

--- a/src/libdmusic/core/dboperate.cpp
+++ b/src/libdmusic/core/dboperate.cpp
@@ -72,7 +72,7 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
 
     int importedCount = 0, importedFailCount = 0, existCount = 0;
     QSet<QString> allHashs;
-    QList<DMusic::MediaMeta> pendingCovers;  // newly imported metas to extract cover/lyrics after loop
+    QList<DMusic::MediaMeta> pendingMetas;  // newly imported metas to extract cover and lyrics in background
     for (auto &filePath : filePaths) {
         QFileInfo fileinfo(filePath);
         while (fileinfo.isSymLink()) {  //to find final target
@@ -99,7 +99,7 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
                 mediaMeta = AudioAnalysis::creatMediaMeta(filePath, hash);
                 if (mediaMeta.length > 0) {
                     mediaMeta.hasimage = false;
-                    pendingCovers.append(mediaMeta);  // cover/lyrics extracted after loop
+                    pendingMetas.append(mediaMeta);  // cover and lyrics extracted by MediaMetaWorker
                     curHashs << "all" << playlistHash;
                     allHashs << "all" << playlistHash;
                     qCDebug(dmMusic) << "Added new meta:" << mediaMeta.title << "to playlist:" << playlistHash;
@@ -118,7 +118,7 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
                 mediaMeta = AudioAnalysis::creatMediaMeta(filePath, hash);
                 if (mediaMeta.length > 0) {
                     mediaMeta.hasimage = false;
-                    pendingCovers.append(mediaMeta);  // cover/lyrics extracted after loop
+                    pendingMetas.append(mediaMeta);  // cover and lyrics extracted by MediaMetaWorker
                     curHashs << "all";
                     allHashs << "all";
                     qCDebug(dmMusic) << "Added new meta:" << mediaMeta.title << "to all music";
@@ -145,45 +145,18 @@ void DBOperate::slotImportMetas(const QStringList &urls, const QSet<QString> &me
         importedCount++;
     }
 
-    // Emit importFinished first so UI shows success / auto-play immediately,
-    // without waiting for the cover batch. upsertMetasDB is triggered later by
-    // signalCoverBatchFinished so m_importedMetas has correct hasimage/coverUrl.
+    // Emit importFinished first so UI shows success / auto-play immediately.
     emit signalImportFinished(allHashs.values(), importedFailCount, importedCount - importedFailCount - existCount, existCount, mediaHash);
 
-    // Extract cover/lyrics after the import loop using parallel batch processing.
-    if (!pendingCovers.isEmpty()) {
-        processPendingCovers(pendingCovers);
+    if (!pendingMetas.isEmpty()) {
+        emit signalEnqueueMetaTasks(pendingMetas);
     }
 
-    emit signalCoverBatchFinished();
+    // Persist base metadata without waiting for background cover and lyrics extraction.
+    emit signalMetaBatchFinished();
 }
 
 void DBOperate::slotClearImportingHash(const QString &hash)
 {
     m_importingHashes.remove(hash);
-}
-
-void DBOperate::processPendingCovers(QList<DMusic::MediaMeta> &pendingCovers)
-{
-    qCInfo(dmMusic) << "Processing" << pendingCovers.size() << "covers/lyrics in parallel batch mode";
-
-    const int batchSize = 8;
-
-    // 使用 QtConcurrent::map 并行处理（修改原地数据）
-    QtConcurrent::map(pendingCovers, [](DMusic::MediaMeta &meta) {
-        AudioAnalysis::parseMetaCoverAndLyrics(meta);
-    }).waitForFinished();
-
-    // 分批发送批量信号，避免一次性更新过多 UI
-    for (int i = 0; i < pendingCovers.size(); i += batchSize) {
-        int end = qMin(i + batchSize, pendingCovers.size());
-        QList<DMusic::MediaMeta> batch = pendingCovers.mid(i, end - i);
-
-        // 逐条发送以保持与现有 UI 逻辑兼容
-        for (const DMusic::MediaMeta &meta : batch) {
-            emit signalMetaCoverReady(meta);
-        }
-    }
-
-    qCInfo(dmMusic) << "Parallel cover/lyrics batch processing completed";
 }

--- a/src/libdmusic/core/dboperate.h
+++ b/src/libdmusic/core/dboperate.h
@@ -7,8 +7,6 @@
 
 #include "global.h"
 #include <QSet>
-#include <QtConcurrent>
-#include <QFuture>
 
 class DBOperate : public QObject
 {
@@ -25,11 +23,8 @@ public slots:
 signals:
     void signalAddOneMeta(QStringList playlistHashs, DMusic::MediaMeta meta);
     void signalImportFinished(QStringList playlistHashs, int failCount, int sucessCount, int existCount, QString mediaHash);
-    void signalCoverBatchFinished();
-    void signalMetaCoverReady(DMusic::MediaMeta meta);
-
-private:
-    void processPendingCovers(QList<DMusic::MediaMeta> &pendingCovers);
+    void signalMetaBatchFinished();
+    void signalEnqueueMetaTasks(QList<DMusic::MediaMeta> metas);
 
 private:
     QStringList          m_supportedSuffixs;

--- a/src/libdmusic/core/mediametaworker.cpp
+++ b/src/libdmusic/core/mediametaworker.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "mediametaworker.h"
+
+#include "audioanalysis.h"
+#include "util/log.h"
+
+MediaMetaWorker::MediaMetaWorker(QObject *parent)
+    : QObject(parent)
+{
+    qCDebug(dmMusic) << "MediaMetaWorker initialized";
+}
+
+void MediaMetaWorker::enqueueMetas(const QList<DMusic::MediaMeta> &metas)
+{
+    for (const DMusic::MediaMeta &meta : metas) {
+        if (meta.hash.isEmpty() || meta.localPath.isEmpty()) {
+            continue;
+        }
+        if (m_doneHashes.contains(meta.hash) || m_pendingHashes.contains(meta.hash)) {
+            qCDebug(dmMusic) << "Metadata task already queued or finished:" << meta.hash;
+            continue;
+        }
+
+        m_queue.enqueue(meta);
+        m_pendingHashes.insert(meta.hash);
+    }
+
+    processQueue();
+}
+
+void MediaMetaWorker::processQueue()
+{
+    while (!m_queue.isEmpty()) {
+        DMusic::MediaMeta meta = m_queue.dequeue();
+        m_pendingHashes.remove(meta.hash);
+
+        AudioAnalysis::parseMetaCoverAndLyrics(meta);
+        m_doneHashes.insert(meta.hash);
+        emit signalMetaAnalysisReady(meta);
+    }
+}

--- a/src/libdmusic/core/mediametaworker.h
+++ b/src/libdmusic/core/mediametaworker.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MEDIAMETAWORKER_H
+#define MEDIAMETAWORKER_H
+
+#include "global.h"
+
+#include <QObject>
+#include <QQueue>
+#include <QSet>
+
+class MediaMetaWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MediaMetaWorker(QObject *parent = nullptr);
+
+public slots:
+    void enqueueMetas(const QList<DMusic::MediaMeta> &metas);
+
+signals:
+    void signalMetaAnalysisReady(DMusic::MediaMeta meta);
+
+private:
+    void processQueue();
+
+private:
+    QQueue<DMusic::MediaMeta> m_queue;
+    QSet<QString> m_pendingHashes;
+    QSet<QString> m_doneHashes;
+};
+
+#endif // MEDIAMETAWORKER_H

--- a/src/libdmusic/presenter.cpp
+++ b/src/libdmusic/presenter.cpp
@@ -157,8 +157,8 @@ Presenter::Presenter(const QString &unknownAlbumStr, const QString &unknownArtis
     connect(m_data->m_dataManager, &DataManager::signalUpdatedMetaCodec, this, [ = ](DMusic::MediaMeta meta, QString preAlbum, QString preArtist) {
         emit updatedMetaCodec(Utils::metaToVariantMap(meta), preAlbum, preArtist);
     });
-    connect(m_data->m_dataManager, &DataManager::signalMetaCoverReady, this, [ = ](DMusic::MediaMeta meta) {
-        emit metaCoverReady(Utils::metaToVariantMap(meta));
+    connect(m_data->m_dataManager, &DataManager::signalMetaAnalysisReady, this, [ = ](DMusic::MediaMeta meta) {
+        emit metaAnalysisReady(Utils::metaToVariantMap(meta));
     });
 
     connect(this, &Presenter::restorePlaybackStatus, this, [ = ]() {

--- a/src/libdmusic/presenter.h
+++ b/src/libdmusic/presenter.h
@@ -144,7 +144,7 @@ signals:
     void deletedPlaylist(QString playlistHash);
     void renamedPlaylist(const QString &name, const QString &playlistHash);
     void updatedMetaCodec(QVariantMap meta, QString preAlbum, QString preArtist);
-    void metaCoverReady(QVariantMap meta);
+    void metaAnalysisReady(QVariantMap meta);
     void updateCDStatus(int status);
     void quitRequested();
     void raiseRequested();

--- a/src/music-player/albumlist/AlbumModel.qml
+++ b/src/music-player/albumlist/AlbumModel.qml
@@ -111,7 +111,7 @@ ListModel {
             }
         }
     }
-    function onMetaCoverReady(meta) {
+    function onMetaAnalysisReady(meta) {
         globalVariant.updateGroupedModelCover(albumModel, meta)
     }
     Component.onCompleted: {
@@ -121,6 +121,6 @@ ListModel {
         Presenter.addOneMeta.connect(onAddOneMetaFinished);
         Presenter.playlistSortChanged.connect(playlistSortChanged)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
-        Presenter.metaCoverReady.connect(onMetaCoverReady)
+        Presenter.metaAnalysisReady.connect(onMetaAnalysisReady)
     }
 }

--- a/src/music-player/musicList/AllMusicListModel.qml
+++ b/src/music-player/musicList/AllMusicListModel.qml
@@ -77,7 +77,7 @@ ListModel {
         }
     }
 
-    function onMetaCoverReady(meta) {
+    function onMetaAnalysisReady(meta) {
         for (var j = 0; j < mediaModels.count; j++) {
             if (mediaModels.get(j)["hash"] === meta.hash) {
                 mediaModels.setProperty(j, "coverUrl", meta.coverUrl)
@@ -95,6 +95,6 @@ ListModel {
         Presenter.addOneMeta.connect(onAddOneMeta);
         Presenter.playlistSortChanged.connect(playlistSortChanged)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
-        Presenter.metaCoverReady.connect(onMetaCoverReady)
+        Presenter.metaAnalysisReady.connect(onMetaAnalysisReady)
     }
 }

--- a/src/music-player/playlist/PlayListModel.qml
+++ b/src/music-player/playlist/PlayListModel.qml
@@ -62,7 +62,7 @@ ListModel {
         }
     }
 
-    function onMetaCoverReady(meta) {
+    function onMetaAnalysisReady(meta) {
         for (var j = 0; j < playlistModel.count; j++) {
             if (playlistModel.get(j)["hash"] === meta.hash) {
                 playlistModel.setProperty(j, "coverUrl", meta.coverUrl)
@@ -80,7 +80,7 @@ ListModel {
         Presenter.importFinished.connect(onAddMetaFinished)
         Presenter.addOneMeta.connect(onAddOneMeta)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
-        Presenter.metaCoverReady.connect(onMetaCoverReady)
+        Presenter.metaAnalysisReady.connect(onMetaAnalysisReady)
 
         Presenter.currentPlaylistSChanged.connect(function(playlistHash){
             if (playlistHash === "") {

--- a/src/music-player/singerlist/ArtistModel.qml
+++ b/src/music-player/singerlist/ArtistModel.qml
@@ -114,7 +114,7 @@ ListModel {
         }
     }
 
-    function onMetaCoverReady(meta) {
+    function onMetaAnalysisReady(meta) {
         globalVariant.updateGroupedModelCover(artistModels, meta)
     }
 
@@ -126,6 +126,6 @@ ListModel {
         Presenter.addOneMeta.connect(onAddOneMetaFinished);
         Presenter.playlistSortChanged.connect(playlistSortChanged)
         Presenter.updatedMetaCodec.connect(onUpdatedMetaCodec)
-        Presenter.metaCoverReady.connect(onMetaCoverReady)
+        Presenter.metaAnalysisReady.connect(onMetaAnalysisReady)
     }
 }

--- a/tests/libdmusic-test/test_audioanalysis.cpp
+++ b/tests/libdmusic-test/test_audioanalysis.cpp
@@ -23,6 +23,7 @@
 #include <QDir>
 #include <QTemporaryFile>
 #include <QBuffer>
+#include <QSignalSpy>
 #include <memory>
 
 #include <taglib/mpegfile.h>
@@ -34,6 +35,7 @@
 #include <taglib/textidentificationframe.h>
 
 #include "audioanalysis.h"
+#include "mediametaworker.h"
 #include "global.h"
 #include "utils.h"
 
@@ -212,6 +214,21 @@ TEST(AudioAnalysisParseFileTest, creatMediaMetaUsesPrecomputedHash)
     EXPECT_EQ(meta.filetype, "mp3");
 }
 
+
+TEST(MediaMetaWorkerTest, enqueueMetasDeduplicatesByHash)
+{
+    ASSERT_TRUE(QFile::exists(sampleMp3Path()));
+    MediaMetaWorker worker;
+    QSignalSpy spy(&worker, &MediaMetaWorker::signalMetaAnalysisReady);
+
+    DMusic::MediaMeta meta;
+    meta.localPath = sampleMp3Path();
+    meta.hash = "duplicate-cover-hash";
+
+    worker.enqueueMetas({meta, meta});
+    EXPECT_EQ(spy.count(), 1);
+}
+
 TEST(AudioAnalysisParseFileTest, parseMetaCoverDoesNotCrash)
 {
     DMusic::MediaMeta meta;
@@ -227,6 +244,15 @@ TEST(AudioAnalysisParseFileTest, parseMetaLyricsDoesNotCrash)
     meta.localPath = sampleMp3Path();
     meta.hash = Utils::filePathHash(sampleMp3Path());
     AudioAnalysis::parseMetaLyrics(meta);       // 提取歌词（可能无），不崩溃即可
+    SUCCEED();
+}
+
+TEST(AudioAnalysisParseFileTest, parseMetaCoverAndLyricsDoesNotCrash)
+{
+    DMusic::MediaMeta meta;
+    meta.localPath = sampleMp3Path();
+    meta.hash = Utils::filePathHash(sampleMp3Path());
+    AudioAnalysis::parseMetaCoverAndLyrics(meta); // 一次打开文件解析封面和歌词
     SUCCEED();
 }
 


### PR DESCRIPTION
Analyze covers and lyrics in a dedicated worker thread. 在独立工作线程中解析封面和歌词。

Log: 异步解析封面和歌词，提升导入响应速度
PMS: BUG-333525
Influence: 导入先完成基础元数据，封面和歌词随后异步更新。

## Summary by Sourcery

Move cover and lyrics analysis to a dedicated media metadata worker thread and adjust signals so imports complete quickly while metadata updates asynchronously.

New Features:
- Introduce a MediaMetaWorker component running on its own thread to parse covers and lyrics for imported media.
- Add batched, asynchronous metadata update signaling so UI can react when cover and lyric analysis completes.

Enhancements:
- Delay database upsert of metadata affected by cover and lyrics until background analysis finishes, with a timer-based batching mechanism.
- Deduplicate metadata analysis tasks by hash to avoid redundant work and ensure consistent updates.
- Simplify Qt module usage by removing the Concurrent module dependency from the build.

Tests:
- Add unit tests for MediaMetaWorker task deduplication and for combined cover-and-lyrics parsing to ensure robustness.