### PR TITLE
fix: remove SystemPalette and use hardcoded colors in sidebar

### DIFF
--- a/src/music-player/musicbaseandsonglist/SideBarItem.qml
+++ b/src/music-player/musicbaseandsonglist/SideBarItem.qml
@@ -1,5 +1,4 @@
-// Copyright (C) 2022-2026 UnionTech Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,10 +22,6 @@ ColumnLayout {
     id: control
     spacing: 10
     Layout.leftMargin: 10
-    SystemPalette {
-        id: systemPalette
-        colorGroup: SystemPalette.Active
-    }
 
     Rectangle {
         id: siderTitle
@@ -38,7 +33,7 @@ ColumnLayout {
             width: 42; height: 20
             anchors.left: parent.left
             anchors.leftMargin: 10
-            color: systemPalette.placeholderText
+            color: DTK.themeType === ApplicationHelper.DarkType ? Qt.rgba(247, 247, 247, 0.7) : Qt.rgba(0, 0, 0, 0.7)
             text: title
             font: DTK.fontManager.t6
             horizontalAlignment: Qt.AlignLeft

--- a/src/music-player/musicbaseandsonglist/SideBarItemDelegate.qml
+++ b/src/music-player/musicbaseandsonglist/SideBarItemDelegate.qml
@@ -12,15 +12,15 @@ import org.deepin.dtk 1.0
 
 ItemDelegate {
     property string type: "library"
-    readonly property color foregroundColor: checked ? systemPalette.highlightedText
-                                                     : systemPalette.windowText
+    readonly property color foregroundColor: {
+        if (checked) {
+            return DTK.themeType === ApplicationHelper.DarkType ? "#FFFFFF" : "#FFFFFF"
+        }
+        return DTK.themeType === ApplicationHelper.DarkType ? "#B2F7F7F7" : "#000000"
+    }
     id: item
     checked: globalVariant !== undefined && globalVariant.curListPage === model.uuid
     palette.buttonText: foregroundColor
-    SystemPalette {
-        id: systemPalette
-        colorGroup: SystemPalette.Active
-    }
     // 屏蔽空格响应
     Keys.onSpacePressed: { event.accepted=false; }
     Keys.onReleased: { event.accepted=(event.key===Qt.Key_Space); }


### PR DESCRIPTION
fix: 移除 SystemPalette，侧边栏使用硬编码颜色

使用系统调色板后，Windows 下切换深色模式时颜色不会变化

## Summary by Sourcery

Fix sidebar color handling by removing system palette dependencies and applying explicit colors for each application theme.

Bug Fixes:
- Ensure sidebar text colors remain correct when switching between light and dark modes on Windows.

Enhancements:
- Replace system palette color usage in sidebar items with explicit theme-aware colors.

Chores:
- Update SPDX copyright header formatting in the sidebar item component.