### PR TITLE
chore(qml): update Connections signal handler syntax

### DIFF
--- a/src/music-player/mainwindow/MainWindow.qml
+++ b/src/music-player/mainwindow/MainWindow.qml
@@ -347,7 +347,7 @@ ApplicationWindow {
     Connections {
         id: toolboxConnect
         target: toolbox
-        onLyricToggleClicked: {
+        function onLyricToggleClicked() {
             if (lrcWindowLoader.status === Loader.Null) {
                 lrcWindowLoader.setSource("LyricWindow.qml")
                 lrcWindowLoader.item.y = -50
@@ -363,7 +363,7 @@ ApplicationWindow {
     Connections {
         id: titleBarConnect
         target: musicTitle
-        onLrcHideBtnClicked: {
+        function onLrcHideBtnClicked() {
             if (lrcWindowLoader.status === Loader.Null) {
                 lrcWindowLoader.setSource("LyricWindow.qml")
                 lrcWindowLoader.item.y = -50
@@ -372,7 +372,7 @@ ApplicationWindow {
                  lrcWindowLoader.item.lyricWindowUp()
              }
         }
-        onSearchItemTriggered: {
+        function onSearchItemTriggered(text, type) {
             //console.log("maindow:onSearchItemTriggered:" + text)
             //searchResultDlgItemTriggered(text)
             contentWindow.onSearchResultItemChanged(text, type)
@@ -380,7 +380,7 @@ ApplicationWindow {
     }
     Connections {
         target: globalVariant.closeConfirmDlgLoader.item
-        onMinimizeToSystemTray: {
+        function onMinimizeToSystemTray() {
             //console.log("onMinimizeToSystemTray......................")
             close()
         }

--- a/src/music-player/mainwindow/MusicContentWindow.qml
+++ b/src/music-player/mainwindow/MusicContentWindow.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -68,7 +68,7 @@ Rectangle {
 
     Connections {
         target: musicBaselist;
-        onMusicBaselistChanged: {
+        function onMusicBaselistChanged(type, displayName) {
             globalVariant.globalSwitchButtonStatus = 0; //初始化切换按钮状态
             globalVariant.curListPage = type
             var item = listViewStackView.find(function(item, index) { return item.objectName === type })
@@ -94,7 +94,7 @@ Rectangle {
     }
     Connections {
         target: globalVariant
-        onUpdateCurrentPlaylistTitleName: {
+        function onUpdateCurrentPlaylistTitleName(name, curHash) {
             var item = listViewStackView.find(function(item, index) { return item.objectName === curHash }); //重命名后，更新列表标题名
             if(item !== null){
                 item.listTitle = name;

--- a/src/music-player/musicbaseandsonglist/MusicBaselistview.qml
+++ b/src/music-player/musicbaseandsonglist/MusicBaselistview.qml
@@ -83,10 +83,10 @@ Rectangle {
 
         Connections {
             target: musicbaseSidebar
-            onItemClicked: {
+            function onItemClicked(key, text) {
                 musicBaselistChanged(key, text);
             }
-            onItemRightClicked: {
+            function onItemRightClicked(key, text) {
                 if (sidebarMenuLoader.status === Loader.Null) {
                     sidebarMenuLoader.setSource("../musicmousemenu/SidebarMenu.qml")
                 }
@@ -99,10 +99,10 @@ Rectangle {
         }
         Connections {
             target: musicSonglist
-            onItemClicked: {
+            function onItemClicked(key, text) {
                 musicBaselistChanged(key, text);
             }
-            onItemRightClicked:{
+            function onItemRightClicked(key, text) {
                 if (key === "cdarole")
                     return
                 if (sidebarMenuLoader.status === Loader.Null )


### PR DESCRIPTION
Use explicit function handlers for Qt 5 and Qt 6 compatibility.

将 Connections 信号处理器改为显式函数写法，兼容 Qt 5 和 Qt 6。

Log: 清理 QML Connections 弃用警告
PMS: BUG-373421
Influence: 消除启动时的 Connections 弃用警告，不改变业务逻辑。

## Summary by Sourcery

Modernize QML Connections handlers to eliminate startup deprecation warnings while preserving existing signal behavior.

Enhancements:
- Update QML Connections signal handlers to explicit function syntax with declared parameters for Qt 5 and Qt 6 compatibility and to remove deprecation warnings without changing behavior.

Chores:
- Refresh the MusicContentWindow copyright year range.