### PR TITLE
fix: disable VLC taglib plugin to avoid crash

### DIFF
--- a/src/libdmusic/player/vlc/Common.cpp
+++ b/src/libdmusic/player/vlc/Common.cpp
@@ -23,7 +23,11 @@ QStringList VlcCommon::args()
                   << "--no-osd"
                   << "--no-loop"
                   << "--no-video-title-show"
-                  << "--drop-late-frames";
+                  << "--drop-late-frames"
+                  // Disable VLC's TagLib metadata plugin: dmusic parses tags with
+                  // TagLib 2, while this plugin links TagLib 1, causing a
+                  // same-process symbol conflict that crashes on playback.
+                  << "--no-taglib";
     }
 
     qCDebug(dmMusic) << "VLC return args:" << args_list;

--- a/tests/libdmusic-test/test_vlc.cpp
+++ b/tests/libdmusic-test/test_vlc.cpp
@@ -58,6 +58,7 @@ TEST(VlcCommonTest, argsReturnsDefaultArgs)
     const QStringList args = VlcCommon::args();
     EXPECT_FALSE(args.isEmpty());
     EXPECT_TRUE(args.contains("--intf=dummy"));  // 默认参数
+    EXPECT_TRUE(args.contains("--no-taglib"));  // disable VLC TagLib plugin to avoid symbol conflict with dmusic TagLib 2
 }
 
 TEST(VlcEnumsTest, constructs)


### PR DESCRIPTION
On Linux, VLC's TagLib metadata plugin links against TagLib 1 while
dmusic uses TagLib 2. The same-process symbol conflict between the two
crashes the app on playback. Add --no-taglib to VlcCommon::args() to
disable VLC's redundant TagLib plugin (dmusic parses tags itself with
TagLib 2), eliminating the conflict at the source. Also add a unit
test assertion for the new default argument.

Log: Fix playback crash caused by VLC TagLib plugin symbol conflict
Influence: Resolve the symbol conflict between VLC's TagLib plugin and dmusic's TagLib 2, preventing the crash on playback; metadata parsing by dmusic is unaffected.

Multica Issue: V-1937
