### PR TITLE
fix: pause playback before suspend to avoid noise

### DIFF
--- a/src/libdmusic/player/playerengine.cpp
+++ b/src/libdmusic/player/playerengine.cpp
@@ -13,6 +13,7 @@
 #include <QRandomGenerator>
 #include <QPropertyAnimation>
 #include <QIcon>
+#include <QDBusConnection>
 
 #include <MprisPlayer>
 
@@ -173,6 +174,17 @@ PlayerEngine::PlayerEngine(QObject *parent, PlayerBase *injectedPlayer)
     m_data->m_fadeInAnimation->setEndValue(1.0000);
     m_data->m_fadeInAnimation->setDuration(sFadeInOutAnimationDuration);
     qCDebug(dmMusic) << "Initializing fade in animation";
+
+    // Listen for systemd-logind suspend/resume signal: pause playback before suspend
+    // to avoid HDMI audio clock drift after wake causing pipewire to fail recovery
+    if (!QDBusConnection::systemBus().connect(
+            QStringLiteral("org.freedesktop.login1"),
+            QStringLiteral("/org/freedesktop/login1"),
+            QStringLiteral("org.freedesktop.login1.Manager"),
+            QStringLiteral("PrepareForSleep"),
+            this, SLOT(onPrepareForSleep(bool)))) {
+        qCWarning(dmMusic) << "Failed to connect to login1 PrepareForSleep";
+    }
 }
 
 PlayerEngine::~PlayerEngine()
@@ -579,6 +591,19 @@ void PlayerEngine::pauseNow()
 {
     qCDebug(dmMusic) << "Pause now requested";
     m_data->m_player->pause();
+}
+
+void PlayerEngine::onPrepareForSleep(bool active)
+{
+    qCInfo(dmMusic) << "PrepareForSleep:" << (active ? "suspending" : "resuming");
+    if (active) {
+        // About to suspend: pause immediately (skip fade animation to ensure pause completes before suspend)
+        if (playbackStatus() == DmGlobal::Playing) {
+            qCInfo(dmMusic) << "Pausing playback before suspend";
+            pauseNow();
+        }
+    }
+    // On wake (active=false) do not auto-resume; let the user start playback manually
 }
 
 void PlayerEngine::playPause()

--- a/src/libdmusic/player/playerengine.h
+++ b/src/libdmusic/player/playerengine.h
@@ -70,6 +70,10 @@ public slots:
     void stop();
     void setFadeInOutFactor(double fadeInOutFactor);
 
+private slots:
+    // System suspend/resume: pause playback before suspend, do not auto-resume on wake (user starts it)
+    void onPrepareForSleep(bool active);
+
 signals:
     void fadeInOutFactorChanged(double fadeInOutFactor);
     void metaChanged();


### PR DESCRIPTION
1. Add PlayerEngine::onPrepareForSleep slot for login1 PrepareForSleep
2. On suspend pause playback immediately, skipping the fade animation
3. On wake do not auto-resume; let the user start playback manually
4. Connect login1.Manager in ctor; log warning if the connection fails

PMS: BUG-365427
Log: Fix HDMI noise after wake by pausing playback before suspend

## Summary by Sourcery

Pause playback before system suspend and require manual restart after wake to prevent HDMI audio issues.

Bug Fixes:
- Pause active playback immediately before system suspend to prevent HDMI audio noise and playback recovery failures after wake.
- Avoid automatically resuming playback when the system wakes, allowing the user to restart it manually.

Enhancements:
- Integrate with system suspend/resume notifications and warn when the login1 signal connection cannot be established.