### PR TITLE
fix(core): preserve pending media analysis tasks

### DIFF
--- a/src/libdmusic/core/datamanager.cpp
+++ b/src/libdmusic/core/datamanager.cpp
@@ -19,6 +19,12 @@
 #include <QTimer>
 #include <QDebug>
 #include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
 
 #include <algorithm>
 
@@ -45,6 +51,91 @@ static bool isValidPlaylistUuid(const QString &uuid)
     static const QRegularExpression re("^[A-Za-z0-9_-]+$");
     return re.match(uuid).hasMatch();
 }
+
+namespace {
+
+QString pendingMetaAnalysisPath()
+{
+    return DmGlobal::cachePath() + "/meta-analysis-pending.json";
+}
+
+QHash<QString, QString> loadPendingMetaAnalysisTasks()
+{
+    QHash<QString, QString> tasks;
+    QFile file(pendingMetaAnalysisPath());
+    if (!file.exists()) {
+        return tasks;
+    }
+    if (!file.open(QIODevice::ReadOnly)) {
+        qCWarning(dmMusic) << "Failed to open pending metadata tasks:" << file.errorString();
+        return tasks;
+    }
+
+    const QJsonDocument document = QJsonDocument::fromJson(file.readAll());
+    if (!document.isArray()) {
+        qCWarning(dmMusic) << "Invalid pending metadata tasks file";
+        return tasks;
+    }
+
+    for (const QJsonValue &value : document.array()) {
+        const QJsonObject object = value.toObject();
+        const QString hash = object.value("hash").toString();
+        const QString localPath = object.value("localPath").toString();
+        if (!hash.isEmpty() && !localPath.isEmpty()) {
+            tasks.insert(hash, localPath);
+        }
+    }
+    return tasks;
+}
+
+bool isSafePendingMetaPath(const QString &path)
+{
+    const QFileInfo fileInfo(path);
+    if (!fileInfo.exists() || !fileInfo.isFile() || fileInfo.isSymLink()) {
+        return false;
+    }
+
+    // Reject symlinks in parent directories as well. The canonical path must
+    // refer to the exact path stored by the media database.
+    return fileInfo.canonicalFilePath() == QDir::cleanPath(fileInfo.absoluteFilePath());
+}
+
+bool savePendingMetaAnalysisTasks(const QHash<QString, QString> &tasks)
+{
+    const QString path = pendingMetaAnalysisPath();
+    if (tasks.isEmpty()) {
+        return !QFile::exists(path) || QFile::remove(path);
+    }
+
+    if (!QDir().mkpath(DmGlobal::cachePath())) {
+        qCWarning(dmMusic) << "Failed to create cache directory for pending metadata tasks";
+        return false;
+    }
+
+    QStringList hashes = tasks.keys();
+    hashes.sort();
+    QJsonArray array;
+    for (const QString &hash : hashes) {
+        QJsonObject object;
+        object.insert("hash", hash);
+        object.insert("localPath", tasks.value(hash));
+        array.append(object);
+    }
+
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        qCWarning(dmMusic) << "Failed to write pending metadata tasks:" << file.errorString();
+        return false;
+    }
+    file.write(QJsonDocument(array).toJson(QJsonDocument::Compact));
+    if (!file.commit()) {
+        qCWarning(dmMusic) << "Failed to commit pending metadata tasks:" << file.errorString();
+        return false;
+    }
+    return true;
+}
+
+} // namespace
 
 static bool compareArtistName(const ArtistInfo &data)
 {
@@ -146,6 +237,7 @@ public:
         : m_parent(parent), m_dbPath(dbPath)
     {
         qCDebug(dmMusic) << "Initializing DataManagerPrivate with supported suffixes:" << supportedSuffixs;
+        m_pendingMetaTasks = loadPendingMetaAnalysisTasks();
         m_settings = new MusicSettings(m_parent);
         m_currentHash = m_settings->value("base.play.last_playlist").toString();
         if (m_currentHash.isEmpty()) m_currentHash = "all";
@@ -190,6 +282,9 @@ public:
             m_workerThread = nullptr;
         }
         if (m_mediaMetaWorker) {
+            // Only the file currently being parsed is allowed to finish.
+            // Queued tasks remain in the sidecar file for the next startup.
+            m_mediaMetaWorker->requestStop();
             m_mediaMetaWorker->deleteLater();
             m_mediaMetaWorker = nullptr;
         }
@@ -217,6 +312,8 @@ private:
     QList<DMusic::MediaMeta>          m_allMetas;
     QHash<QString, int>               m_metaHashIndex;  // hash -> m_allMetas index, for O(1) metaIndexFromHash
     QList<DMusic::MediaMeta>          m_importedMetas;   // newly imported metas this batch; consumed and cleared by upsertMetasDB
+    QHash<QString, QString>            m_pendingMetaTasks;
+    QSet<QString>                      m_metaAnalysisReadyHashes;
     bool                               m_dirty = false;   // true if persistent in-memory model changed and needs full saveDataToDB on exit
     QList<DMusic::AlbumInfo>          m_allAlbums;
     QHash<QString, int>               m_albumNameIndex;   // album name -> m_allAlbums index
@@ -240,13 +337,15 @@ DataManager::DataManager(QStringList supportedSuffixs, QObject *parent, const QS
     connect(m_data->m_dbOperate, &DBOperate::signalAddOneMeta, this, &DataManager::slotAddOneMeta, Qt::QueuedConnection);
     connect(m_data->m_dbOperate, &DBOperate::signalImportFinished, this, &DataManager::signalImportFinished, Qt::QueuedConnection);
     connect(m_data->m_dbOperate, &DBOperate::signalMetaBatchFinished, this, &DataManager::slotMetaBatchFinished, Qt::QueuedConnection);
-    connect(m_data->m_dbOperate, &DBOperate::signalEnqueueMetaTasks, m_data->m_mediaMetaWorker, &MediaMetaWorker::enqueueMetas, Qt::QueuedConnection);
+    connect(m_data->m_dbOperate, &DBOperate::signalEnqueueMetaTasks, this, &DataManager::slotEnqueueMetaTasks, Qt::QueuedConnection);
+    connect(this, &DataManager::signalEnqueueMetaTasks, m_data->m_mediaMetaWorker, &MediaMetaWorker::enqueueMetas, Qt::QueuedConnection);
     connect(m_data->m_mediaMetaWorker, &MediaMetaWorker::signalMetaAnalysisReady, this, &DataManager::slotMetaAnalysisReady, Qt::QueuedConnection);
     connect(m_data->m_metaUpsertTimer, &QTimer::timeout, this, &DataManager::slotMetaBatchFinished);
     connect(this, &DataManager::signalClearImportingHash, m_data->m_dbOperate, &DBOperate::slotClearImportingHash, Qt::QueuedConnection);
 
     m_data->m_workerThread->start();
     m_data->m_mediaMetaThread->start();
+    restorePendingMetaTasks();
     qCDebug(dmMusic) << "DataManager initialized with worker thread";
 }
 
@@ -255,6 +354,9 @@ DataManager::~DataManager()
     qCDebug(dmMusic) << "Destroying DataManager";
     if (m_data) {
         m_data->stopWorkerAndDrain();
+        // Persist results already delivered to the main thread without waiting
+        // for queued analysis results that have not arrived yet.
+        slotMetaBatchFinished();
         saveDataToDB();
         // 关键：触发 DataManagerPrivate 析构走安全销毁路径（disconnect + deleteLater + quit + wait）
         delete m_data;
@@ -420,6 +522,7 @@ void DataManager::deleteMetaFromAllMetas(const QStringList &hashs)
             if (allHashs.isEmpty()) break;
         }
     }
