### PR TITLE
fix(window): handle dialog flags and close actions safely

### DIFF
--- a/src/music-player/dialogs/CDRemovedDialog.qml
+++ b/src/music-player/dialogs/CDRemovedDialog.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.0
+import QtQml 2.15
 import QtQuick.Layouts 1.11
 import QtQuick.Window 2.11
 import org.deepin.dtk 1.0
@@ -15,7 +16,10 @@ DialogWindow {
     modality: Qt.ApplicationModal
     color: Qt.rgba(247,247,247,0.80);
     icon: globalVariant.appIconName
-    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
+    Binding on flags {
+        when: Qt.platform.os === "windows"
+        value: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint
+    }
 
     onVisibleChanged: {
         if (visible && Qt.platform.os === "windows") {

--- a/src/music-player/dialogs/CloseConfirmDialog.qml
+++ b/src/music-player/dialogs/CloseConfirmDialog.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.0
+import QtQml 2.15
 import QtQuick.Layouts 1.11
 import QtQuick.Window 2.11
 import QtQml.Models 2.11
@@ -19,7 +20,10 @@ DialogWindow {
     height: 230
     modality: Qt.ApplicationModal
     icon: globalVariant.appIconName
-    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
+    Binding on flags {
+        when: Qt.platform.os === "windows"
+        value: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint
+    }
 
     header: DialogTitleBar {
         enableInWindowBlendBlur: false

--- a/src/music-player/dialogs/DeleteLocalDialog.qml
+++ b/src/music-player/dialogs/DeleteLocalDialog.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.0
+import QtQml 2.15
 import QtQuick.Layouts 1.11
 import QtQuick.Window 2.11
 import org.deepin.dtk 1.0
@@ -17,7 +18,10 @@ DialogWindow {
     modality: Qt.ApplicationModal
 //    color: Qt.rgba(247,247,247,0.80);
     icon: globalVariant.appIconName
-    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint) : undefined
+    Binding on flags {
+        when: Qt.platform.os === "windows"
+        value: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
+    }
 
     onVisibleChanged: {
         if (visible && Qt.platform.os === "windows") {

--- a/src/music-player/dialogs/DeleteSonglistDialog.qml
+++ b/src/music-player/dialogs/DeleteSonglistDialog.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.11
+import QtQml 2.15
 import QtQuick.Layouts 1.11
 import QtQuick.Window 2.11
 import Qt5Compat.GraphicalEffects
@@ -19,7 +20,10 @@ DialogWindow {
     height: deleteSongsLabel.height + 110
     modality: Qt.ApplicationModal
     icon: globalVariant.appIconName
-    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint) : undefined
+    Binding on flags {
+        when: Qt.platform.os === "windows"
+        value: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
+    }
 
     onVisibleChanged: {
         if (visible && Qt.platform.os === "windows") {

--- a/src/music-player/dialogs/EqualizerDialog.qml
+++ b/src/music-player/dialogs/EqualizerDialog.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.11
+import QtQml 2.15
 import QtQuick.Layouts 1.11
 import QtQuick.Window 2.11
 import QtQml.Models 2.11
@@ -75,7 +76,10 @@ DialogWindow {
     minimumHeight: 426
     maximumWidth: 572
     maximumHeight: 426
-    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
+    Binding on flags {
+        when: Qt.platform.os === "windows"
+        value: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint
+    }
     header: DialogTitleBar {
         enableInWindowBlendBlur: false
     }

--- a/src/music-player/dialogs/MusicInfoDialog.qml
+++ b/src/music-player/dialogs/MusicInfoDialog.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
+import QtQml 2.15
 import QtQuick.Layouts
 import QtQuick.Window
 import QtQml.Models
@@ -14,7 +15,10 @@ DialogWindow {
 
     width: 386
     height: 468
-    flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint) : undefined
+    Binding on flags {
+        when: Qt.platform.os === "windows"
+        value: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.FramelessWindowHint
+    }
 
     onVisibleChanged: {
         if (visible && Qt.platform.os === "windows") {

--- a/src/music-player/dialogs/SettingsDialog.qml
+++ b/src/music-player/dialogs/SettingsDialog.qml
@@ -121,22 +121,20 @@ Settings.SettingsDialog {
                         }
                         onValueChanged: {
 //                            console.log("onValueChanged closeAction.........." + value)
-                            Presenter.setValueToSettings("base.close.close_action", value)
-                            if (value === 2) {
-                                Presenter.setValueToSettings("base.close.is_close", false)
-                            } else {
-                                Presenter.setValueToSettings("base.close.is_close", true)
-                            }
+                            var closeAction = Number(value)
+                            if (isNaN(closeAction))
+                                return
+                            Presenter.setValueToSettings("base.close.close_action", closeAction)
+                            Presenter.setValueToSettings("base.close.is_close", closeAction !== 2)
                         }
                         Component.onCompleted: {
 //                            console.log("closeAction Component.onCompleted.........." + Presenter.valueFromSettings("base.close.close_action") + value)
-                            value = Presenter.valueFromSettings("base.close.close_action")
+                            var closeAction = Number(Presenter.valueFromSettings("base.close.close_action"))
+                            if (isNaN(closeAction))
+                                closeAction = 2
+                            value = closeAction
 //                            console.log("Settings.SettingsOption.value:", value)
-                            if (value === 2) {
-                                Presenter.setValueToSettings("base.close.is_close", false)
-                            } else {
-                                Presenter.setValueToSettings("base.close.is_close", true)
-                            }
+                            Presenter.setValueToSettings("base.close.is_close", closeAction !== 2)
                         }
                     }
                 }

--- a/src/music-player/mainwindow/GlobalVariant.qml
+++ b/src/music-player/mainwindow/GlobalVariant.qml
@@ -42,7 +42,14 @@ Item {
     signal showSearchEdit()     // 显示搜索框信号
 
     Loader { id: globalFileDlgLoader }
-    property Loader closeConfirmDlgLoader: Loader {}
+    property Loader closeConfirmDlgLoader: Loader {
+        onStatusChanged: {
+            if (status === Loader.Error) {
+                console.warn("Failed to load close confirmation dialog")
+                source = ""
+            }
+        }
+    }
     Loader { id: cdRemovedDlgLoader }
     Loader { id: musicInfoDlgLoader }
     Timer {

--- a/src/music-player/mainwindow/MainWindow.qml
+++ b/src/music-player/mainwindow/MainWindow.qml
@@ -320,18 +320,29 @@ ApplicationWindow {
     }
 
     onClosing: {
-        var closeAction = Presenter.valueFromSettings("base.close.close_action")
+        var closeAction = Number(Presenter.valueFromSettings("base.close.close_action"))
+        if (isNaN(closeAction))
+            closeAction = 2
         //console.log("closeAction: " + closeAction)
+
+        // Do not instantiate the confirmation dialog when the configured action is direct exit.
+        if (closeAction === 1) {
+            Presenter.forceExit()
+            return
+        }
 
         if (globalVariant.closeConfirmDlgLoader.status === Loader.Null)
             globalVariant.closeConfirmDlgLoader.setSource("../dialogs/CloseConfirmDialog.qml")
 
+        if (globalVariant.closeConfirmDlgLoader.status !== Loader.Ready) {
+            close.accepted = false
+            console.warn("Failed to load close confirmation dialog")
+            return
+        }
+
         if (globalVariant.closeConfirmDlgLoader.item.isMinimize) {
             //最小化
             globalVariant.closeConfirmDlgLoader.item.isMinimize = false
-        } else if (closeAction == 1) {
-            //退出
-            Presenter.forceExit();
         } else {
             //询问
             globalVariant.closeConfirmDlgLoader.item.isClose = Presenter.valueFromSettings("base.close.is_close")

--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
+import QtQml 2.15
 import QtQuick.Window
 import QtQuick.Layouts
 import org.deepin.dtk 1.0
@@ -119,7 +120,10 @@ TitleBar {
                 companyLogo: globalVariant.appIconName
                 websiteName: DTK.deepinWebsiteName
                 websiteLink: DTK.deepinWebsiteLink
-                flags: Qt.platform.os === "windows" ? (Qt.Dialog | Qt.WindowCloseButtonHint | Qt.FramelessWindowHint) : undefined
+                Binding on flags {
+        when: Qt.platform.os === "windows"
+        value: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.FramelessWindowHint
+    }
                 header: DialogTitleBar {
                     enableInWindowBlendBlur: false
                 }


### PR DESCRIPTION
Avoid undefined window flags and handle deferred close dialogs safely.

修复窗口 flags 未定义及关闭对话框延迟加载时的退出处理。

Log: 修复对话框 flags 和关闭行为
PMS: BUG-373421
Influence: 消除相关 QML 警告，确保退出、最小化和关闭确认行为正确。

## Summary by Sourcery

Safely handle window flags and close actions across dialogs and deferred confirmation flows.

Bug Fixes:
- Handle missing or invalid close-action settings safely and preserve correct exit, minimize, and confirmation behavior.
- Prevent window flag warnings by applying platform-specific dialog flags only on Windows.
- Handle deferred or failed close-confirmation dialog loading without unsafe access or unintended close behavior.