### PR TITLE
fix: disable unnecessary VLC modules and add Qt6::DBus dependency

### DIFF
--- a/src/libdmusic/player/vlc/Instance.cpp
+++ b/src/libdmusic/player/vlc/Instance.cpp
@@ -100,7 +100,13 @@ VlcInstance::VlcInstance(const QStringList &args,
     }
 #endif
 
-    _vlcInstance = vlc_new(0, nullptr);
+    // 禁用不需要的模块（音乐播放器不需要视频、字幕等功能）
+    const char *vlcArgs[] = {
+        "--no-video",            // 禁用视频输出
+        "--no-stats",            // 禁用统计信息
+        "--no-spu",              // 禁用字幕处理单元
+    };
+    _vlcInstance = vlc_new(sizeof(vlcArgs) / sizeof(vlcArgs[0]), vlcArgs);
     if (_vlcInstance) {
         qCDebug(dmMusic) << "VLC instance created successfully";
         vlc_set_user_agent(_vlcInstance, DmGlobal::getAppName().toStdString().c_str(), "");//name

--- a/src/music-player/CMakeLists.txt
+++ b/src/music-player/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the Qt6Quick library
 find_package(Dtk6Declarative REQUIRED)
-find_package(Qt6 COMPONENTS Core Widgets Quick LinguistTools REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets Quick LinguistTools DBus REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(DTK REQUIRED IMPORTED_TARGET dtk6core)


### PR DESCRIPTION
fix: 禁用不需要的 VLC 模块，添加 Qt6::DBus 依赖

Linux中默认安装 DBus, 但Windows下没有,不添加会报错

## Summary by Sourcery

Streamline VLC initialization for music playback and ensure the required Qt6 DBus dependency is available across platforms.

Bug Fixes:
- Prevent Windows build or runtime dependency errors by explicitly requiring the Qt6 DBus component.

Enhancements:
- Reduce unnecessary VLC functionality for the music player by disabling video output, statistics, and subtitle processing.

Build:
- Add Qt6::DBus to the required Qt components for the music-player target.