### PR TITLE
fix: fix titlebar control overlap at small window widths

### DIFF
--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -210,14 +210,17 @@ TitleBar {
 
         RowLayout {
             id: titleRowLayout
-            width: parent.width - 20
             anchors {
                 left: parent.left
+                right: parent.right
                 leftMargin: 30
+                rightMargin: 20
             }
 
             // 响应式显示控制 - 使用内容区域自身宽度判断
-            property bool showSearchEdit: titleRowLayout.width > 400
+            // 搜索框+添加按钮全部显示时需要约 468px（导航82+搜索300+添加36+边距50），
+            // 阈值取 500 确保内容能完全容纳时才显示，避免控件重叠
+            property bool showSearchEdit: titleRowLayout.width > 500
             property bool showNavButtons: titleRowLayout.width > 300
 
             RowLayout {


### PR DESCRIPTION
## 根因分析

**强根因**：`WindowTitlebar.qml` 中 `titleRowLayout` 的 `width: parent.width - 20` 未计入 `anchors.leftMargin: 30`，导致 RowLayout 右边缘溢出父容器（DTK TitleBar customCenter）10px，侵入菜单按钮区域。同时响应式阈值 `showSearchEdit: titleRowLayout.width > 400` 低于内容实际所需宽度 468px（导航82+搜索300+添加36+边距50），当宽度在 400~468px 之间时搜索框和添加按钮显示但无法容纳，`AlignCenter`/`AlignRight` 布局导致控件互相重叠。

**关键证据**：
- `WindowTitlebar.qml:216` — `width: parent.width - 20` + `leftMargin: 30` → 右边缘溢出 10px
- `WindowTitlebar.qml:220` — 阈值 400 < 内容所需 468px
- DTK TitleBar `customCenter` 紧邻 `optionMenuBtn`（菜单按钮），溢出直接侵入

## 修复方案

1. 将 `width: parent.width - 20` + `anchors.left` 改为 `anchors.left + anchors.right` 双端锚定（leftMargin 30, rightMargin 20），消除溢出
2. 将 `showSearchEdit` 阈值从 400 提高到 500，确保内容能完全容纳时才显示

## 改动安全评估

**低风险**：仅调整 QML 布局属性和条件阈值，无函数签名变更，无外部调用者（References=0）。修改的代码行中，width/anchors 部分为 2023 年原始代码（非之前修复），阈值部分为 2026-01 修复的改进（非撤销）。

## Summary by Sourcery

Adjust title bar layout responsiveness to prevent control overlap at small window widths.

Bug Fixes:
- Fix title bar center layout overflowing into the menu button area at narrow window widths.
- Update the search field visibility threshold so search and add controls only appear when there is sufficient space.