### PR TITLE
test(libdmusic): KMEANS 单元测试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ obj-x86_64-linux-gnu/
 .codegraph/
 .trellis/
 AGENTS.md
+
+# 单元测试生成产物（不入库）
+build-debug/
+.codebase-memory/
+tests/.ut-session.json
+*.info
+*.gcov

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,4 +4,12 @@
 # add_subdirectory(tst_music-player)
 add_subdirectory(libdmusic-test)
 
+# ── 模块化单元测试自动发现（增量补全）─────────────────────────────────────
+# 每个测试类独立子目录 tests/ut_<classname>/，含独立 CMakeLists.txt。
+# 新增测试只需新建 ut_<classname>/ 子目录，无需修改本文件，避免多 PR 合并冲突。
+file(GLOB MULTICA_UT_SUBDIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/ut_*)
+foreach(_ut_dir ${MULTICA_UT_SUBDIRS})
+    add_subdirectory(${_ut_dir})
+endforeach()
+
 

--- a/tests/ut_ykmeans/CMakeLists.txt
+++ b/tests/ut_ykmeans/CMakeLists.txt
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# ut_ykmeans —— KMEANS 模板类（src/libdmusic/util/ykmeans.h）单元测试
+# 该类为头文件内联模板，无项目库依赖，独立编译。
+
+cmake_minimum_required(VERSION 3.10)
+project(ut_ykmeans)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+find_package(Threads REQUIRED)
+
+add_executable(${PROJECT_NAME} test_kmeans.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/libdmusic/util)
+
+# Debug 覆盖率插桩（与主工程 Debug 一致），供 lcov 统计被测模板函数覆盖率
+target_compile_options(${PROJECT_NAME} PRIVATE -fprofile-arcs -ftest-coverage -g)
+target_link_options(${PROJECT_NAME} PRIVATE -fprofile-arcs)
+
+target_link_libraries(${PROJECT_NAME} gtest gtest_main Threads::Threads)
+
+include(CTest)
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/ut_ykmeans/test_kmeans.cpp
+++ b/tests/ut_ykmeans/test_kmeans.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "ykmeans.h"
+
+#include <vector>
+#include <algorithm>
+#include <limits>
+
+namespace {
+// 两个充分分离的簇：A 位于原点附近，B 位于 (10,10) 附近。
+std::vector<std::vector<float> > makeTwoClusters()
+{
+    return std::vector<std::vector<float> >{
+        {0.0f, 0.0f}, {0.1f, 0.1f}, {0.2f, 0.0f},
+        {10.0f, 10.0f}, {9.9f, 10.0f}, {10.0f, 9.8f}
+    };
+}
+}  // namespace
+
+// 构造函数：新实例公共成员应为空。
+TEST(KMEANSTest, Constructor_NewInstance_HasEmptyPublicState)
+{
+    KMEANS<float> km;
+    EXPECT_TRUE(km.dataSet.empty());
+    EXPECT_TRUE(km.centroids.empty());
+    EXPECT_TRUE(km.clusterAssment.empty());
+}
+
+// Node 内嵌结构构造函数：保存索引与距离。
+TEST(KMEANSTest, Node_Constructor_StoresIndexAndDistance)
+{
+    KMEANS<float>::tNode node(2, 3.5);
+    EXPECT_EQ(node.minIndex, 2);
+    EXPECT_DOUBLE_EQ(node.minDist, 3.5);
+}
+
+// loadData：载入数据后 dataSet 按行/列保存。
+TEST(KMEANSTest, LoadData_ValidDataset_StoresDataAndDimensions)
+{
+    KMEANS<float> km;
+    km.loadData(makeTwoClusters());
+    EXPECT_EQ(km.dataSet.size(), 6u);
+    EXPECT_EQ(km.dataSet.front().size(), 2u);
+    EXPECT_EQ(km.dataSet.back().size(), 2u);
+}
+
+// kmeans（双簇）：产生合法的 2 簇分配结果，覆盖 getMinMax / randCent /
+// defaultDistEclud 等受保护/静态方法。
+TEST(KMEANSTest, Kmeans_TwoClustersSeparated_ProducesValidAssignment)
+{
+    KMEANS<float> km;
+    km.loadData(makeTwoClusters());
+    km.kmeans(2);
+
+    ASSERT_EQ(km.clusterAssment.size(), 6u);
+    EXPECT_EQ(km.centroids.size(), 2u);
+
+    for (const auto &node : km.clusterAssment) {
+        EXPECT_GE(node.minIndex, 0);
+        EXPECT_LT(node.minIndex, 2);
+        EXPECT_GE(node.minDist, 0.0);
+    }
+
+    // 质心坐标应落在数据范围 [0,10] 内。
+    for (const auto &center : km.centroids) {
+        for (float v : center) {
+            EXPECT_GE(v, -0.5f);
+            EXPECT_LE(v, 10.5f);
+        }
+    }
+}
+
+// kmeans（单簇）：所有点归入唯一的簇 0。
+TEST(KMEANSTest, Kmeans_SingleCluster_AssignsAllPointsToGroupZero)
+{
+    KMEANS<float> km;
+    km.loadData(makeTwoClusters());
+    km.kmeans(1);
+
+    ASSERT_EQ(km.clusterAssment.size(), 6u);
+    EXPECT_EQ(km.centroids.size(), 1u);
+    for (const auto &node : km.clusterAssment) {
+        EXPECT_EQ(node.minIndex, 0);
+        EXPECT_GE(node.minDist, 0.0);
+    }
+}
+
+// kmeans 收敛后再次调用仍稳定（覆盖重复执行路径）。
+TEST(KMEANSTest, Kmeans_RepeatedRun_StaysConsistentInSize)
+{
+    KMEANS<float> km;
+    km.loadData(makeTwoClusters());
+    km.kmeans(2);
+    auto firstSize = km.clusterAssment.size();
+    km.kmeans(2);
+    EXPECT_EQ(km.clusterAssment.size(), firstSize);
+    EXPECT_EQ(km.centroids.size(), 2u);
+}


