### PR TITLE
chore: update version to 7.0.64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-music (7.0.64) unstable; urgency=medium
+
+  * chore(deps): remove unused Qt5 and Dtk6Widget dependencies
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 14 Aug 2026 15:29:02 +0800
+
 deepin-music (7.0.63) unstable; urgency=medium
 
   * fix(core): store pending media task hashes only

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.63.1
+  version: 7.0.64.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
- bump version to 7.0.64

Log : bump version to 7.0.64

## Summary by Sourcery

Build:
- Update application package version in linglong.yaml to 7.0.64.1.