### PR TITLE
fix: Use version-agnostic library names for FFmpeg DLLs on Windows

### DIFF
--- a/src/libdmusic/core/dynamiclibraries.cpp
+++ b/src/libdmusic/core/dynamiclibraries.cpp
@@ -15,15 +15,15 @@
 #ifdef Q_OS_WIN
 static const QString libvlccoreStr = "libvlccore";
 static const QString libvlcStr = "libvlc";
-static const QString libavcodecStr = "avcodec-62";
-static const QString libavformateStr = "avformat-62";
-static const QString libavutilStr = "avutil-60";
-static const QString libswresampleStr = "swresample-6";
+static const QString libavcodecStr = "avcodec";
+static const QString libavformatStr = "avformat";
+static const QString libavutilStr = "avutil";
+static const QString libswresampleStr = "swresample";
 #else
 static const QString libvlccoreStr = "libvlccore.so";
 static const QString libvlcStr = "libvlc.so";
 static const QString libavcodecStr = "libavcodec.so";
-static const QString libavformateStr = "libavformat.so";
+static const QString libavformatStr = "libavformat.so";
 static const QString libavutilStr = "libavutil.so";
 static const QString libswresampleStr = "libswresample.so";
 #endif
@@ -181,7 +181,7 @@ bool DynamicLibraries::loadLibraries()
         return false;
     }
 
-    QString strlibformate = DmGlobal::libPath(libavformateStr);
+    QString strlibformate = DmGlobal::libPath(libavformatStr);
     qCDebug(dmMusic) << "Loading avformat library from:" << strlibformate;
     if (QLibrary::isLibrary(strlibformate)) {
         avformateLib.setFileName(strlibformate);


### PR DESCRIPTION
Remove hardcoded version suffixes (e.g. avcodec-63) from FFmpeg library names so that libPath's wildcard matching can automatically resolve the latest available version at runtime.

fix: Windows 下使用无版本号的 FFmpeg 库名以实现动态适配

移除 FFmpeg 库名中硬编码的版本号后缀（如 avcodec-63），使 libPath 的通配 符匹配机制能够自动解析运行时可用的最新版本，避免因 FFmpeg 版本更替导致库加载失败。

## Summary by Sourcery

Remove hardcoded FFmpeg version suffixes from Windows library names to support automatic runtime resolution of installed versions.

Bug Fixes:
- Use version-agnostic FFmpeg library names on Windows so runtime wildcard resolution can select available library versions and prevent loading failures after FFmpeg upgrades.

Enhancements:
- Align FFmpeg library naming across platforms and correct the avformat library identifier.