### PR DESCRIPTION
## ut: KMEANS 单元测试

为 `src/libdmusic/util/ykmeans.h` 的 `KMEANS` 模板类补全单元测试，目标函数覆盖率 100%。

### 覆盖情况
| 类 | 文件 | 函数覆盖 | 用例数 | 编译 | 运行 |
|----|------|---------|--------|------|------|
| KMEANS | src/libdmusic/util/ykmeans.h | 9/9 (100%) | 6 | ✅ | ✅ |

lcov 结果：`ykmeans.h` 函数覆盖率 100.0%（9 of 9），行覆盖率 100.0%（76 of 76）。

### 测试内容
- 构造函数初始空状态
- `tNode` 构造保存索引/距离
- `loadData` 载入数据与维度
- `kmeans` 双簇分离产生合法分配（覆盖 `getMinMax`/`randCent`/`defaultDistEclud`）
- `kmeans` 单簇全归簇 0
- `kmeans` 重复执行稳定

### 模块化结构
- 测试位于独立子目录 `tests/ut_ykmeans/`，含独立 `CMakeLists.txt`
- `tests/CMakeLists.txt` 增量追加 `ut_*` 子目录自动发现，后续每类 PR 仅新增子目录，避免合并冲突
- Google Test 框架，Debug 构建启用 gcov 覆盖率插桩

### 基线
- `2ea7ed05` fix: persist album view display mode across menu switches (#338091) (2026-08-10)

## Summary by Sourcery

Add modular unit tests for the KMEANS template class in libdmusic and wire them into the test build.

Build:
- Update tests/CMakeLists.txt to auto-discover and add ut_* unit test subdirectories, enabling incremental test additions without central list changes.

Tests:
- Introduce a new Google Test-based ut_ykmeans test target that exercises KMEANS constructor, data loading, clustering behavior, and repeated execution.
- Ensure the KMEANS unit tests achieve full function and line coverage for ykmeans.h via gcov instrumentation in Debug builds.