### PR TITLE
chore: bump version to 7.0.66

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+deepin-music (7.0.66) unstable; urgency=medium
+
+  * perf(startup): defer non-critical initialization until first frame
+  * fix(startup): restore deferred UI interactions
+  * fix(database): migrate legacy music columns safely
+  * chore(qml): update Connections signal handler syntax
+  * fix(startup): refresh queue count without playlist view
+  * fix(window): handle dialog flags and close actions safely
+  * fix(album): restore clickability of empty-state buttons
+  * chore: Sync by
+    https://github.com/linuxdeepin/.github/commit/a300f8523d4876677112ed
+    ab6a0772f7ad112976
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 19 Aug 2026 20:07:02 +0800
+
 deepin-music (7.0.65) unstable; urgency=medium
 
   * fix: pause playback before suspend to avoid noise

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.music
   name: "deepin-music"
-  version: 7.0.65.1
+  version: 7.0.66.1
   kind: app
   description: |
     music for deepin os.


### PR DESCRIPTION
Update changelog and linglong versions to 7.0.66.

## Summary by Sourcery

Chores:
- Update the application and package metadata to version 7.0.66.