+    removePendingMetaTasks(hashs);
     rebuildMetaHashIndex();  // removeAt shifts indices; full rebuild is simplest
     qCDebug(dmMusic) << "Finished deleting metas";
 }
@@ -2494,10 +2597,80 @@ void DataManager::slotAddOneMeta(QStringList playlistHashs, MediaMeta meta)
     emit signalAddOneMeta(playlistHashs, curMeta, true);
 }
 
+void DataManager::slotEnqueueMetaTasks(const QList<DMusic::MediaMeta> &metas)
+{
+    if (m_data->m_workerStopped) {
+        return;
+    }
+
+    bool changed = false;
+    for (const DMusic::MediaMeta &meta : metas) {
+        if (meta.hash.isEmpty() || meta.localPath.isEmpty()) {
+            continue;
+        }
+        if (m_data->m_pendingMetaTasks.value(meta.hash) != meta.localPath) {
+            m_data->m_pendingMetaTasks.insert(meta.hash, meta.localPath);
+            changed = true;
+        }
+    }
+    if (changed) {
+        savePendingMetaAnalysisTasks(m_data->m_pendingMetaTasks);
+    }
+    emit signalEnqueueMetaTasks(metas);
+}
+
+void DataManager::restorePendingMetaTasks()
+{
+    QList<DMusic::MediaMeta> tasks;
+    bool changed = false;
+    for (auto it = m_data->m_pendingMetaTasks.begin(); it != m_data->m_pendingMetaTasks.end();) {
+        const int index = metaIndexFromHash(it.key());
+        if (index < 0) {
+            it = m_data->m_pendingMetaTasks.erase(it);
+            changed = true;
+            continue;
+        }
+
+        const QString trustedPath = m_data->m_allMetas.at(index).localPath;
+        if (it.value() != trustedPath) {
+            // The sidecar is only a recovery hint. Never let its path override
+            // the path loaded from the media database.
+            it.value() = trustedPath;
+            changed = true;
+        }
+
+        if (isSafePendingMetaPath(trustedPath)) {
+            tasks.append(m_data->m_allMetas.at(index));
+        }
+        ++it;
+    }
+    if (changed) {
+        savePendingMetaAnalysisTasks(m_data->m_pendingMetaTasks);
+    }
+    if (!tasks.isEmpty()) {
+        emit signalEnqueueMetaTasks(tasks);
+    }
+}
+
+void DataManager::removePendingMetaTasks(const QStringList &hashes)
+{
+    bool changed = false;
+    for (const QString &hash : hashes) {
+        changed = m_data->m_pendingMetaTasks.remove(hash) > 0 || changed;
+        m_data->m_metaAnalysisReadyHashes.remove(hash);
+    }
+    if (changed) {
+        savePendingMetaAnalysisTasks(m_data->m_pendingMetaTasks);
+    }
+}
+
 void DataManager::slotMetaAnalysisReady(DMusic::MediaMeta meta)
 {
     int index = metaIndexFromHash(meta.hash);
-    if (index < 0) return;
+    if (index < 0) {
+        removePendingMetaTasks(QStringList() << meta.hash);
+        return;
+    }
 
     // 1. m_allMetas
     m_data->m_allMetas[index].coverUrl = meta.coverUrl;
@@ -2532,6 +2705,7 @@ void DataManager::slotMetaAnalysisReady(DMusic::MediaMeta meta)
     }
 
     m_data->m_dirty = true;  // hasimage/coverUrl/lyricPath affect DB row
