### PR TITLE
fix(startup): refresh queue count without playlist view

### DIFF
--- a/src/music-player/mainwindow/GlobalVariant.qml
+++ b/src/music-player/mainwindow/GlobalVariant.qml
@@ -45,7 +45,25 @@ Item {
     property Loader closeConfirmDlgLoader: Loader {}
     Loader { id: cdRemovedDlgLoader }
     Loader { id: musicInfoDlgLoader }
+    Timer {
+        id: playingCountRefreshTimer
+        interval: 0
+        repeat: false
+        onTriggered: refreshPlayingCount()
+    }
 
+    function refreshPlayingCount() {
+        playingCount = Presenter.playQueueCount()
+    }
+    function refreshPlayingCountIfNeeded(playlistHashs) {
+        for (var i = 0; i < playlistHashs.length; i++) {
+            if (playlistHashs[i] === "play") {
+                if (!playingCountRefreshTimer.running)
+                    playingCountRefreshTimer.start()
+                return
+            }
+        }
+    }
     function onMetaChanged(){
         currentMediaMeta = Presenter.getActivateMeta();
         curPlayingHash = currentMediaMeta.hash


### PR DESCRIPTION
Provide queue count helpers for deferred playlist UI updates.

补齐延迟播放列表界面的队列计数辅助函数，确保状态更新可用。

Log: 修复播放队列计数更新
PMS: BUG-373421
Influence: 避免延迟加载时调用未定义函数，保证上一首和下一首状态正确刷新。

## Summary by Sourcery

Fix queue count updates when the playlist view is unavailable during startup or deferred loading.

Bug Fixes:
- Ensure the playing queue count refreshes correctly when playlist UI loading is deferred, keeping previous and next track state updates accurate.

Enhancements:
- Add shared helpers to refresh the playing queue count immediately or schedule it after relevant playlist changes.