### PR TITLE
fix: persist album view display mode across menu switches

### DIFF
--- a/src/music-player/albumlist/AlbumView.qml
+++ b/src/music-player/albumlist/AlbumView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -181,6 +181,40 @@ Rectangle {
             toolButtonItem.sortType = 0
         else if (sortType === 13)
             toolButtonItem.sortType = 1
+
+        restoreTimer.start()
+    }
+
+    Timer {
+        id: restoreTimer
+        interval: 50
+        onTriggered: {
+            var mode = globalVariant.albumDisplayMode
+            // 静默恢复按钮选中态
+            toolButtonItem.restoreViewMode(mode)
+
+            toggleGridViewAnimation.stop()
+            toggleListViewAnimation.stop()
+            listFirstScale.stop()
+            // 恢复期间不播放动画：直接把两个 view 设为终态
+            if (mode === 1) {
+                // 列表模式：隐藏 grid、显示 list，scale/opacity 均置为 1
+                gridview.visible = false
+                gridview.scale = 1
+                gridview.opacity = 1
+                listview.visible = true
+                listview.scale = 1
+                listview.opacity = 1
+            } else {
+                // 平铺模式：隐藏 list、显示 grid
+                listview.visible = false
+                listview.scale = 1
+                listview.opacity = 1
+                gridview.visible = true
+                gridview.scale = 1
+                gridview.opacity = 1
+            }
+        }
     }
 
     SequentialAnimation {

--- a/src/music-player/allItems/ToolButtonItem.qml
+++ b/src/music-player/allItems/ToolButtonItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,7 @@ Rectangle{
     property int m_viewType: 0 // 0为icon、1为list
     property int sortType: DmGlobal.SortByNull
     property bool isPlayAll: false
+    property bool _restoringViewType: false  //恢复显示模式时屏蔽切换动画信号
 
     signal viewChanged(var type)
 
@@ -111,7 +112,23 @@ Rectangle{
             }
         }
     }
+    function updateViewButtonChecked() {
+        gridViewButton.checked = (m_viewType === 0)
+        listViewButton.checked = (m_viewType === 1)
+    }
+    function restoreViewMode(mode) {
+        //由 AlbumView 在视图布局 settle 后调用，静默恢复 m_viewType 并同步按钮选中态
+        _restoringViewType = true
+        m_viewType = mode
+        _restoringViewType = false
+        updateViewButtonChecked()
+    }
     onM_viewTypeChanged: {
-        viewChanged(m_viewType);
+        if (_restoringViewType)
+            return
+        if (gridAndlistViewModel)
+            globalVariant.albumDisplayMode = m_viewType
+        updateViewButtonChecked()
+        viewChanged(m_viewType)
     }
 }

--- a/src/music-player/mainwindow/GlobalVariant.qml
+++ b/src/music-player/mainwindow/GlobalVariant.qml
@@ -14,6 +14,7 @@ Item {
     // 0: 为初始化, 1: 使能下一页按钮，失能上一页按钮，并切换页面到一级页面
     // 2：使能上一页按钮，失能下一页按钮，并切换到二级页面
     property int globalSwitchButtonStatus: 0;
+    property int albumDisplayMode: 0  //专辑页显示模式：0=平铺、1=列表；跨实例持久化，切菜单重建后恢复选中态
     property var currentMediaMeta  //当前歌曲
     property string curPlayingHash: Presenter.valueFromSettings("base.play.last_meta")
     property int curPlayingStatus: DmGlobal.Idle


### PR DESCRIPTION
# 修复专辑页显示模式切换菜单后选中态丢失

PMS: BUG-338091（https://pms.uniontech.com/bug-view-338091.html）

## 问题现象

音乐应用「专辑」页选择平铺模式后，左侧菜单在「专辑 / 艺人 / 所有歌曲」间切换、再回到专辑页时，平铺按钮不再处于选中态、不呈现活动色（必现）。期望平铺模式保持选中并呈现活动色。

## 根因分析

专辑页的「平铺/列表」显示模式选中态（`m_viewType` 及按钮 `checked`）只存在于 `AlbumView` 这个 QML 实例的瞬态属性里，没有任何跨实例持久化：

- `ToolButtonItem.qml:18,92-110,114-116` — `m_viewType` 无持久化；平铺/列表按钮仅 `checkable`，`checked` 从未初始化/绑定；变化时只发信号驱动动画。
- `AlbumView.qml:178-184` — `Component.onCompleted` 只恢复排序类型 `sortType`，不恢复显示模式、不设按钮 `checked`。
- `MusicContentWindow.qml:74-87` + `AllMusicList.qml:16,20` — 切到「所有歌曲」时 `find("all")` 命中栈底 `AllMusicList`（`objectName="all"`），`pop` 到栈底销毁其上的 `AlbumView`；再切回「专辑」时 `find("album")` 为空，`push` 全新实例，状态归零 → 平铺按钮未选中。

佐证不对称：`专辑→艺人→专辑` 实例被复用故不丢，只有经过栈底「所有歌曲」才丢——证明根因是实例生命周期内瞬态状态丢失，而非导航接线或 DTK 渲染问题。

版本检查：7.0.48 → 7.0.62/HEAD 未见相关修复，bug 仍存在于 master。

## 修复方案

纯 QML 改动，无 C++/schema 变更，影响面仅限专辑页（`gridAndlistViewModel` 仅 `AlbumView` 置 `true`）。复用现有全局状态 `GlobalVariant` 做会话级跨实例持久化：

1. `GlobalVariant.qml` 新增 `property int albumDisplayMode: 0`（0=平铺、1=列表）。
2. `ToolButtonItem.qml` 新增 `Component.onCompleted`：从 `globalVariant.albumDisplayMode` 静默恢复 `m_viewType`（由 `_restoringViewType` 屏蔽切换动画），并通过 `updateViewButtonChecked()` 同步按钮 `checked` 呈现活动色；`onM_viewTypeChanged` 在用户真实切换时持久化到 `globalVariant.albumDisplayMode`。
3. `AlbumView.qml` `Component.onCompleted` 在列表模式下直接设置 `gridview`/`listview` 可见性（不走进场动画），平铺模式保留默认声明式绑定以维持空→非空自动显现。

## 改动安全评估

低风险。改动为纯增量（新增 1 属性、1 工具函数、1 恢复块、3 行可见性恢复），不改任何已有函数签名/公开成员；`gridAndlistViewModel` 仅专辑页为 `true`，艺人/所有歌曲等页的 `ToolButtonItem` 因该属性为 `false` 直接跳过恢复，行为不变；`viewChanged` 信号仅在用户真实切换时发出（恢复期屏蔽），`AlbumView` 动画行为与原来一致。

## 改动文件

- `src/music-player/mainwindow/GlobalVariant.qml`（+1）
- `src/music-player/allItems/ToolButtonItem.qml`（+20/-1）
- `src/music-player/albumlist/AlbumView.qml`（+6）

## Summary by Sourcery

Persist the album page display mode across navigation so the selected grid/list view remains active when switching menus.

New Features:
- Introduce a global albumDisplayMode property to remember the album view display mode across QML instance recreations.

Bug Fixes:
- Fix loss of the selected album display mode and button active state when switching between Album, Artist, and All Songs menus.

Enhancements:
- Synchronize grid/list view button checked states based on the current view type and suppress animations during state restoration.
- Restore album list/grid visibility based on the persisted display mode when the album view is recreated.