+    m_data->m_metaAnalysisReadyHashes.insert(meta.hash);
     if (m_data->m_metaUpsertTimer && !m_data->m_metaUpsertTimer->isActive()) {
         m_data->m_metaUpsertTimer->start();
     }
@@ -2540,7 +2714,12 @@ void DataManager::slotMetaAnalysisReady(DMusic::MediaMeta meta)
 
 void DataManager::slotMetaBatchFinished()
 {
-    upsertMetasDB();
+    const bool persisted = upsertMetasDB();
+    if (persisted && !m_data->m_metaAnalysisReadyHashes.isEmpty()) {
+        const QStringList hashes = m_data->m_metaAnalysisReadyHashes.values();
+        m_data->m_metaAnalysisReadyHashes.clear();
+        removePendingMetaTasks(hashes);
+    }
     emit signalMetaBatchFinished();
 }
 

--- a/src/libdmusic/core/datamanager.h
+++ b/src/libdmusic/core/datamanager.h
@@ -72,6 +72,7 @@ public:
 
 public slots:
     void slotAddOneMeta(QStringList playlistHashs, DMusic::MediaMeta meta);
+    void slotEnqueueMetaTasks(const QList<DMusic::MediaMeta> &metas);
     void slotLazyLoadDatabase();
     void slotMetaAnalysisReady(DMusic::MediaMeta meta);
     void slotMetaBatchFinished();
@@ -84,6 +85,7 @@ signals:
     void signalAddMetaFinished(QStringList playlistHashs);
     void signalImportFinished(QStringList playlistHashs, int failCount, int sucessCount, int existCount, QString mediaHash);
     void signalMetaBatchFinished();
+    void signalEnqueueMetaTasks(QList<DMusic::MediaMeta> metas);
     void signalMetaAnalysisReady(DMusic::MediaMeta meta);
     void signalDeleteOneMeta(QStringList playlistHashs, QString hash, const bool &addToPlay);
     void signalDeleteFinished(QStringList playlistHashs);
@@ -94,6 +96,8 @@ signals:
 
 private:
     void initPlaylist();
+    void restorePendingMetaTasks();
+    void removePendingMetaTasks(const QStringList &hashes);
     int metaIndexFromHash(const QString &hash);
     void rebuildMetaHashIndex();
     int albumIndexFromName(const QString &name);

--- a/src/libdmusic/core/mediametaworker.cpp
+++ b/src/libdmusic/core/mediametaworker.cpp
@@ -7,14 +7,25 @@
 #include "audioanalysis.h"
 #include "util/log.h"
 
+#include <QTimer>
+
 MediaMetaWorker::MediaMetaWorker(QObject *parent)
     : QObject(parent)
 {
     qCDebug(dmMusic) << "MediaMetaWorker initialized";
 }
 
