### PR TITLE
fix(album): restore clickability of empty-state buttons

### DIFF
--- a/src/music-player/albumlist/AlbumView.qml
+++ b/src/music-player/albumlist/AlbumView.qml
@@ -59,6 +59,8 @@ Rectangle {
             }
             AlbumDefaultPage {
                 id: defaultPage
+                // Keep empty-state controls above the full-page DropArea below.
+                z: 1
                 width: toolButtonItem.width; height: contenWindow.height - toolButtonItem.height
                 anchors.left: toolButtonItem.left
                 anchors.top: toolButtonItem.bottom;


### PR DESCRIPTION
Raise AlbumDefaultPage above the full-page DropArea.

Log: 修复专辑默认页按钮无法点击问题
PMS: BUG-374225
Influence: 确保专辑为空时，默认页中的添加歌曲和打开文件夹按钮可以正常响应点击。

## Summary by Sourcery

Bug Fixes:
- Restore click handling for the empty album page’s add-song and open-folder buttons.