### PR TITLE
chore(deps): remove obsolete Qt5 build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ _The **master** branch is current development branch, build dependencies may cha
 * libavformat-dev
 * libdtk6core-bin
 * libdtk6gui-dev
-* libdbusextended-qt5-dev
-* libgsettings-qt-dev
 * libicu-dev
 * libmpris-qt6-dev
 * libtag1-dev

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -15,8 +15,6 @@ _The **master** branch is current development branch, build dependencies may cha
 * libavformat-dev
 * libdtk6core-bin
 * libdtk6gui-dev
-* libdbusextended-qt5-dev
-* libgsettings-qt-dev
 * libicu-dev
 * libmpris-qt6-dev
 * libtag1-dev

--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,6 @@ Build-Depends:
  libavformat-dev,
  libdtk6core-bin,
  libdtk6gui-dev,
- libdbusextended-qt5-dev,
- libgsettings-qt-dev,
  libicu-dev,
  libmpris-qt6-dev,
  libtag1-dev,

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -21,7 +21,7 @@ command:
 
 build: |
   # 下载和安装依赖
-  apt -y install --download-only libavutil-dev libavcodec-dev libavformat-dev libdtk6core-bin libdtk6gui-dev libdbusextended-qt5-dev libgsettings-qt-dev libicu-dev libmpris-qt6-dev libtag1-dev qt6-svg-dev libqt6sql6-sqlite libxtst-dev libvlc-dev libvlccore-dev vlc-plugin-base qt6-multimedia-dev qt6-tools-dev qt6-tools-dev-tools qml6-module-qtquick-dialogs qt6-declarative-dev libdtk6declarative-dev qt6-5compat-dev libsdl2-dev libsdl1.2debian
+  apt -y install --download-only libavutil-dev libavcodec-dev libavformat-dev libdtk6core-bin libdtk6gui-dev libicu-dev libmpris-qt6-dev libtag1-dev qt6-svg-dev libqt6sql6-sqlite libxtst-dev libvlc-dev libvlccore-dev vlc-plugin-base qt6-multimedia-dev qt6-tools-dev qt6-tools-dev-tools qml6-module-qtquick-dialogs qt6-declarative-dev libdtk6declarative-dev qt6-5compat-dev libsdl2-dev libsdl1.2debian
   bash ./install_dep /var/cache/apt/archives "$PREFIX"
 
   # 修改路径

--- a/src/music-player/CMakeLists.txt
+++ b/src/music-player/CMakeLists.txt
@@ -10,13 +10,10 @@ find_package(Dtk6Declarative REQUIRED)
 find_package(Qt6 COMPONENTS Core Widgets Quick LinguistTools REQUIRED)
 find_package(PkgConfig REQUIRED)
 
-# pkg_check_modules(DTK REQUIRED IMPORTED_TARGET dtk6widget)
 pkg_check_modules(DTK REQUIRED IMPORTED_TARGET dtk6core)
 pkg_check_modules(DTK REQUIRED IMPORTED_TARGET dtk6gui)
 
-# Since the dtk6widget.pc file is incorrect, use cmake config file to find Dtk6Widget
 find_package(Qt6 COMPONENTS Svg REQUIRED)
-find_package(Dtk6Widget REQUIRED)
 
 qt6_add_resources(RCC_SOURCES ${RESOURCES})
 


### PR DESCRIPTION
Remove obsolete Qt5 and Dtk6Widget build dependencies and CMake discovery.
移除遗留的 Qt5、Dtk6Widget 构建依赖及对应的 CMake 查找配置。

Log: 清理无用 Qt5 和 Dtk6Widget 构建依赖
Influence: 减少构建环境依赖，并确保项目在不安装 Dtk6Widget 开发包时正常构建。