+void MediaMetaWorker::requestStop()
+{
+    m_stopRequested.store(true, std::memory_order_release);
+}
+
 void MediaMetaWorker::enqueueMetas(const QList<DMusic::MediaMeta> &metas)
 {
+    if (m_stopRequested.load(std::memory_order_acquire)) {
+        return;
+    }
+
     for (const DMusic::MediaMeta &meta : metas) {
         if (meta.hash.isEmpty() || meta.localPath.isEmpty()) {
             continue;
@@ -28,17 +39,33 @@ void MediaMetaWorker::enqueueMetas(const QList<DMusic::MediaMeta> &metas)
         m_pendingHashes.insert(meta.hash);
     }
 
-    processQueue();
+    scheduleNext();
 }
 
-void MediaMetaWorker::processQueue()
+void MediaMetaWorker::scheduleNext()
 {
-    while (!m_queue.isEmpty()) {
-        DMusic::MediaMeta meta = m_queue.dequeue();
-        m_pendingHashes.remove(meta.hash);
-
-        AudioAnalysis::parseMetaCoverAndLyrics(meta);
-        m_doneHashes.insert(meta.hash);
-        emit signalMetaAnalysisReady(meta);
+    if (m_stopRequested.load(std::memory_order_acquire)
+        || m_processScheduled || m_queue.isEmpty()) {
+        return;
     }
+
+    m_processScheduled = true;
+    QTimer::singleShot(0, this, &MediaMetaWorker::processNext);
+}
+
+void MediaMetaWorker::processNext()
+{
+    m_processScheduled = false;
+    if (m_stopRequested.load(std::memory_order_acquire) || m_queue.isEmpty()) {
+        return;
+    }
+
+    DMusic::MediaMeta meta = m_queue.dequeue();
+    m_pendingHashes.remove(meta.hash);
+
+    AudioAnalysis::parseMetaCoverAndLyrics(meta);
+    m_doneHashes.insert(meta.hash);
+    emit signalMetaAnalysisReady(meta);
+
+    scheduleNext();
 }

--- a/src/libdmusic/core/mediametaworker.h
+++ b/src/libdmusic/core/mediametaworker.h
@@ -11,11 +11,17 @@
 #include <QQueue>
 #include <QSet>
 
+#include <atomic>
+
 class MediaMetaWorker : public QObject
 {
     Q_OBJECT
 public:
     explicit MediaMetaWorker(QObject *parent = nullptr);
+
+    // Can be called from the owner thread while the worker is parsing. The
+    // current file is allowed to finish, but no queued file is started.
+    void requestStop();
 
 public slots:
     void enqueueMetas(const QList<DMusic::MediaMeta> &metas);
@@ -23,13 +29,18 @@ public slots:
 signals:
     void signalMetaAnalysisReady(DMusic::MediaMeta meta);
 
+private slots:
+    void processNext();
+
 private:
-    void processQueue();
+    void scheduleNext();
 
 private:
     QQueue<DMusic::MediaMeta> m_queue;
     QSet<QString> m_pendingHashes;
     QSet<QString> m_doneHashes;
+    bool m_processScheduled = false;
+    std::atomic_bool m_stopRequested{false};
 };
 
 #endif // MEDIAMETAWORKER_H

--- a/tests/libdmusic-test/test_audioanalysis.cpp
+++ b/tests/libdmusic-test/test_audioanalysis.cpp
@@ -226,6 +226,7 @@ TEST(MediaMetaWorkerTest, enqueueMetasDeduplicatesByHash)
     meta.hash = "duplicate-cover-hash";
 
     worker.enqueueMetas({meta, meta});
+    ASSERT_TRUE(spy.wait(1000));
     EXPECT_EQ(spy.count(), 1);
 }
 


### PR DESCRIPTION
Persist unfinished cover and lyric analysis tasks outside the database, and resume only valid tasks on the next startup.

将未完成的封面和歌词解析任务持久化到数据库之外，并在下次启动时恢复有效任务。

Log: 修复媒体元数据解析任务退出后丢失问题
PMS: BUG-333525
Influence: 应用退出时不再等待整个解析队列，未完成任务可在下次启动继续处理。

## Summary by Sourcery

Persist and restore pending media metadata analysis tasks across application restarts, ensuring only valid tasks are resumed and completed results are flushed without blocking shutdown.

Bug Fixes:
- Prevent loss of unfinished cover and lyric analysis tasks when the application exits by persisting the pending queue to a cache file.
- Avoid processing invalid or deleted media entries by validating pending tasks against existing metas and file paths before resuming them.
- Ensure that metadata analysis results are saved before shutdown without waiting for all queued tasks to finish.

Enhancements:
- Introduce a sidecar JSON cache for tracking pending media metadata analysis tasks and keeping it in sync as tasks are enqueued, completed, or removed.
- Add controlled stopping behavior to the media metadata worker so the currently processing file can finish while queued files are deferred to the next startup.

Tests:
- Update media metadata worker tests to verify that deduplication and processing of enqueued tasks still completes within a bounded time.