### PR TITLE
[AT] deepin-music AT-SPI 测试套件

### DIFF
--- a/tests/at/at-tree-annotated.yaml
+++ b/tests/at/at-tree-annotated.yaml
@@ -1,0 +1,2454 @@
+version: '1.0'
+tree:
+- id: ''
+  role: panel
+  name: albumlist
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: AlbumDefaultPage.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: Add Songs
+      object_name: importMusicFile
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Open Folders
+      object_name: importMusicDir
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AlbumGridDelegate.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: image
+      name: BackgroundImage
+      object_name: backgroundImage
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: RoundedImage_CircularButton
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Morebutton
+      object_name: morebutton
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AlbumGridView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: AlbumGridView
+      object_name: albumGridView
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: GridView_ScrollBar
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: ItemDelegate
+      object_name: itemDelegate
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AlbumListDelegate.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list item
+      name: Imagecell
+      object_name: imagecell
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AlbumListView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: Listview_2
+      object_name: listview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: ListView_ScrollBar
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: ListView_AlbumListDelegate
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AlbumView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: Component_AlbumSublistView
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Albums
+      object_name: toolButtonItem
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: panel
+      name: DefaultPage
+      object_name: defaultPage
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Listview
+      object_name: listview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Gridview
+      object_name: gridview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: allItems
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: CircularButton.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: CircularButton_Button
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: SortMenu.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: SortBtn
+      object_name: sortBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: Menu
+      object_name: menu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: title
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: SublistTitleButton.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: image
+      name: Image
+      object_name: image
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Play All
+      object_name: palyall
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ToolButtonItem.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: DataSort
+      object_name: dataSort
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: GridViewButton
+      object_name: gridViewButton
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: ListViewButton
+      object_name: listViewButton
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: dialogs
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: CDRemovedDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: Cancel
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: CloseConfirmDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: radio button
+      name: Minimize to system tray
+      object_name: minimizeBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: radio button
+      name: Exit
+      object_name: closeBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: check box
+      name: Do not ask again
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Cancel
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Confirm
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: DeleteLocalDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: Cancel
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: DeleteSonglistDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: Cancel
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: EqualizerDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: toggle button
+      name: SwitchBtn
+      object_name: switchBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: combo box
+      name: SelectComBox
+      object_name: selectComBox
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Save
+      object_name: saveBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Reset
+      object_name: resetBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: slider
+      name: PreamplifierSlider
+      object_name: preamplifierSlider
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: RightSliderListView
+      object_name: rightSliderListView
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: slider
+      name: DelegateSlider
+      object_name: delegateSlider
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: FileDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: dialog
+      name: FileDialog
+      object_name: fileDialog
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: FolderDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: dialog
+      name: FolderDialog
+      object_name: folderDialog
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ImportFailedDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: OK
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: MusicInfoDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list item
+      name: Title
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: Artist
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: Album
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: Type
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: Size
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: Duration
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: Path
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: PropertyItem.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: title
+      object_name: titleBar
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Info
+      object_name: info
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: SettingsDialog.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: dialog
+      name: Dialog
+      object_name: dialog
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: check box
+      name: SettingsDialog_CheckBox
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: check box
+      name: SettingsDialog_CheckBox_2
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: check box
+      name: SettingsDialog_CheckBox_3
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: radio button
+      name: Minimize to system tray
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: radio button
+      name: Exit
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: radio button
+      name: Ask me always
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Cancel
+      object_name: cancelBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Replace
+      object_name: replaceBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Restore Defaults
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: lyric
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: EffectLightWave.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: R_4
+      object_name: r
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: EffectLine.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: R_3
+      object_name: r
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: EffectParticle.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: R_5
+      object_name: r
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: EffectRing.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: R
+      object_name: r
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: EffectSun.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: R_2
+      object_name: r
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: EffectWaterWave.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: R_6
+      object_name: r
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: LyricPage.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: ShaderView
+      object_name: shaderView
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: LyricRect
+      object_name: lyricRect
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: LyricRect.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: ListViewLyric
+      object_name: listViewLyric
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: ListView_ScrollBar_3
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ShaderView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: Around
+      object_name: around
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: image
+      name: CircularImg_2
+      object_name: circular_img
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: Around_2
+      object_name: around
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: image
+      name: CircularImg_3
+      object_name: circular_img
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: Around_3
+      object_name: around
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: image
+      name: CircularImg_4
+      object_name: circular_img
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: Around_4
+      object_name: around
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: image
+      name: CircularImg_5
+      object_name: circular_img
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: Around_5
+      object_name: around
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: image
+      name: CircularImg_6
+      object_name: circular_img
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: image
+      name: CircularImg_7
+      object_name: circular_img
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: main.qml
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: main.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: frame
+      name: Root
+      object_name: root
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: mainwindow
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: LyricWindow.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: panel
+      name: LyricPage
+      object_name: lyricPage
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: MainWindow.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: panel
+      name: MusicTitle
+      object_name: musicTitle
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: panel
+      name: Shortcuts
+      object_name: shortcuts
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: panel
+      name: ContentWindow
+      object_name: contentWindow
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: panel
+      name: Toolbox
+      object_name: toolbox
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: Component_Menu
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Play/Pause
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Previous
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Next
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Exit
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: MusicContentWindow.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: Component_AllMusicList
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Component_AlbumView
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Component_ArtistView
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Component_AllMusicList_2
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: MusicBaselist
+      object_name: musicBaselist
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: MusicContentWindow_AllMusicList
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: SearchResultWindow.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: Component_ArtistSublistView
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Component_AlbumSublistView_2
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: page tab list
+      name: TabArea
+      object_name: tabArea
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: page tab
+      name: Music
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: page tab
+      name: Album
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: page tab
+      name: Artist
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: AllMusicSortMenu
+      object_name: allMusicSortMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: AlbumMusicSortMenu
+      object_name: albumMusicSortMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: ArtistMusicSortMenu
+      object_name: artistMusicSortMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: AllMusicList
+      object_name: allMusicList
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: ArtistView
+      object_name: artistView
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: GridView_ScrollBar_2
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: MusicSingerGridItem
+      object_name: musicSingerGridItem
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: AlbumGridView_2
+      object_name: albumGridView
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: GridView_ScrollBar_3
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: ItemDelegate_2
+      object_name: itemDelegate
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: Toolbar.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: panel
+      name: ToolbarRoot
+      object_name: toolbarRoot
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: Waveform
+      object_name: waveform
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: LrcBtn
+      object_name: lrcBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: VolumeBtn
+      object_name: volumeBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: ListBtn
+      object_name: listBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: WindowTitlebar.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: WindowTitlebar_Menu
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Add playlist
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Add music
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Settings
+      object_name: settingsControl
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: Component_SearchResultDialog
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: musicList
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: AllMusicDefaultPage.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: Add Songs
+      object_name: importMusicFile
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Open Folders
+      object_name: importMusicDir
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AllMusicList.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: listTitle
+      object_name: toolButtonItem
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: panel
+      name: DefaultPage_3
+      object_name: defaultPage
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Component_AllMusicListView
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AllMusicListDelegate.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list item
+      name: Imagecell_4
+      object_name: imagecell
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AllMusicListView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: Listview_6
+      object_name: listview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: ListView_ScrollBar_5
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: ItemD
+      object_name: itemD
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: RemoveSong_7
+      object_name: removeSong
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: musicbaseandsonglist
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: MusicBaselistview.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: panel
+      name: Library
+      object_name: musicbaseSidebar
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: panel
+      name: Playlists
+      object_name: musicSonglist
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: SideBarItem.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: SideListView
+      object_name: sideListView
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: SidebarItem
+      object_name: sidebarItem
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: SideBarItemDelegate.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: Item
+      object_name: item
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: musicmousemenu
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: AlbumMoreMenu.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: MoreMenu
+      object_name: moreMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: View details
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Play all
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: Add to
+      object_name: imporAlbumtMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ArtistMoreMenu.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: MoreMenu_3
+      object_name: moreMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: View details
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Play all
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: Add to
+      object_name: importArtistMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ImportMenu.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: ImportMenu
+      object_name: importMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Play queue
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: My favorites
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Create new playlist
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: '&lt;'
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: MulitSelectMenu.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: MulitSelectMenu
+      object_name: mulitSelectMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: Add to
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: RemoveSong_6
+      object_name: removeSong
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: play
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: DeleteLocal_2
+      object_name: deleteLocal
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Delete from local disk
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: MusicMoreMenu.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: MoreMenu_2
+      object_name: moreMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Pause
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: Add to
+      object_name: musicMoreImportMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Open in file manager
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: RemoveSong_5
+      object_name: removeSong
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: play
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: DeleteLocal
+      object_name: deleteLocal
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Delete from local disk
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu
+      name: Encoding
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: encodings
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: InfoDialog
+      object_name: infoDialog
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Song info
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: SidebarMenu.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: menu
+      name: PlaylistMenu
+      object_name: playlistMenu
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Play
+      object_name: playMenuItem
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Add songs
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Rename
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: RemoveSong_4
+      object_name: removeSong
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: menu item
+      name: Delete
+      object_name: deletePlaylist
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: musicsublist
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: AlbumSublist.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: label
+      name: MusicSublistTitle_3
+      object_name: musicSublistTitle
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Listview_5
+      object_name: listview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: ListView_ScrollBar_2
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: ListView_AlbumSublistDelegate_2
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: AlbumSublistView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: label
+      name: MusicSublistTitle
+      object_name: musicSublistTitle
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Listview_3
+      object_name: listview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: AlbumSublistScrollBar
+      object_name: albumSublistScrollBar
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: ListView_AlbumSublistDelegate
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: RemoveSong
+      object_name: removeSong
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ArtistSublistDelegate.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: SublistDelegate
+      object_name: sublistDelegate
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: Imagecell_2
+      object_name: imagecell
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ArtistSublistView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: label
+      name: MusicSublistTitle_2
+      object_name: musicSublistTitle
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Listview_4
+      object_name: listview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: ArtistSublistScrollBar
+      object_name: artistSublistScrollBar
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: ListView_ArtistSublistDelegate
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: RemoveSong_2
+      object_name: removeSong
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: MusicSublistTitle.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: panel
+      name: TitleBackground
+      object_name: titleBackground
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: TitleButton1
+      object_name: titleButton1
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: playlist
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: CurrentPlayList.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: panel
+      name: PlaylistRoot
+      object_name: playlistRoot
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Empty
+      object_name: deleteBtn
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: PlaylistView
+      object_name: playlistView
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: ListView_ScrollBar_4
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: PlaylistDelegate
+      object_name: playlistDelegate
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: dialog
+      name: RemoveSong_3
+      object_name: removeSong
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: CurrentPlayListDelegate.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list item
+      name: Imagecell_3
+      object_name: imagecell
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: singerlist
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: ArtistDefaultPage.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: push button
+      name: Add Songs
+      object_name: importMusicFile
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Open Folders
+      object_name: importMusicDir
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ArtistGridDelegate.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: image
+      name: CircularImg
+      object_name: circular_img
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: CircularImg_CircularButton
+      object_name: ''
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Morebutton_2
+      object_name: morebutton
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: ArtistView.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: list
+      name: Component_ArtistSublistView_2
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: push button
+      name: Artists
+      object_name: toolButtonItem
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: panel
+      name: DefaultPage_2
+      object_name: defaultPage
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list
+      name: Singergridview
+      object_name: singergridview
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: scroll bar
+      name: GridView_ScrollBar_4
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: list item
+      name: MusicSingerGridItem_2
+      object_name: musicSingerGridItem
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+- id: ''
+  role: panel
+  name: toolbar
+  object_name: ''
+  accessible_id: ''
+  classification: container
+  comment: ''
+  annotation_status: draft
+  children:
+  - id: ''
+    role: panel
+    name: VolumeSlider.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: slider
+      name: ContentSlider
+      object_name: contentSlider
+      accessible_id: ''
+      classification: interactive
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: WaveformItem.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: WaveformItem_StripedRectangle
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: WaveformItem_StripedRectangle_2
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+  - id: ''
+    role: panel
+    name: WaveformRect.qml
+    object_name: ''
+    accessible_id: ''
+    classification: container
+    comment: ''
+    annotation_status: draft
+    children:
+    - id: ''
+      role: canvas
+      name: WaveItem
+      object_name: waveItem
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: TimeLabel
+      object_name: timeLabel
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft
+    - id: ''
+      role: canvas
+      name: WaveformRect_Triangle
+      object_name: ''
+      accessible_id: ''
+      classification: container
+      comment: ''
+      annotation_status: draft

--- a/tests/at/at-tree.yaml
+++ b/tests/at/at-tree.yaml
@@ -1,0 +1,4237 @@
+version: '1.0'
+app: deepin-music
+tree:
+- name: albumlist
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: albumlist
+  children:
+  - name: AlbumDefaultPage.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumDefaultPage.qml
+    children:
+    - name: Add Songs
+      role: push button
+      object_name: importMusicFile
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: &id001 []
+      index_in_parent: -1
+      states: &id002 []
+      state_labels: &id003 []
+      comment: ''
+      annotation_status: draft
+    - name: Open Folders
+      role: push button
+      object_name: importMusicDir
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AlbumGridDelegate.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumGridDelegate.qml
+    children:
+    - name: BackgroundImage
+      role: image
+      object_name: backgroundImage
+      accessible_id: ''
+      source: static
+      class_name: RoundedImage
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RoundedImage_CircularButton
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: CircularButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Morebutton
+      role: push button
+      object_name: morebutton
+      accessible_id: ''
+      source: static
+      class_name: CircularButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AlbumGridView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumGridView.qml
+    children:
+    - name: AlbumGridView
+      role: list
+      object_name: albumGridView
+      accessible_id: ''
+      source: static
+      class_name: GridView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: GridView_ScrollBar
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ItemDelegate
+      role: list item
+      object_name: itemDelegate
+      accessible_id: ''
+      source: static
+      class_name: AlbumGridDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AlbumListDelegate.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumListDelegate.qml
+    children:
+    - name: Imagecell
+      role: list item
+      object_name: imagecell
+      accessible_id: ''
+      source: static
+      class_name: ImageCell
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AlbumListView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumListView.qml
+    children:
+    - name: Listview_2
+      role: list
+      object_name: listview
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_ScrollBar
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_AlbumListDelegate
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AlbumListDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AlbumView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumView.qml
+    children:
+    - name: Component_AlbumSublistView
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AlbumSublistView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Albums
+      role: push button
+      object_name: toolButtonItem
+      accessible_id: ''
+      source: static
+      class_name: ToolButtonItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: DefaultPage
+      role: panel
+      object_name: defaultPage
+      accessible_id: ''
+      source: static
+      class_name: AlbumDefaultPage
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Listview
+      role: list
+      object_name: listview
+      accessible_id: ''
+      source: static
+      class_name: AlbumListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Gridview
+      role: list
+      object_name: gridview
+      accessible_id: ''
+      source: static
+      class_name: AlbumGridView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: allItems
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: allItems
+  children:
+  - name: CircularButton.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: CircularButton.qml
+    children:
+    - name: CircularButton_Button
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: SortMenu.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: SortMenu.qml
+    children:
+    - name: SortBtn
+      role: push button
+      object_name: sortBtn
+      accessible_id: ''
+      source: static
+      class_name: ToolButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Menu
+      role: menu
+      object_name: menu
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: title
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: SublistTitleButton.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: SublistTitleButton.qml
+    children:
+    - name: Image
+      role: image
+      object_name: image
+      accessible_id: ''
+      source: static
+      class_name: RoundedImage
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Play All
+      role: push button
+      object_name: palyall
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ToolButtonItem.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ToolButtonItem.qml
+    children:
+    - name: DataSort
+      role: menu
+      object_name: dataSort
+      accessible_id: ''
+      source: static
+      class_name: SortMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: GridViewButton
+      role: push button
+      object_name: gridViewButton
+      accessible_id: ''
+      source: static
+      class_name: ToolButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListViewButton
+      role: push button
+      object_name: listViewButton
+      accessible_id: ''
+      source: static
+      class_name: ToolButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: dialogs
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: dialogs
+  children:
+  - name: CDRemovedDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: CDRemovedDialog.qml
+    children:
+    - name: Cancel
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: CloseConfirmDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: CloseConfirmDialog.qml
+    children:
+    - name: Minimize to system tray
+      role: radio button
+      object_name: minimizeBtn
+      accessible_id: ''
+      source: static
+      class_name: RadioButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Exit
+      role: radio button
+      object_name: closeBtn
+      accessible_id: ''
+      source: static
+      class_name: RadioButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Do not ask again
+      role: check box
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: CheckBox
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Cancel
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Confirm
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: DeleteLocalDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: DeleteLocalDialog.qml
+    children:
+    - name: Cancel
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: DeleteSonglistDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: DeleteSonglistDialog.qml
+    children:
+    - name: Cancel
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: EqualizerDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: EqualizerDialog.qml
+    children:
+    - name: SwitchBtn
+      role: toggle button
+      object_name: switchBtn
+      accessible_id: ''
+      source: static
+      class_name: Switch
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: SelectComBox
+      role: combo box
+      object_name: selectComBox
+      accessible_id: ''
+      source: static
+      class_name: ComboBox
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Save
+      role: push button
+      object_name: saveBtn
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Reset
+      role: push button
+      object_name: resetBtn
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: PreamplifierSlider
+      role: slider
+      object_name: preamplifierSlider
+      accessible_id: ''
+      source: static
+      class_name: Slider
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RightSliderListView
+      role: list
+      object_name: rightSliderListView
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: DelegateSlider
+      role: slider
+      object_name: delegateSlider
+      accessible_id: ''
+      source: static
+      class_name: Slider
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: FileDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: FileDialog.qml
+    children:
+    - name: FileDialog
+      role: dialog
+      object_name: fileDialog
+      accessible_id: ''
+      source: static
+      class_name: FileDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: FolderDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: FolderDialog.qml
+    children:
+    - name: FolderDialog
+      role: dialog
+      object_name: folderDialog
+      accessible_id: ''
+      source: static
+      class_name: FolderDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ImportFailedDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ImportFailedDialog.qml
+    children:
+    - name: OK
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: MusicInfoDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: MusicInfoDialog.qml
+    children:
+    - name: Title
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: PropertyItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Artist
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: PropertyItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Album
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: PropertyItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Type
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: PropertyItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Size
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: PropertyItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Duration
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: PropertyItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Path
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: PropertyItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: PropertyItem.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: PropertyItem.qml
+    children:
+    - name: title
+      role: push button
+      object_name: titleBar
+      accessible_id: ''
+      source: static
+      class_name: ItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Info
+      role: list
+      object_name: info
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: SettingsDialog.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: SettingsDialog.qml
+    children:
+    - name: Dialog
+      role: dialog
+      object_name: dialog
+      accessible_id: ''
+      source: static
+      class_name: SettingsDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: SettingsDialog_CheckBox
+      role: check box
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: CheckBox
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: SettingsDialog_CheckBox_2
+      role: check box
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: CheckBox
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: SettingsDialog_CheckBox_3
+      role: check box
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: CheckBox
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Minimize to system tray
+      role: radio button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: RadioButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Exit
+      role: radio button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: RadioButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Ask me always
+      role: radio button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: RadioButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Cancel
+      role: push button
+      object_name: cancelBtn
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Replace
+      role: push button
+      object_name: replaceBtn
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Restore Defaults
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: lyric
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: lyric
+  children:
+  - name: EffectLightWave.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: EffectLightWave.qml
+    children:
+    - name: R_4
+      role: canvas
+      object_name: r
+      accessible_id: ''
+      source: static
+      class_name: CusShaderToy
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: EffectLine.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: EffectLine.qml
+    children:
+    - name: R_3
+      role: canvas
+      object_name: r
+      accessible_id: ''
+      source: static
+      class_name: CusShaderToy
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: EffectParticle.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: EffectParticle.qml
+    children:
+    - name: R_5
+      role: canvas
+      object_name: r
+      accessible_id: ''
+      source: static
+      class_name: CusShaderToy
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: EffectRing.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: EffectRing.qml
+    children:
+    - name: R
+      role: canvas
+      object_name: r
+      accessible_id: ''
+      source: static
+      class_name: CusShaderToy
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: EffectSun.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: EffectSun.qml
+    children:
+    - name: R_2
+      role: canvas
+      object_name: r
+      accessible_id: ''
+      source: static
+      class_name: CusShaderToy
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: EffectWaterWave.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: EffectWaterWave.qml
+    children:
+    - name: R_6
+      role: canvas
+      object_name: r
+      accessible_id: ''
+      source: static
+      class_name: CusShaderToy
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: LyricPage.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: LyricPage.qml
+    children:
+    - name: ShaderView
+      role: canvas
+      object_name: shaderView
+      accessible_id: ''
+      source: static
+      class_name: ShaderView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: LyricRect
+      role: canvas
+      object_name: lyricRect
+      accessible_id: ''
+      source: static
+      class_name: LyricRect
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: LyricRect.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: LyricRect.qml
+    children:
+    - name: ListViewLyric
+      role: list
+      object_name: listViewLyric
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_ScrollBar_3
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ShaderView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ShaderView.qml
+    children:
+    - name: Around
+      role: canvas
+      object_name: around
+      accessible_id: ''
+      source: static
+      class_name: EffectLine
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: CircularImg_2
+      role: image
+      object_name: circular_img
+      accessible_id: ''
+      source: static
+      class_name: Circular_img
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Around_2
+      role: canvas
+      object_name: around
+      accessible_id: ''
+      source: static
+      class_name: EffectLightWave
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: CircularImg_3
+      role: image
+      object_name: circular_img
+      accessible_id: ''
+      source: static
+      class_name: Circular_img
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Around_3
+      role: canvas
+      object_name: around
+      accessible_id: ''
+      source: static
+      class_name: EffectSun
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: CircularImg_4
+      role: image
+      object_name: circular_img
+      accessible_id: ''
+      source: static
+      class_name: Circular_img
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Around_4
+      role: canvas
+      object_name: around
+      accessible_id: ''
+      source: static
+      class_name: EffectWaterWave
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: CircularImg_5
+      role: image
+      object_name: circular_img
+      accessible_id: ''
+      source: static
+      class_name: Circular_img
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Around_5
+      role: canvas
+      object_name: around
+      accessible_id: ''
+      source: static
+      class_name: EffectParticle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: CircularImg_6
+      role: image
+      object_name: circular_img
+      accessible_id: ''
+      source: static
+      class_name: Circular_img
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: CircularImg_7
+      role: image
+      object_name: circular_img
+      accessible_id: ''
+      source: static
+      class_name: Circular_img
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: main.qml
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: main.qml
+  children:
+  - name: main.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: main.qml
+    children:
+    - name: Root
+      role: frame
+      object_name: root
+      accessible_id: ''
+      source: static
+      class_name: MainWindow
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: mainwindow
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: mainwindow
+  children:
+  - name: LyricWindow.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: LyricWindow.qml
+    children:
+    - name: LyricPage
+      role: panel
+      object_name: lyricPage
+      accessible_id: ''
+      source: static
+      class_name: LyricPage
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: MainWindow.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: MainWindow.qml
+    children:
+    - name: MusicTitle
+      role: panel
+      object_name: musicTitle
+      accessible_id: ''
+      source: static
+      class_name: WindowTitlebar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Shortcuts
+      role: panel
+      object_name: shortcuts
+      accessible_id: ''
+      source: static
+      class_name: Shortcuts
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ContentWindow
+      role: panel
+      object_name: contentWindow
+      accessible_id: ''
+      source: static
+      class_name: MusicContentWindow
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Toolbox
+      role: panel
+      object_name: toolbox
+      accessible_id: ''
+      source: static
+      class_name: Toolbar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Component_Menu
+      role: menu
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Play/Pause
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Previous
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Next
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Exit
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: MusicContentWindow.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: MusicContentWindow.qml
+    children:
+    - name: Component_AllMusicList
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AllMusicList
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Component_AlbumView
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AlbumView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Component_ArtistView
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ArtistView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Component_AllMusicList_2
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AllMusicList
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: MusicBaselist
+      role: list
+      object_name: musicBaselist
+      accessible_id: ''
+      source: static
+      class_name: MusicBaselistview
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: MusicContentWindow_AllMusicList
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AllMusicList
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: SearchResultWindow.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: SearchResultWindow.qml
+    children:
+    - name: Component_ArtistSublistView
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ArtistSublistView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Component_AlbumSublistView_2
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AlbumSublistView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: TabArea
+      role: page tab list
+      object_name: tabArea
+      accessible_id: ''
+      source: static
+      class_name: TabBar
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Music
+      role: page tab
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: TabButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Album
+      role: page tab
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: TabButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Artist
+      role: page tab
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: TabButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: AllMusicSortMenu
+      role: menu
+      object_name: allMusicSortMenu
+      accessible_id: ''
+      source: static
+      class_name: SortMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: AlbumMusicSortMenu
+      role: menu
+      object_name: albumMusicSortMenu
+      accessible_id: ''
+      source: static
+      class_name: SortMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ArtistMusicSortMenu
+      role: menu
+      object_name: artistMusicSortMenu
+      accessible_id: ''
+      source: static
+      class_name: SortMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: AllMusicList
+      role: list
+      object_name: allMusicList
+      accessible_id: ''
+      source: static
+      class_name: AllMusicListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ArtistView
+      role: list
+      object_name: artistView
+      accessible_id: ''
+      source: static
+      class_name: GridView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: GridView_ScrollBar_2
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: MusicSingerGridItem
+      role: list item
+      object_name: musicSingerGridItem
+      accessible_id: ''
+      source: static
+      class_name: ArtistGridDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: AlbumGridView_2
+      role: list
+      object_name: albumGridView
+      accessible_id: ''
+      source: static
+      class_name: GridView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: GridView_ScrollBar_3
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ItemDelegate_2
+      role: list item
+      object_name: itemDelegate
+      accessible_id: ''
+      source: static
+      class_name: AlbumGridDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: Toolbar.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: Toolbar.qml
+    children:
+    - name: ToolbarRoot
+      role: panel
+      object_name: toolbarRoot
+      accessible_id: ''
+      source: static
+      class_name: ToolFloatingPanel
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Waveform
+      role: canvas
+      object_name: waveform
+      accessible_id: ''
+      source: static
+      class_name: WaveformRect
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: LrcBtn
+      role: push button
+      object_name: lrcBtn
+      accessible_id: ''
+      source: static
+      class_name: ToolButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: VolumeBtn
+      role: push button
+      object_name: volumeBtn
+      accessible_id: ''
+      source: static
+      class_name: ToolButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListBtn
+      role: push button
+      object_name: listBtn
+      accessible_id: ''
+      source: static
+      class_name: ToolButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: WindowTitlebar.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: WindowTitlebar.qml
+    children:
+    - name: WindowTitlebar_Menu
+      role: menu
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Add playlist
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Add music
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Settings
+      role: menu item
+      object_name: settingsControl
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Component_SearchResultDialog
+      role: dialog
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: SearchResultDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: musicList
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: musicList
+  children:
+  - name: AllMusicDefaultPage.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AllMusicDefaultPage.qml
+    children:
+    - name: Add Songs
+      role: push button
+      object_name: importMusicFile
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Open Folders
+      role: push button
+      object_name: importMusicDir
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AllMusicList.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AllMusicList.qml
+    children:
+    - name: listTitle
+      role: push button
+      object_name: toolButtonItem
+      accessible_id: ''
+      source: static
+      class_name: ToolButtonItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: DefaultPage_3
+      role: panel
+      object_name: defaultPage
+      accessible_id: ''
+      source: static
+      class_name: AllMusicDefaultPage
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Component_AllMusicListView
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AllMusicListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AllMusicListDelegate.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AllMusicListDelegate.qml
+    children:
+    - name: Imagecell_4
+      role: list item
+      object_name: imagecell
+      accessible_id: ''
+      source: static
+      class_name: ImageCell
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AllMusicListView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AllMusicListView.qml
+    children:
+    - name: Listview_6
+      role: list
+      object_name: listview
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_ScrollBar_5
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ItemD
+      role: list item
+      object_name: itemD
+      accessible_id: ''
+      source: static
+      class_name: AllMusicListDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RemoveSong_7
+      role: dialog
+      object_name: removeSong
+      accessible_id: ''
+      source: static
+      class_name: DeleteSonglistDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: musicbaseandsonglist
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: musicbaseandsonglist
+  children:
+  - name: MusicBaselistview.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: MusicBaselistview.qml
+    children:
+    - name: Library
+      role: panel
+      object_name: musicbaseSidebar
+      accessible_id: ''
+      source: static
+      class_name: SideBarItem
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Playlists
+      role: panel
+      object_name: musicSonglist
+      accessible_id: ''
+      source: static
+      class_name: SideBarItem
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: SideBarItem.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: SideBarItem.qml
+    children:
+    - name: SideListView
+      role: list
+      object_name: sideListView
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: SidebarItem
+      role: list item
+      object_name: sidebarItem
+      accessible_id: ''
+      source: static
+      class_name: SideBarItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: SideBarItemDelegate.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: SideBarItemDelegate.qml
+    children:
+    - name: Item
+      role: push button
+      object_name: item
+      accessible_id: ''
+      source: static
+      class_name: ItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: musicmousemenu
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: musicmousemenu
+  children:
+  - name: AlbumMoreMenu.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumMoreMenu.qml
+    children:
+    - name: MoreMenu
+      role: menu
+      object_name: moreMenu
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: View details
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Play all
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Add to
+      role: menu
+      object_name: imporAlbumtMenu
+      accessible_id: ''
+      source: static
+      class_name: ImportMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ArtistMoreMenu.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ArtistMoreMenu.qml
+    children:
+    - name: MoreMenu_3
+      role: menu
+      object_name: moreMenu
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: View details
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Play all
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Add to
+      role: menu
+      object_name: importArtistMenu
+      accessible_id: ''
+      source: static
+      class_name: ImportMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ImportMenu.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ImportMenu.qml
+    children:
+    - name: ImportMenu
+      role: menu
+      object_name: importMenu
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Play queue
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: My favorites
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Create new playlist
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: '&lt;'
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: MulitSelectMenu.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: MulitSelectMenu.qml
+    children:
+    - name: MulitSelectMenu
+      role: menu
+      object_name: mulitSelectMenu
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Add to
+      role: menu
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ImportMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RemoveSong_6
+      role: dialog
+      object_name: removeSong
+      accessible_id: ''
+      source: static
+      class_name: DeleteSonglistDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: play
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: DeleteLocal_2
+      role: dialog
+      object_name: deleteLocal
+      accessible_id: ''
+      source: static
+      class_name: DeleteLocalDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Delete from local disk
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: MusicMoreMenu.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: MusicMoreMenu.qml
+    children:
+    - name: MoreMenu_2
+      role: menu
+      object_name: moreMenu
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Pause
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Add to
+      role: menu
+      object_name: musicMoreImportMenu
+      accessible_id: ''
+      source: static
+      class_name: ImportMenu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Open in file manager
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RemoveSong_5
+      role: dialog
+      object_name: removeSong
+      accessible_id: ''
+      source: static
+      class_name: DeleteSonglistDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: play
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: DeleteLocal
+      role: dialog
+      object_name: deleteLocal
+      accessible_id: ''
+      source: static
+      class_name: DeleteLocalDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Delete from local disk
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Encoding
+      role: menu
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: encodings
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: InfoDialog
+      role: dialog
+      object_name: infoDialog
+      accessible_id: ''
+      source: static
+      class_name: MusicInfoDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Song info
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: SidebarMenu.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: SidebarMenu.qml
+    children:
+    - name: PlaylistMenu
+      role: menu
+      object_name: playlistMenu
+      accessible_id: ''
+      source: static
+      class_name: Menu
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Play
+      role: menu item
+      object_name: playMenuItem
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Add songs
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Rename
+      role: menu item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RemoveSong_4
+      role: dialog
+      object_name: removeSong
+      accessible_id: ''
+      source: static
+      class_name: DeleteSonglistDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Delete
+      role: menu item
+      object_name: deletePlaylist
+      accessible_id: ''
+      source: static
+      class_name: MenuItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: musicsublist
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: musicsublist
+  children:
+  - name: AlbumSublist.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumSublist.qml
+    children:
+    - name: MusicSublistTitle_3
+      role: label
+      object_name: musicSublistTitle
+      accessible_id: ''
+      source: static
+      class_name: MusicSublistTitle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Listview_5
+      role: list
+      object_name: listview
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_ScrollBar_2
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_AlbumSublistDelegate_2
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AlbumSublistDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: AlbumSublistView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: AlbumSublistView.qml
+    children:
+    - name: MusicSublistTitle
+      role: label
+      object_name: musicSublistTitle
+      accessible_id: ''
+      source: static
+      class_name: MusicSublistTitle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Listview_3
+      role: list
+      object_name: listview
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: AlbumSublistScrollBar
+      role: scroll bar
+      object_name: albumSublistScrollBar
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_AlbumSublistDelegate
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: AlbumSublistDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RemoveSong
+      role: dialog
+      object_name: removeSong
+      accessible_id: ''
+      source: static
+      class_name: DeleteSonglistDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ArtistSublistDelegate.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ArtistSublistDelegate.qml
+    children:
+    - name: SublistDelegate
+      role: push button
+      object_name: sublistDelegate
+      accessible_id: ''
+      source: static
+      class_name: ItemDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Imagecell_2
+      role: list item
+      object_name: imagecell
+      accessible_id: ''
+      source: static
+      class_name: ImageCell
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ArtistSublistView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ArtistSublistView.qml
+    children:
+    - name: MusicSublistTitle_2
+      role: label
+      object_name: musicSublistTitle
+      accessible_id: ''
+      source: static
+      class_name: MusicSublistTitle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Listview_4
+      role: list
+      object_name: listview
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ArtistSublistScrollBar
+      role: scroll bar
+      object_name: artistSublistScrollBar
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_ArtistSublistDelegate
+      role: list item
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ArtistSublistDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RemoveSong_2
+      role: dialog
+      object_name: removeSong
+      accessible_id: ''
+      source: static
+      class_name: DeleteSonglistDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: MusicSublistTitle.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: MusicSublistTitle.qml
+    children:
+    - name: TitleBackground
+      role: panel
+      object_name: titleBackground
+      accessible_id: ''
+      source: static
+      class_name: SublistTitleBackground
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: TitleButton1
+      role: push button
+      object_name: titleButton1
+      accessible_id: ''
+      source: static
+      class_name: SublistTitleButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: playlist
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: playlist
+  children:
+  - name: CurrentPlayList.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: CurrentPlayList.qml
+    children:
+    - name: PlaylistRoot
+      role: panel
+      object_name: playlistRoot
+      accessible_id: ''
+      source: static
+      class_name: CurrentFloatingPanel
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Empty
+      role: push button
+      object_name: deleteBtn
+      accessible_id: ''
+      source: static
+      class_name: ToolButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: PlaylistView
+      role: list
+      object_name: playlistView
+      accessible_id: ''
+      source: static
+      class_name: ListView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: ListView_ScrollBar_4
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: PlaylistDelegate
+      role: list item
+      object_name: playlistDelegate
+      accessible_id: ''
+      source: static
+      class_name: CurrentPlayListDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: RemoveSong_3
+      role: dialog
+      object_name: removeSong
+      accessible_id: ''
+      source: static
+      class_name: DeleteSonglistDialog
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: CurrentPlayListDelegate.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: CurrentPlayListDelegate.qml
+    children:
+    - name: Imagecell_3
+      role: list item
+      object_name: imagecell
+      accessible_id: ''
+      source: static
+      class_name: ImageCell
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: singerlist
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: singerlist
+  children:
+  - name: ArtistDefaultPage.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ArtistDefaultPage.qml
+    children:
+    - name: Add Songs
+      role: push button
+      object_name: importMusicFile
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Open Folders
+      role: push button
+      object_name: importMusicDir
+      accessible_id: ''
+      source: static
+      class_name: Button
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ArtistGridDelegate.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ArtistGridDelegate.qml
+    children:
+    - name: CircularImg
+      role: image
+      object_name: circular_img
+      accessible_id: ''
+      source: static
+      class_name: CircularImg
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: CircularImg_CircularButton
+      role: push button
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: CircularButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Morebutton_2
+      role: push button
+      object_name: morebutton
+      accessible_id: ''
+      source: static
+      class_name: CircularButton
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: ArtistView.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: ArtistView.qml
+    children:
+    - name: Component_ArtistSublistView_2
+      role: list
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ArtistSublistView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Artists
+      role: push button
+      object_name: toolButtonItem
+      accessible_id: ''
+      source: static
+      class_name: ToolButtonItem
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: DefaultPage_2
+      role: panel
+      object_name: defaultPage
+      accessible_id: ''
+      source: static
+      class_name: ArtistDefaultPage
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: Singergridview
+      role: list
+      object_name: singergridview
+      accessible_id: ''
+      source: static
+      class_name: GridView
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: GridView_ScrollBar_4
+      role: scroll bar
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: ScrollBar
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: MusicSingerGridItem_2
+      role: list item
+      object_name: musicSingerGridItem
+      accessible_id: ''
+      source: static
+      class_name: ArtistGridDelegate
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft
+- name: toolbar
+  role: panel
+  object_name: ''
+  accessible_id: ''
+  source: static
+  class_name: toolbar
+  children:
+  - name: VolumeSlider.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: VolumeSlider.qml
+    children:
+    - name: ContentSlider
+      role: slider
+      object_name: contentSlider
+      accessible_id: ''
+      source: static
+      class_name: Slider
+      classification: interactive
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: WaveformItem.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: WaveformItem.qml
+    children:
+    - name: WaveformItem_StripedRectangle
+      role: canvas
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: StripedRectangle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: WaveformItem_StripedRectangle_2
+      role: canvas
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: StripedRectangle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  - name: WaveformRect.qml
+    role: panel
+    object_name: ''
+    accessible_id: ''
+    source: static
+    class_name: WaveformRect.qml
+    children:
+    - name: WaveItem
+      role: canvas
+      object_name: waveItem
+      accessible_id: ''
+      source: static
+      class_name: WaveformItem
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: TimeLabel
+      role: canvas
+      object_name: timeLabel
+      accessible_id: ''
+      source: static
+      class_name: ArrowRectangle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    - name: WaveformRect_Triangle
+      role: canvas
+      object_name: ''
+      accessible_id: ''
+      source: static
+      class_name: Triangle
+      classification: container
+      description: ''
+      actions: *id001
+      index_in_parent: -1
+      states: *id002
+      state_labels: *id003
+      comment: ''
+      annotation_status: draft
+    classification: container
+    description: ''
+    actions: *id001
+    index_in_parent: -1
+    states: *id002
+    state_labels: *id003
+    comment: ''
+    annotation_status: draft
+  classification: container
+  description: ''
+  actions: *id001
+  index_in_parent: -1
+  states: *id002
+  state_labels: *id003
+  comment: ''
+  annotation_status: draft

--- a/tests/at/cases_mapped.yaml
+++ b/tests/at/cases_mapped.yaml
@@ -1,0 +1,2113 @@
+# === 格式范例 ===
+# version: '1.0'
+# cases:
+#   - id: suite_<module>_<NNN>_s<M>            # 用例唯一 ID
+#     name: <用例标题>                           # 用例名称（≤60 字符）
+#     module: <模块名>                            # 所属模块
+#     status: unsupported                         # 可选：不可自动化时标记
+#     reason: <不可自动化原因>                      # 可选：status=unsupported 时必填
+#     steps:                                      # 步骤列表
+#       - action: <动作类型>                        # session_start/mouse_click/...
+#         selector:                                # 元素选择器
+#           name: <accessibleName>                 # AT-SPI 元素名称
+#           role: <AT-SPI 角色>                     # 角色
+#       - action: assert_element                   # 断言步骤
+#         selector:
+#           name: <元素名称>
+#           role: <角色>
+# === 格式范例 ===
+version: '1.0'
+cases:
+- id: suite_音乐_001_s1
+  name: 主菜单-关于
+  module: 音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: assert_element
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 主菜单-关于
+    case_id: case_2003951
+    case_name: 主菜单-关于
+    AT元素引用:
+    - WindowTitlebar_Menu
+- id: suite_音乐_002_s1
+  name: 音乐_窗口菜单hover状态检查
+  module: 音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: assert_element
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 音乐_窗口菜单hover状态检查
+    case_id: case_1992957
+    case_name: 音乐_窗口菜单hover状态检查
+    AT元素引用:
+    - WindowTitlebar_Menu
+- id: suite_音乐_外部交互_任务栏_001_s1
+  name: 托盘-删除所有歌曲后检查托盘右键菜单选项状态
+  module: 音乐_外部交互_任务栏
+  steps:
+  - action: mouse_right_click
+    selector:
+      name: Component_Menu
+      role: menu
+  - action: dtk_context_menu
+    selector:
+      name: Component_Menu
+    items:
+    - Play/Pause
+    - Previous
+    - Next
+    - Exit
+  - action: assert_element
+    selector:
+      name: Component_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐-任务栏
+    测试功能: 托盘-删除所有歌曲后检查托盘右键菜单选项状态
+    case_id: case_1676659
+    case_name: 托盘-删除所有歌曲后检查托盘右键菜单选项状态
+    AT元素引用:
+    - Component_Menu
+- id: suite_音乐_外部交互_任务栏_003_s1
+  name: '[302][smoke][acp1]托盘-调起'
+  module: 音乐_外部交互_任务栏
+  steps:
+  - action: mouse_click
+    selector:
+      name: Component_Menu
+      role: menu
+  - action: assert_element
+    selector:
+      name: Component_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐-任务栏
+    测试功能: '[302][smoke][acp1]托盘-调起'
+    case_id: case_1676639
+    case_name: '[302][smoke][acp1]托盘-调起'
+    AT元素引用:
+    - Component_Menu
+- id: suite_音乐_打开_关闭_002_s1
+  name: '[174][smoke][acp1]打开-右键菜单打开'
+  module: 音乐_打开_关闭
+  steps:
+  - action: assert_element
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐-关闭
+    测试功能: '[174][smoke][acp1]打开-右键菜单打开'
+    case_id: case_1677785
+    case_name: '[174][smoke][acp1]打开-右键菜单打开'
+    AT元素引用:
+    - WindowTitlebar_Menu
+- id: suite_音乐_用户场景_001_s1
+  name: '[acp2][音乐]检查音乐播放功能'
+  module: 音乐_用户场景
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-用户场景
+    测试功能: '[acp2][音乐]检查音乐播放功能'
+    case_id: case_1676597
+    case_name: '[acp2][音乐]检查音乐播放功能'
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - PlaylistDelegate
+- id: suite_音乐_界面操作_主菜单_001_s1
+  name: 设置-修改为重复快捷键
+  module: 音乐_界面操作_主菜单
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: Replace
+      role: push button
+  - action: assert_element
+    selector:
+      name: Replace
+      role: push button
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: 设置-修改为重复快捷键
+    case_id: case_1677101
+    case_name: 设置-修改为重复快捷键
+    AT元素引用:
+    - Replace
+- id: suite_音乐_界面操作_主菜单_002_s1
+  name: '[129][core][acp1]设置-每次询问'
+  module: 音乐_界面操作_主菜单
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: Ask me always
+      role: radio button
+  - action: mouse_click
+    selector:
+      name: Cancel
+      role: push button
+  - action: assert_element
+    selector:
+      name: Ask me always
+      role: radio button
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[129][core][acp1]设置-每次询问'
+    case_id: case_1677097
+    case_name: '[129][core][acp1]设置-每次询问'
+    AT元素引用:
+    - Ask me always
+    - Cancel
+- id: suite_音乐_界面操作_主菜单_006_s1
+  name: '[136]均衡器-调整数值后恢复默认'
+  module: 音乐_界面操作_主菜单
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: SwitchBtn
+      role: toggle button
+  - action: element_set_value
+    selector:
+      name: PreamplifierSlider
+      role: slider
+    value: '50'
+  - action: mouse_click
+    selector:
+      name: Reset
+      role: push button
+  - action: assert_element
+    selector:
+      name: PreamplifierSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[136]均衡器-调整数值后恢复默认'
+    case_id: case_1677079
+    case_name: '[136]均衡器-调整数值后恢复默认'
+    AT元素引用:
+    - SwitchBtn
+    - PreamplifierSlider
+    - Reset
+- id: suite_音乐_界面操作_主菜单_007_s1
+  name: '[135][core][acp1]均衡器-自定义调整数值'
+  module: 音乐_界面操作_主菜单
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: SwitchBtn
+      role: toggle button
+  - action: element_set_value
+    selector:
+      name: PreamplifierSlider
+      role: slider
+    value: '50'
+  - action: assert_element
+    selector:
+      name: PreamplifierSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[135][core][acp1]均衡器-自定义调整数值'
+    case_id: case_1677077
+    case_name: '[135][core][acp1]均衡器-自定义调整数值'
+    AT元素引用:
+    - SwitchBtn
+    - PreamplifierSlider
+- id: suite_音乐_界面操作_主菜单_009_s1
+  name: '[005][smoke][acp1]主菜单-添加新歌单选项'
+  module: 音乐_界面操作_主菜单
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Add playlist
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[005][smoke][acp1]主菜单-添加新歌单选项'
+    case_id: case_1677053
+    case_name: '[005][smoke][acp1]主菜单-添加新歌单选项'
+    AT元素引用:
+    - WindowTitlebar_Menu
+    - Add playlist
+    - PlaylistDelegate
+- id: suite_音乐_界面操作_右键菜单_001_s1
+  name: '[262]右键菜单-自定义歌单右键菜单检查'
+  module: 音乐_界面操作_右键菜单
+  steps:
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Play
+    - Add songs
+    - Rename
+    - Delete
+  - action: assert_element
+    selector:
+      name: PlaylistMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-右键菜单
+    测试功能: '[262]右键菜单-自定义歌单右键菜单检查'
+    case_id: case_1677191
+    case_name: '[262]右键菜单-自定义歌单右键菜单检查'
+    AT元素引用:
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_界面操作_右键菜单_002_s1
+  name: '[356]右键菜单-播放队列从播放队列删除'
+  module: 音乐_界面操作_右键菜单
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Delete
+  - action: assert_element
+    selector:
+      name: PlaylistMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-右键菜单
+    测试功能: '[356]右键菜单-播放队列从播放队列删除'
+    case_id: case_1677163
+    case_name: '[356]右键菜单-播放队列从播放队列删除'
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_界面操作_右键菜单_003_s1
+  name: '[352]右键菜单-多选文件右键菜单检查'
+  module: 音乐_界面操作_右键菜单
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_right_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: ItemD
+    items:
+    - play
+    - Add to
+    - Delete from local disk
+  - action: assert_element
+    selector:
+      name: MulitSelectMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-右键菜单
+    测试功能: '[352]右键菜单-多选文件右键菜单检查'
+    case_id: case_1677133
+    case_name: '[352]右键菜单-多选文件右键菜单检查'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+    - MulitSelectMenu
+- id: suite_音乐_界面操作_工具栏_001_s1
+  name: 排序-播放队列-使用shift多选歌曲拖拽排序，歌曲按照所选顺序排序
+  module: 音乐_界面操作_工具栏
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_drag
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: 排序-播放队列-使用shift多选歌曲拖拽排序，歌曲按照所选顺序排序
+    case_id: case_1677475
+    case_name: 排序-播放队列-使用shift多选歌曲拖拽排序，歌曲按照所选顺序排序
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+- id: suite_音乐_界面操作_工具栏_003_s1
+  name: 排序-播放队列-拖动歌曲至播放队列上滚动区域向上翻页功能
+  module: 音乐_界面操作_工具栏
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_scroll
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: 排序-播放队列-拖动歌曲至播放队列上滚动区域向上翻页功能
+    case_id: case_1677461
+    case_name: 排序-播放队列-拖动歌曲至播放队列上滚动区域向上翻页功能
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+- id: suite_音乐_界面操作_工具栏_005_s1
+  name: '[351][core]工具栏-歌词与切换歌曲交互'
+  module: 音乐_界面操作_工具栏
+  steps:
+  - action: mouse_click
+    selector:
+      name: LrcBtn
+      role: push button
+  - action: assert_element
+    selector:
+      name: LrcBtn
+      role: push button
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[351][core]工具栏-歌词与切换歌曲交互'
+    case_id: case_1677413
+    case_name: '[351][core]工具栏-歌词与切换歌曲交互'
+    AT元素引用:
+    - LrcBtn
+- id: suite_音乐_界面操作_工具栏_006_s1
+  name: '[032][core][acp1]工具栏-播放歌曲时从播放队列移除当前歌曲'
+  module: 音乐_界面操作_工具栏
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Delete
+  - action: assert_element
+    selector:
+      name: PlaylistMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[032][core][acp1]工具栏-播放歌曲时从播放队列移除当前歌曲'
+    case_id: case_1677389
+    case_name: '[032][core][acp1]工具栏-播放歌曲时从播放队列移除当前歌曲'
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_界面操作_工具栏_008_s1
+  name: '[238][core][acp1]工具栏-点击音量条静音按钮解除静'
+  module: 音乐_界面操作_工具栏
+  steps:
+  - action: mouse_click
+    selector:
+      name: VolumeBtn
+      role: push button
+  - action: mouse_click
+    selector:
+      name: ContentSlider
+      role: slider
+  - action: assert_element
+    selector:
+      name: ContentSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[238][core][acp1]工具栏-点击音量条静音按钮解除静'
+    case_id: case_1677369
+    case_name: '[238][core][acp1]工具栏-点击音量条静音按钮解除静'
+    AT元素引用:
+    - VolumeBtn
+    - ContentSlider
+- id: suite_音乐_界面操作_工具栏_009_s1
+  name: '[235][core][acp1]工具栏-拖拽放大音量条声'
+  module: 音乐_界面操作_工具栏
+  steps:
+  - action: mouse_click
+    selector:
+      name: VolumeBtn
+      role: push button
+  - action: element_set_value
+    selector:
+      name: ContentSlider
+      role: slider
+    value: '50'
+  - action: assert_element
+    selector:
+      name: ContentSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[235][core][acp1]工具栏-拖拽放大音量条声'
+    case_id: case_1677363
+    case_name: '[235][core][acp1]工具栏-拖拽放大音量条声'
+    AT元素引用:
+    - VolumeBtn
+    - ContentSlider
+- id: suite_音乐_界面操作_歌曲导入_001_s1
+  name: '[314][core][acp1]歌曲导入-自定义歌单页面拖拽添加音乐目录'
+  module: 音乐_界面操作_歌曲导入
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-歌曲导入
+    测试功能: '[314][core][acp1]歌曲导入-自定义歌单页面拖拽添加音乐目录'
+    case_id: case_1677709
+    case_name: '[314][core][acp1]歌曲导入-自定义歌单页面拖拽添加音乐目录'
+    AT元素引用:
+    - Add Songs
+    - PlaylistDelegate
+- id: suite_音乐_窗口_专辑_001_s1
+  name: '[186][smoke][acp1]专辑-详情页面返回按钮'
+  module: 音乐_窗口_专辑
+  steps:
+  - action: mouse_click
+    selector:
+      name: SublistDelegate
+      role: push button
+  - action: assert_element
+    selector:
+      name: Albums
+      role: push button
+  annotation:
+    测试界面: 音乐-专辑
+    测试功能: '[186][smoke][acp1]专辑-详情页面返回按钮'
+    case_id: case_1677873
+    case_name: '[186][smoke][acp1]专辑-详情页面返回按钮'
+    AT元素引用:
+    - SublistDelegate
+    - Albums
+- id: suite_音乐_窗口_我的收藏_001_s1
+  name: 排序-我的收藏-列表模式使用shift从文管多选歌曲拖拽排序，歌曲按照所选顺序排序
+  module: 音乐_窗口_我的收藏
+  steps:
+  - action: mouse_click
+    selector:
+      name: SidebarItem
+      role: list item
+  - action: mouse_drag
+    selector:
+      name: ItemD
+      role: list item
+  - action: assert_element
+    selector:
+      name: SidebarItem
+      role: list item
+  annotation:
+    测试界面: 音乐-我的收藏
+    测试功能: 排序-我的收藏-列表模式使用shift从文管多选歌曲拖拽排序，歌曲按照所选顺序排序
+    case_id: case_1678497
+    case_name: 排序-我的收藏-列表模式使用shift从文管多选歌曲拖拽排序，歌曲按照所选顺序排序
+    AT元素引用:
+    - SidebarItem
+    - ItemD
+- id: suite_音乐_窗口_我的收藏_002_s1
+  name: '[329][smoke]排序-我的收藏-列表模式下拖拽多首歌排序'
+  module: 音乐_窗口_我的收藏
+  steps:
+  - action: mouse_right_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: ItemD
+    items:
+    - Add to
+    - My favorites
+  - action: assert_element
+    selector:
+      name: ImportMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-我的收藏
+    测试功能: '[329][smoke]排序-我的收藏-列表模式下拖拽多首歌排序'
+    case_id: case_1678367
+    case_name: '[329][smoke]排序-我的收藏-列表模式下拖拽多首歌排序'
+    AT元素引用:
+    - ItemD
+    - ImportMenu
+    - My favorites
+- id: suite_音乐_窗口_我的收藏_003_s1
+  name: '[095]我的收藏-删除所有歌曲'
+  module: 音乐_窗口_我的收藏
+  steps:
+  - action: mouse_click
+    selector:
+      name: SidebarItem
+      role: list item
+  - action: keyboard_hot_key
+    key: ctrl+a
+  - action: keyboard_press
+    key: Delete
+  - action: assert_element
+    selector:
+      name: SidebarItem
+      role: list item
+  annotation:
+    测试界面: 音乐-我的收藏
+    测试功能: '[095]我的收藏-删除所有歌曲'
+    case_id: case_1678285
+    case_name: '[095]我的收藏-删除所有歌曲'
+    AT元素引用:
+    - SidebarItem
+- id: suite_音乐_窗口_我的歌单_001_s1
+  name: 新建歌单时，输入html标签能正常显示
+  module: 音乐_窗口_我的歌单
+  steps:
+  - action: mouse_click
+    selector:
+      name: Empty
+      role: push button
+  - action: keyboard_type
+    text: test
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: 新建歌单时，输入html标签能正常显示
+    case_id: case_1678697
+    case_name: 新建歌单时，输入html标签能正常显示
+    AT元素引用:
+    - Empty
+    - PlaylistDelegate
+- id: suite_音乐_窗口_我的歌单_002_s1
+  name: 排序-我的歌单-拖拽歌单至音乐库列表
+  module: 音乐_窗口_我的歌单
+  steps:
+  - action: mouse_click
+    selector:
+      name: Empty
+      role: push button
+  - action: mouse_drag
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: 排序-我的歌单-拖拽歌单至音乐库列表
+    case_id: case_1678653
+    case_name: 排序-我的歌单-拖拽歌单至音乐库列表
+    AT元素引用:
+    - Empty
+    - PlaylistDelegate
+- id: suite_音乐_窗口_我的歌单_004_s1
+  name: '[207][smoke][acp1]我的歌单-播放所有按钮播放'
+  module: 音乐_窗口_我的歌单
+  steps:
+  - action: mouse_click
+    selector:
+      name: SidebarItem
+      role: list item
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: '[207][smoke][acp1]我的歌单-播放所有按钮播放'
+    case_id: case_1678563
+    case_name: '[207][smoke][acp1]我的歌单-播放所有按钮播放'
+    AT元素引用:
+    - SidebarItem
+    - Play All
+    - PlaylistDelegate
+- id: suite_音乐_窗口_我的歌单_006_s1
+  name: '[205][smoke][acp1]我的歌单-新建按钮增加歌单'
+  module: 音乐_窗口_我的歌单
+  steps:
+  - action: mouse_click
+    selector:
+      name: Empty
+      role: push button
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: '[205][smoke][acp1]我的歌单-新建按钮增加歌单'
+    case_id: case_1678541
+    case_name: '[205][smoke][acp1]我的歌单-新建按钮增加歌单'
+    AT元素引用:
+    - Empty
+    - PlaylistDelegate
+- id: suite_音乐_窗口_所有音乐_001_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从本地删除歌曲，播放队列同步减少歌曲
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: ItemD
+    items:
+    - Delete from local disk
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从本地删除歌曲，播放队列同步减少歌曲
+    case_id: case_1678763
+    case_name: 播放队列同步-所有音乐-播放歌曲时从本地删除歌曲，播放队列同步减少歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ItemD
+    - MoreMenu_2
+- id: suite_音乐_窗口_所有音乐_003_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从文管拖拽歌曲增加歌曲，播放队列同步增加歌曲
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从文管拖拽歌曲增加歌曲，播放队列同步增加歌曲
+    case_id: case_1678759
+    case_name: 播放队列同步-所有音乐-播放歌曲时从文管拖拽歌曲增加歌曲，播放队列同步增加歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ListBtn
+    - PlaylistDelegate
+- id: suite_音乐_窗口_所有音乐_004_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从主菜单添加选项增加歌曲，播放队列同步增加歌曲
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Add music
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test2.mp3
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从主菜单添加选项增加歌曲，播放队列同步增加歌曲
+    case_id: case_1678757
+    case_name: 播放队列同步-所有音乐-播放歌曲时从主菜单添加选项增加歌曲，播放队列同步增加歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - WindowTitlebar_Menu
+    - Add music
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_005_s1
+  name: '[322][core]播放队列同步-所有音乐-播放歌曲时从标题栏添加按钮增加歌曲，播放队列同步增加歌曲'
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test2.mp3
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[322][core]播放队列同步-所有音乐-播放歌曲时从标题栏添加按钮增加歌曲，播放队列同步增加歌曲'
+    case_id: case_1678755
+    case_name: '[322][core]播放队列同步-所有音乐-播放歌曲时从标题栏添加按钮增加歌曲，播放队列同步增加歌曲'
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_006_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从歌单右键菜单增加歌曲，播放队列同步增加歌曲
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Add songs
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test2.mp3
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从歌单右键菜单增加歌曲，播放队列同步增加歌曲
+    case_id: case_1678753
+    case_name: 播放队列同步-所有音乐-播放歌曲时从歌单右键菜单增加歌曲，播放队列同步增加歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_窗口_所有音乐_007_s1
+  name: '[191][smoke][acp1]所有音乐-歌曲数量展示情况'
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: assert_element
+    selector:
+      name: listTitle
+      role: push button
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[191][smoke][acp1]所有音乐-歌曲数量展示情况'
+    case_id: case_1678733
+    case_name: '[191][smoke][acp1]所有音乐-歌曲数量展示情况'
+    AT元素引用:
+    - Add Songs
+    - listTitle
+- id: suite_音乐_窗口_所有音乐_008_s1
+  name: '[374]所有音乐-翻页查看所有歌曲'
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_scroll
+    selector:
+      name: ItemD
+      role: list item
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[374]所有音乐-翻页查看所有歌曲'
+    case_id: case_1678731
+    case_name: '[374]所有音乐-翻页查看所有歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_009_s1
+  name: '[192][core][acp1]所有音乐-删除所有歌曲'
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: keyboard_hot_key
+    key: ctrl+a
+  - action: keyboard_press
+    key: Delete
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[192][core][acp1]所有音乐-删除所有歌曲'
+    case_id: case_1678727
+    case_name: '[192][core][acp1]所有音乐-删除所有歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_010_s1
+  name: 所有音乐-歌曲名称反向排序
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: SortBtn
+      role: push button
+  - action: dtk_context_menu
+    selector:
+      name: SortBtn
+    items:
+    - title
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 所有音乐-歌曲名称反向排序
+    case_id: case_1678717
+    case_name: 所有音乐-歌曲名称反向排序
+    AT元素引用:
+    - SortBtn
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_012_s1
+  name: '[373]所有音乐-Enter键播放歌曲'
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: keyboard_press
+    key: Enter
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[373]所有音乐-Enter键播放歌曲'
+    case_id: case_1678703
+    case_name: '[373]所有音乐-Enter键播放歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+    - PlaylistDelegate
+- id: suite_音乐_窗口_所有音乐_013_s1
+  name: '[190][core][acp1]所有音乐-平铺视图下双击播放歌曲'
+  module: 音乐_窗口_所有音乐
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: ItemD
+      role: list item
+    do: dblclick
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[190][core][acp1]所有音乐-平铺视图下双击播放歌曲'
+    case_id: case_1678701
+    case_name: '[190][core][acp1]所有音乐-平铺视图下双击播放歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+    - PlaylistDelegate
+- id: suite_音乐_窗口_搜索_001_s1
+  name: '[372]搜索结果-清除搜索关键词'
+  module: 音乐_窗口_搜索
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: keyboard_press
+    key: Enter
+  - action: keyboard_press
+    key: Escape
+  - action: assert_element
+    selector:
+      name: TabArea
+      role: page tab list
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: '[372]搜索结果-清除搜索关键词'
+    case_id: case_1678819
+    case_name: '[372]搜索结果-清除搜索关键词'
+    AT元素引用:
+    - TabArea
+- id: suite_音乐_窗口_搜索_002_s1
+  name: '[150]搜索结果-歌曲页面播放所有'
+  module: 音乐_窗口_搜索
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: keyboard_press
+    key: Enter
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: '[150]搜索结果-歌曲页面播放所有'
+    case_id: case_1678815
+    case_name: '[150]搜索结果-歌曲页面播放所有'
+    AT元素引用:
+    - Play All
+    - PlaylistDelegate
+- id: suite_音乐_窗口_搜索_003_s1
+  name: '[219][smoke][acp1]搜索结果-歌曲页面展示'
+  module: 音乐_窗口_搜索
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: keyboard_press
+    key: Enter
+  - action: assert_element
+    selector:
+      name: Play All
+      role: push button
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: '[219][smoke][acp1]搜索结果-歌曲页面展示'
+    case_id: case_1678781
+    case_name: '[219][smoke][acp1]搜索结果-歌曲页面展示'
+    AT元素引用:
+    - Play All
+- id: suite_音乐_窗口_搜索_004_s1
+  name: 搜索-搜索列表结果长度限制
+  module: 音乐_窗口_搜索
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: assert_element
+    selector:
+      name: ItemDelegate_2
+      role: list item
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: 搜索-搜索列表结果长度限制
+    case_id: case_1678775
+    case_name: 搜索-搜索列表结果长度限制
+    AT元素引用:
+    - ItemDelegate_2
+- id: suite_音乐_窗口_搜索_005_s1
+  name: 搜索-撤销搜索内容
+  module: 音乐_窗口_搜索
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: mouse_right_click
+    selector:
+      name: ItemDelegate_2
+      role: list item
+  - action: assert_element
+    selector:
+      name: ItemDelegate_2
+      role: list item
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: 搜索-撤销搜索内容
+    case_id: case_1678773
+    case_name: 搜索-撤销搜索内容
+    AT元素引用:
+    - ItemDelegate_2
+- id: suite_音乐_窗口_演唱者_001_s1
+  name: '[124]演唱者-暂停时删除当前演唱者的所有歌曲'
+  module: 音乐_窗口_演唱者
+  steps:
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: keyboard_hot_key
+    key: ctrl+a
+  - action: keyboard_press
+    key: Delete
+  - action: assert_element
+    selector:
+      name: MusicSingerGridItem_2
+      role: list item
+  annotation:
+    测试界面: 音乐-演唱者
+    测试功能: '[124]演唱者-暂停时删除当前演唱者的所有歌曲'
+    case_id: case_1678093
+    case_name: '[124]演唱者-暂停时删除当前演唱者的所有歌曲'
+    AT元素引用:
+    - Play All
+    - MusicSingerGridItem_2
+- id: suite_音乐_窗口_演唱者_002_s1
+  name: 演唱者-演唱者名称排序
+  module: 音乐_窗口_演唱者
+  steps:
+  - action: mouse_click
+    selector:
+      name: SortBtn
+      role: push button
+  - action: dtk_context_menu
+    selector:
+      name: SortBtn
+    items:
+    - title
+  - action: assert_element
+    selector:
+      name: MusicSingerGridItem_2
+      role: list item
+  annotation:
+    测试界面: 音乐-演唱者
+    测试功能: 演唱者-演唱者名称排序
+    case_id: case_1678065
+    case_name: 演唱者-演唱者名称排序
+    AT元素引用:
+    - SortBtn
+    - MusicSingerGridItem_2
+- id: suite_音乐_窗口_演唱者_003_s1
+  name: '[180][smoke][acp1]演唱者-详情页面返回按钮'
+  module: 音乐_窗口_演唱者
+  steps:
+  - action: mouse_click
+    selector:
+      name: SublistDelegate
+      role: push button
+  - action: assert_element
+    selector:
+      name: Artists
+      role: push button
+  annotation:
+    测试界面: 音乐-演唱者
+    测试功能: '[180][smoke][acp1]演唱者-详情页面返回按钮'
+    case_id: case_1678051
+    case_name: '[180][smoke][acp1]演唱者-详情页面返回按钮'
+    AT元素引用:
+    - SublistDelegate
+    - Artists
+- id: suite_音乐_适配_键盘交互_001_s1
+  name: 快捷键-下一首Ctrl+Right
+  module: 音乐_适配_键盘交互
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+right
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: 快捷键-下一首Ctrl+Right
+    case_id: case_1676927
+    case_name: 快捷键-下一首Ctrl+Right
+    AT元素引用:
+    - ItemD
+- id: suite_音乐_适配_键盘交互_006_s1
+  name: '[163]快捷键-重命名歌单F2'
+  module: 音乐_适配_键盘交互
+  steps:
+  - action: keyboard_press
+    key: F2
+  - action: assert_element
+    selector:
+      name: SidebarItem
+      role: list item
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: '[163]快捷键-重命名歌单F2'
+    case_id: case_1676917
+    case_name: '[163]快捷键-重命名歌单F2'
+    AT元素引用:
+    - SidebarItem
+- id: suite_音乐_音乐格式_003_s1
+  name: '[318][core][acp1]格式支持-ac3'
+  module: 音乐_音乐格式
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.ac3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-音乐格式
+    测试功能: '[318][core][acp1]格式支持-ac3'
+    case_id: case_1676601
+    case_name: '[318][core][acp1]格式支持-ac3'
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ItemD
+- id: suite_音乐_003
+  name: 【玲珑】【音乐】卸载指定版本的玲珑应用
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】卸载指定版本的玲珑应用
+    case_id: case_1798249
+    case_name: 【玲珑】【音乐】卸载指定版本的玲珑应用
+    AT元素引用: []
+- id: suite_音乐_004
+  name: 【玲珑】【音乐】卸载玲珑应用
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】卸载玲珑应用
+    case_id: case_1798247
+    case_name: 【玲珑】【音乐】卸载玲珑应用
+    AT元素引用: []
+- id: suite_音乐_005
+  name: 【玲珑】【音乐】杀掉玲珑应用运行进程
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】杀掉玲珑应用运行进程
+    case_id: case_1798243
+    case_name: 【玲珑】【音乐】杀掉玲珑应用运行进程
+    AT元素引用: []
+- id: suite_音乐_006
+  name: 【玲珑】【音乐】检查玲珑应用运行情况
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】检查玲珑应用运行情况
+    case_id: case_1798241
+    case_name: 【玲珑】【音乐】检查玲珑应用运行情况
+    AT元素引用: []
+- id: suite_音乐_007
+  name: 【玲珑】【音乐】进入容器内部
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】进入容器内部
+    case_id: case_1798239
+    case_name: 【玲珑】【音乐】进入容器内部
+    AT元素引用: []
+- id: suite_音乐_008
+  name: 【玲珑】【音乐】更新玲珑应用指定版本
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】更新玲珑应用指定版本
+    case_id: case_1798237
+    case_name: 【玲珑】【音乐】更新玲珑应用指定版本
+    AT元素引用: []
+- id: suite_音乐_009
+  name: 【玲珑】【音乐】更新玲珑应用
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】更新玲珑应用
+    case_id: case_1798235
+    case_name: 【玲珑】【音乐】更新玲珑应用
+    AT元素引用: []
+- id: suite_音乐_010
+  name: 【玲珑】【音乐】音乐基本功能验证
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】音乐基本功能验证
+    case_id: case_1798233
+    case_name: 【玲珑】【音乐】音乐基本功能验证
+    AT元素引用: []
+- id: suite_音乐_011
+  name: 【玲珑】【音乐】运行玲珑应用
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】运行玲珑应用
+    case_id: case_1798229
+    case_name: 【玲珑】【音乐】运行玲珑应用
+    AT元素引用: []
+- id: suite_音乐_012
+  name: 【玲珑】【音乐】安装玲珑应用
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】安装玲珑应用
+    case_id: case_1798225
+    case_name: 【玲珑】【音乐】安装玲珑应用
+    AT元素引用: []
+- id: suite_音乐_013
+  name: 【玲珑】【音乐】仓库玲珑应用信息
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】仓库玲珑应用信息
+    case_id: case_1798223
+    case_name: 【玲珑】【音乐】仓库玲珑应用信息
+    AT元素引用: []
+- id: suite_音乐_014
+  name: 【玲珑】【音乐】查看玲珑应用信息
+  module: 音乐
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 【玲珑】【音乐】查看玲珑应用信息
+    case_id: case_1798221
+    case_name: 【玲珑】【音乐】查看玲珑应用信息
+    AT元素引用: []
+- id: suite_音乐_ai自然语言支持_001
+  name: 【入口】通过UOS AI能够成功打开音乐
+  module: 音乐_ai自然语言支持
+  status: unsupported
+  reason: 依赖UOS AI外部应用，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-ai自然语言支持
+    测试功能: 【入口】通过UOS AI能够成功打开音乐
+    case_id: case_1678991
+    case_name: 【入口】通过UOS AI能够成功打开音乐
+    AT元素引用: []
+- id: suite_音乐_ai自然语言支持_002
+  name: 【UOS AI调起音乐】验证本地存在适配文件，录入完整的歌手名通过UOS AI能打开音乐并播放歌曲
+  module: 音乐_ai自然语言支持
+  status: unsupported
+  reason: 依赖UOS AI外部应用，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-ai自然语言支持
+    测试功能: 【UOS AI调起音乐】验证本地存在适配文件，录入完整的歌手名通过UOS AI能打开音乐并播放歌曲
+    case_id: case_1678983
+    case_name: 【UOS AI调起音乐】验证本地存在适配文件，录入完整的歌手名通过UOS AI能打开音乐并播放歌曲
+    AT元素引用: []
+- id: suite_音乐_ai自然语言支持_003
+  name: 【UOS AI控制音乐】验证通过UOS AI录入“暂停”控制音乐中歌曲的暂停操作
+  module: 音乐_ai自然语言支持
+  status: unsupported
+  reason: 依赖UOS AI外部应用，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-ai自然语言支持
+    测试功能: 【UOS AI控制音乐】验证通过UOS AI录入“暂停”控制音乐中歌曲的暂停操作
+    case_id: case_1678955
+    case_name: 【UOS AI控制音乐】验证通过UOS AI录入“暂停”控制音乐中歌曲的暂停操作
+    AT元素引用: []
+- id: suite_音乐_ai自然语言支持_004
+  name: 【UOS AI控制音乐】验证播放列表存在上一首歌曲，通过UOS AI录入“上一首”控制音乐中歌曲的播放
+  module: 音乐_ai自然语言支持
+  status: unsupported
+  reason: 依赖UOS AI外部应用，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-ai自然语言支持
+    测试功能: 【UOS AI控制音乐】验证播放列表存在上一首歌曲，通过UOS AI录入“上一首”控制音乐中歌曲的播放
+    case_id: case_1678953
+    case_name: 【UOS AI控制音乐】验证播放列表存在上一首歌曲，通过UOS AI录入“上一首”控制音乐中歌曲的播放
+    AT元素引用: []
+- id: suite_音乐_ai自然语言支持_005
+  name: 【UOS AI控制音乐】验证播放列表存在下一首歌曲，通过UOS AI录入“下一首”控制音乐中歌曲的播放
+  module: 音乐_ai自然语言支持
+  status: unsupported
+  reason: 依赖UOS AI外部应用，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-ai自然语言支持
+    测试功能: 【UOS AI控制音乐】验证播放列表存在下一首歌曲，通过UOS AI录入“下一首”控制音乐中歌曲的播放
+    case_id: case_1678949
+    case_name: 【UOS AI控制音乐】验证播放列表存在下一首歌曲，通过UOS AI录入“下一首”控制音乐中歌曲的播放
+    AT元素引用: []
+- id: suite_音乐_ai自然语言支持_006
+  name: 【UOS AI控制音乐】验证通过UOS AI录入“随机播放”设置歌曲的播放模式
+  module: 音乐_ai自然语言支持
+  status: unsupported
+  reason: 依赖UOS AI外部应用，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-ai自然语言支持
+    测试功能: 【UOS AI控制音乐】验证通过UOS AI录入“随机播放”设置歌曲的播放模式
+    case_id: case_1678937
+    case_name: 【UOS AI控制音乐】验证通过UOS AI录入“随机播放”设置歌曲的播放模式
+    AT元素引用: []
+- id: suite_音乐_bug转用例_001
+  name: 【bug转用例】双击U盘中的音乐文件冷启动音乐播放器
+  module: 音乐_bug转用例
+  status: unsupported
+  reason: 性能基准测试，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-bug转用例
+    测试功能: 【bug转用例】双击U盘中的音乐文件冷启动音乐播放器
+    case_id: case_1678917
+    case_name: 【bug转用例】双击U盘中的音乐文件冷启动音乐播放器
+    AT元素引用: []
+- id: suite_音乐_商业定制_中孚定制xwininfo_001
+  name: 中孚-检查音乐xwininfo展示路径情况
+  module: 音乐_商业定制_中孚定制xwininfo
+  status: unsupported
+  reason: 需要外部硬件设备(USB/CD)，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-中孚定制xwininfo
+    测试功能: 中孚-检查音乐xwininfo展示路径情况
+    case_id: case_1677045
+    case_name: 中孚-检查音乐xwininfo展示路径情况
+    AT元素引用: []
+- id: suite_音乐_四性_安全_001
+  name: 【音乐安全性】播放音乐静置场景内存泄漏监测
+  module: 音乐_四性_安全
+  status: unsupported
+  reason: 内存泄漏监测，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-安全
+    测试功能: 【音乐安全性】播放音乐静置场景内存泄漏监测
+    case_id: case_1919815
+    case_name: 【音乐安全性】播放音乐静置场景内存泄漏监测
+    AT元素引用: []
+- id: suite_音乐_四性_性能_001
+  name: 性能-音乐热启动
+  module: 音乐_四性_性能
+  status: unsupported
+  reason: 性能基准测试，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-性能
+    测试功能: 性能-音乐热启动
+    case_id: case_1676823
+    case_name: 性能-音乐热启动
+    AT元素引用: []
+- id: suite_音乐_四性_性能_002
+  name: 性能-音乐冷启动
+  module: 音乐_四性_性能
+  status: unsupported
+  reason: 性能基准测试，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-性能
+    测试功能: 性能-音乐冷启动
+    case_id: case_1676821
+    case_name: 性能-音乐冷启动
+    AT元素引用: []
+- id: suite_音乐_四性_性能_003
+  name: 性能-循环播放音乐12h
+  module: 音乐_四性_性能
+  status: unsupported
+  reason: 性能基准测试，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-性能
+    测试功能: 性能-循环播放音乐12h
+    case_id: case_1676817
+    case_name: 性能-循环播放音乐12h
+    AT元素引用: []
+- id: suite_音乐_外部交互_系统事件响应机制_001
+  name: '[core]锁屏-播放歌曲时待机后唤醒'
+  module: 音乐_外部交互_系统事件响应机制
+  status: unsupported
+  reason: 需要锁屏/待机/休眠等系统级操作，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-系统事件响应机制
+    测试功能: '[core]锁屏-播放歌曲时待机后唤醒'
+    case_id: case_1676617
+    case_name: '[core]锁屏-播放歌曲时待机后唤醒'
+    AT元素引用: []
+- id: suite_音乐_外部交互_系统事件响应机制_002
+  name: '[core]锁屏-播放歌曲时休眠后唤醒'
+  module: 音乐_外部交互_系统事件响应机制
+  status: unsupported
+  reason: 需要锁屏/待机/休眠等系统级操作，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-系统事件响应机制
+    测试功能: '[core]锁屏-播放歌曲时休眠后唤醒'
+    case_id: case_1676615
+    case_name: '[core]锁屏-播放歌曲时休眠后唤醒'
+    AT元素引用: []
+- id: suite_音乐_外部交互_锁屏界面_001
+  name: '[core]锁屏-切换上一首歌曲'
+  module: 音乐_外部交互_锁屏界面
+  status: unsupported
+  reason: 需要锁屏/待机/休眠等系统级操作，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-锁屏界面
+    测试功能: '[core]锁屏-切换上一首歌曲'
+    case_id: case_1676629
+    case_name: '[core]锁屏-切换上一首歌曲'
+    AT元素引用: []
+- id: suite_音乐_外部交互_锁屏界面_002
+  name: 锁屏-音乐控件检查
+  module: 音乐_外部交互_锁屏界面
+  status: unsupported
+  reason: 需要锁屏/待机/休眠等系统级操作，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-锁屏界面
+    测试功能: 锁屏-音乐控件检查
+    case_id: case_1676619
+    case_name: 锁屏-音乐控件检查
+    AT元素引用: []
+- id: suite_音乐_安装_卸载_001
+  name: 卸载-启动器卸载
+  module: 音乐_安装_卸载
+  status: unsupported
+  reason: 需要系统安装/卸载操作，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-卸载
+    测试功能: 卸载-启动器卸载
+    case_id: case_1678913
+    case_name: 卸载-启动器卸载
+    AT元素引用: []
+- id: suite_音乐_安装_卸载_002
+  name: 卸载-终端命令卸载
+  module: 音乐_安装_卸载
+  status: unsupported
+  reason: 需要系统安装/卸载操作，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-卸载
+    测试功能: 卸载-终端命令卸载
+    case_id: case_1678911
+    case_name: 卸载-终端命令卸载
+    AT元素引用: []
+- id: suite_音乐_打开_关闭_001
+  name: 【玲珑】【音乐】查看玲珑应用包含的文件
+  module: 音乐_打开_关闭
+  status: unsupported
+  reason: 需要linglong容器环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-关闭
+    测试功能: 【玲珑】【音乐】查看玲珑应用包含的文件
+    case_id: case_1798245
+    case_name: 【玲珑】【音乐】查看玲珑应用包含的文件
+    AT元素引用: []
+- id: suite_音乐_打开_关闭_003
+  name: 打开-应用商店启动
+  module: 音乐_打开_关闭
+  status: unsupported
+  reason: 需要应用商店环境，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-关闭
+    测试功能: 打开-应用商店启动
+    case_id: case_1677781
+    case_name: 打开-应用商店启动
+    AT元素引用: []
+- id: suite_音乐_用户场景_002
+  name: '[acp2][音乐]检查外设输出音频功能'
+  module: 音乐_用户场景
+  status: unsupported
+  reason: 需要外部音频设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-用户场景
+    测试功能: '[acp2][音乐]检查外设输出音频功能'
+    case_id: case_1676593
+    case_name: '[acp2][音乐]检查外设输出音频功能'
+    AT元素引用: []
+- id: suite_音乐_界面操作_工具栏_011
+  name: '[231][core][acp1]工具栏-切换列表播放'
+  module: 音乐_界面操作_工具栏
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[231][core][acp1]工具栏-切换列表播放'
+    case_id: case_1677355
+    case_name: '[231][core][acp1]工具栏-切换列表播放'
+    AT元素引用: []
+- id: suite_音乐_界面操作_工具栏_015
+  name: '[026][smoke][acp1]工具栏-收藏按钮收藏歌曲'
+  module: 音乐_界面操作_工具栏
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[026][smoke][acp1]工具栏-收藏按钮收藏歌曲'
+    case_id: case_1677339
+    case_name: '[026][smoke][acp1]工具栏-收藏按钮收藏歌曲'
+    AT元素引用: []
+- id: suite_音乐_界面操作_工具栏_016
+  name: 工具栏-播放歌曲时点击快进歌曲进度条
+  module: 音乐_界面操作_工具栏
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: 工具栏-播放歌曲时点击快进歌曲进度条
+    case_id: case_1677323
+    case_name: 工具栏-播放歌曲时点击快进歌曲进度条
+    AT元素引用: []
+- id: suite_音乐_界面操作_工具栏_017
+  name: '[smoke]工具栏-进度条状态检查'
+  module: 音乐_界面操作_工具栏
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[smoke]工具栏-进度条状态检查'
+    case_id: case_1677321
+    case_name: '[smoke]工具栏-进度条状态检查'
+    AT元素引用: []
+- id: suite_音乐_界面操作_工具栏_018
+  name: '[229][smoke][acp1]工具栏-播放音乐时点击上一首按钮'
+  module: 音乐_界面操作_工具栏
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[229][smoke][acp1]工具栏-播放音乐时点击上一首按钮'
+    case_id: case_1677309
+    case_name: '[229][smoke][acp1]工具栏-播放音乐时点击上一首按钮'
+    AT元素引用: []
+- id: suite_音乐_界面操作_歌曲导入_008
+  name: '[004][smoke][acp1]歌曲导入-初始界面添加歌曲路径'
+  module: 音乐_界面操作_歌曲导入
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-歌曲导入
+    测试功能: '[004][smoke][acp1]歌曲导入-初始界面添加歌曲路径'
+    case_id: case_1677617
+    case_name: '[004][smoke][acp1]歌曲导入-初始界面添加歌曲路径'
+    AT元素引用: []
+- id: suite_音乐_窗口_001
+  name: '[020][core][acp1]窗口-歌曲信息详情检查'
+  module: 音乐_窗口
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-窗口
+    测试功能: '[020][core][acp1]窗口-歌曲信息详情检查'
+    case_id: case_1678889
+    case_name: '[020][core][acp1]窗口-歌曲信息详情检查'
+    AT元素引用: []
+- id: suite_音乐_窗口_002
+  name: 窗口-移动歌曲信息弹窗
+  module: 音乐_窗口
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-窗口
+    测试功能: 窗口-移动歌曲信息弹窗
+    case_id: case_1678883
+    case_name: 窗口-移动歌曲信息弹窗
+    AT元素引用: []
+- id: suite_音乐_窗口_003
+  name: '[285][core][acp1]窗口-关闭歌曲信息弹窗'
+  module: 音乐_窗口
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-窗口
+    测试功能: '[285][core][acp1]窗口-关闭歌曲信息弹窗'
+    case_id: case_1678881
+    case_name: '[285][core][acp1]窗口-关闭歌曲信息弹窗'
+    AT元素引用: []
+- id: suite_音乐_窗口_004
+  name: '[371]窗口-初始界面主菜单检查'
+  module: 音乐_窗口
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-窗口
+    测试功能: '[371]窗口-初始界面主菜单检查'
+    case_id: case_1678879
+    case_name: '[371]窗口-初始界面主菜单检查'
+    AT元素引用: []
+- id: suite_音乐_适配_001
+  name: 埋点-音乐埋点检查
+  module: 音乐_适配
+  status: unsupported
+  reason: 埋点数据检查，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-适配
+    测试功能: 埋点-音乐埋点检查
+    case_id: case_1677043
+    case_name: 埋点-音乐埋点检查
+    AT元素引用: []
+- id: suite_音乐_适配_002
+  name: 适配-1.25缩放比下音乐界面UI检查
+  module: 音乐_适配
+  status: unsupported
+  reason: 缩放比UI检查，需要人工目视验证
+  steps: []
+  annotation:
+    测试界面: 音乐-适配
+    测试功能: 适配-1.25缩放比下音乐界面UI检查
+    case_id: case_1677041
+    case_name: 适配-1.25缩放比下音乐界面UI检查
+    AT元素引用: []
+- id: suite_音乐_适配_003
+  name: 可靠性-连续12H播放音乐
+  module: 音乐_适配
+  status: unsupported
+  reason: 长时间可靠性测试，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-适配
+    测试功能: 可靠性-连续12H播放音乐
+    case_id: case_1676991
+    case_name: 可靠性-连续12H播放音乐
+    AT元素引用: []
+- id: suite_音乐_适配_004
+  name: '[core]适配-断开外设音频输出暂停播放'
+  module: 音乐_适配
+  status: unsupported
+  reason: 需要外部音频设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-适配
+    测试功能: '[core]适配-断开外设音频输出暂停播放'
+    case_id: case_1676985
+    case_name: '[core]适配-断开外设音频输出暂停播放'
+    AT元素引用: []
+- id: suite_音乐_适配_触摸屏_001
+  name: 触摸屏-dock栏音乐插件
+  module: 音乐_适配_触摸屏
+  status: unsupported
+  reason: 需要触摸屏/触摸板硬件设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-触摸屏
+    测试功能: 触摸屏-dock栏音乐插件
+    case_id: case_1676951
+    case_name: 触摸屏-dock栏音乐插件
+    AT元素引用: []
+- id: suite_音乐_适配_触摸屏_002
+  name: 触摸屏-音量调节
+  module: 音乐_适配_触摸屏
+  status: unsupported
+  reason: 需要触摸屏/触摸板硬件设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-触摸屏
+    测试功能: 触摸屏-音量调节
+    case_id: case_1676939
+    case_name: 触摸屏-音量调节
+    AT元素引用: []
+- id: suite_音乐_适配_触摸屏_003
+  name: 触摸屏-歌词界面与进度条交互
+  module: 音乐_适配_触摸屏
+  status: unsupported
+  reason: 需要触摸屏/触摸板硬件设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-触摸屏
+    测试功能: 触摸屏-歌词界面与进度条交互
+    case_id: case_1676937
+    case_name: 触摸屏-歌词界面与进度条交互
+    AT元素引用: []
+- id: suite_音乐_适配_触摸屏_004
+  name: 触摸屏-拖拽添加音乐文件
+  module: 音乐_适配_触摸屏
+  status: unsupported
+  reason: 需要触摸屏/触摸板硬件设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-触摸屏
+    测试功能: 触摸屏-拖拽添加音乐文件
+    case_id: case_1676931
+    case_name: 触摸屏-拖拽添加音乐文件
+    AT元素引用: []
+- id: suite_音乐_适配_触摸板_001
+  name: 触摸板-播放队列
+  module: 音乐_适配_触摸板
+  status: unsupported
+  reason: 需要触摸屏/触摸板硬件设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-触摸板
+    测试功能: 触摸板-播放队列
+    case_id: case_1676971
+    case_name: 触摸板-播放队列
+    AT元素引用: []
+- id: suite_音乐_适配_触摸板_002
+  name: 触摸板—歌词控件检查
+  module: 音乐_适配_触摸板
+  status: unsupported
+  reason: 需要触摸屏/触摸板硬件设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-触摸板
+    测试功能: 触摸板—歌词控件检查
+    case_id: case_1676965
+    case_name: 触摸板—歌词控件检查
+    AT元素引用: []
+- id: suite_音乐_适配_触摸板_003
+  name: 触摸板—一指拖拽添加音乐文件
+  module: 音乐_适配_触摸板
+  status: unsupported
+  reason: 需要触摸屏/触摸板硬件设备，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-触摸板
+    测试功能: 触摸板—一指拖拽添加音乐文件
+    case_id: case_1676961
+    case_name: 触摸板—一指拖拽添加音乐文件
+    AT元素引用: []
+- id: suite_音乐_适配_键盘交互_005
+  name: '[164]快捷键-删除歌曲/歌单Delet'
+  module: 音乐_适配_键盘交互
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: '[164]快捷键-删除歌曲/歌单Delet'
+    case_id: case_1676919
+    case_name: '[164]快捷键-删除歌曲/歌单Delet'
+    AT元素引用: []
+- id: suite_音乐_适配_键盘交互_007
+  name: '[162]快捷键-新建歌单Ctrl+Shift+'
+  module: 音乐_适配_键盘交互
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: '[162]快捷键-新建歌单Ctrl+Shift+'
+    case_id: case_1676915
+    case_name: '[162]快捷键-新建歌单Ctrl+Shift+'
+    AT元素引用: []
+- id: suite_音乐_适配_键盘交互_010
+  name: '[158]捷键-音量减小Ctrl+Alt+Dow'
+  module: 音乐_适配_键盘交互
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: '[158]捷键-音量减小Ctrl+Alt+Dow'
+    case_id: case_1676909
+    case_name: '[158]捷键-音量减小Ctrl+Alt+Dow'
+    AT元素引用: []
+- id: suite_音乐_适配_键盘交互_012
+  name: '[156]快捷键-播放/暂停Spac'
+  module: 音乐_适配_键盘交互
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: '[156]快捷键-播放/暂停Spac'
+    case_id: case_1676905
+    case_name: '[156]快捷键-播放/暂停Spac'
+    AT元素引用: []
+- id: suite_音乐_音乐动效_001
+  name: 详情图/列表模式切换
+  module: 音乐_音乐动效
+  status: unsupported
+  reason: 动画效果验证，需要人工目视确认，无法通过AT-SPI断言
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐动效
+    测试功能: 详情图/列表模式切换
+    case_id: case_1695449
+    case_name: 详情图/列表模式切换
+    AT元素引用: []
+- id: suite_音乐_音乐动效_002
+  name: 专辑/艺人打开二级页面
+  module: 音乐_音乐动效
+  status: unsupported
+  reason: 动画效果验证，需要人工目视确认，无法通过AT-SPI断言
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐动效
+    测试功能: 专辑/艺人打开二级页面
+    case_id: case_1695447
+    case_name: 专辑/艺人打开二级页面
+    AT元素引用: []
+- id: suite_音乐_音乐动效_003
+  name: 专辑详情页鼠标移出
+  module: 音乐_音乐动效
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐动效
+    测试功能: 专辑详情页鼠标移出
+    case_id: case_1695445
+    case_name: 专辑详情页鼠标移出
+    AT元素引用: []
+- id: suite_音乐_音乐动效_004
+  name: 专辑详情页悬浮
+  module: 音乐_音乐动效
+  status: unsupported
+  reason: 动画效果验证，需要人工目视确认，无法通过AT-SPI断言
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐动效
+    测试功能: 专辑详情页悬浮
+    case_id: case_1695443
+    case_name: 专辑详情页悬浮
+    AT元素引用: []
+- id: suite_音乐_音乐动效_005
+  name: 歌词展开收起
+  module: 音乐_音乐动效
+  status: unsupported
+  reason: 动画效果验证，需要人工目视确认，无法通过AT-SPI断言
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐动效
+    测试功能: 歌词展开收起
+    case_id: case_1695441
+    case_name: 歌词展开收起
+    AT元素引用: []
+- id: suite_音乐_音乐格式_001
+  name: 格式支持-CD歌单与所有音乐交互
+  module: 音乐_音乐格式
+  status: unsupported
+  reason: 需要外部硬件设备(USB/CD)，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐格式
+    测试功能: 格式支持-CD歌单与所有音乐交互
+    case_id: case_1676611
+    case_name: 格式支持-CD歌单与所有音乐交互
+    AT元素引用: []
+- id: suite_音乐_音乐格式_002
+  name: '[core]格式支持-CD歌单播放'
+  module: 音乐_音乐格式
+  status: unsupported
+  reason: 需要外部硬件设备(USB/CD)，无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐格式
+    测试功能: '[core]格式支持-CD歌单播放'
+    case_id: case_1676607
+    case_name: '[core]格式支持-CD歌单播放'
+    AT元素引用: []
+- id: suite_音乐_音乐格式_004
+  name: '[318][core][acp1]格式支持-ap'
+  module: 音乐_音乐格式
+  status: unsupported
+  reason: 无法通过AT-SPI自动化
+  steps: []
+  annotation:
+    测试界面: 音乐-音乐格式
+    测试功能: '[318][core][acp1]格式支持-ap'
+    case_id: case_1676599
+    case_name: '[318][core][acp1]格式支持-ap'
+    AT元素引用: []

--- a/tests/at/context-bundle.md
+++ b/tests/at/context-bundle.md
@@ -1,0 +1,247 @@
+# Context Bundle — deepin-music
+
+## 1. 元素-功能对照表
+
+| 元素名 | Role | 功能描述 | 可见条件 |
+|--------|------|----------|----------|
+| Add Songs | push button | 添加音乐文件（点击打开文件对话框选择音乐） | 专辑默认页（无音乐时） |
+| Open Folders | push button | 添加音乐文件夹（点击打开文件夹选择对话框） | 专辑默认页（无音乐时） |
+| RoundedImage_CircularButton | push button | 专辑封面圆形播放按钮（点击播放该专辑） | 专辑网格视图 |
+| Morebutton | push button | 专辑项更多操作按钮 | 专辑网格视图 |
+| ItemDelegate | list item | 专辑列表项代理 | 专辑网格视图 |
+| Imagecell | list item | 专辑列表项图片单元格 | 专辑列表视图 |
+| ListView_AlbumListDelegate | list item | 专辑列表项代理 | 专辑列表视图 |
+| Albums | push button | 专辑视图标题按钮（切换到专辑视图） | 专辑视图 |
+| CircularButton_Button | push button | 专辑/歌曲项圆形播放按钮 | 列表/网格项悬停时 |
+| SortBtn | push button | 排序按钮（打开排序菜单） | 点击排序按钮后弹出 |
+| Menu | menu | 排序菜单 | 点击排序按钮后弹出 |
+| title | menu item | 排序菜单标题项 | 点击排序按钮后弹出 |
+| Play All | push button | 播放全部按钮（播放当前列表所有歌曲） | 子列表标题区域 |
+| DataSort | menu | 数据排序菜单 | 工具栏区域 |
+| GridViewButton | push button | 网格视图切换按钮 | 工具栏区域 |
+| ListViewButton | push button | 列表视图切换按钮 | 工具栏区域 |
+| Cancel | push button | 取消按钮（关闭对话框） | CD移除对话框弹出时 |
+| Minimize to system tray | radio button | 最小化到系统托盘单选项 | 关闭确认对话框弹出时 |
+| Exit | radio button | 退出单选项 | 关闭确认对话框弹出时 |
+| Do not ask again | check box | 不再询问复选框 | 关闭确认对话框弹出时 |
+| Cancel | push button | 取消按钮（关闭对话框） | 关闭确认对话框弹出时 |
+| Confirm | push button | 确认按钮（确认对话框操作） | 关闭确认对话框弹出时 |
+| Cancel | push button | 取消按钮（关闭对话框） | 删除本地文件确认对话框 |
+| Cancel | push button | 取消按钮（关闭对话框） | 删除歌单确认对话框 |
+| SwitchBtn | toggle button | 均衡器开关切换按钮 | 均衡器对话框弹出时 |
+| SelectComBox | combo box | 均衡器模式选择下拉框 | 均衡器对话框弹出时 |
+| Save | push button | 保存按钮（保存均衡器设置） | 均衡器对话框弹出时 |
+| Reset | push button | 重置按钮（重置均衡器设置） | 均衡器对话框弹出时 |
+| PreamplifierSlider | slider | 前置放大增益滑块 | 均衡器对话框弹出时 |
+| DelegateSlider | slider | 频率波段滑块 | 均衡器对话框弹出时 |
+| OK | push button | 确定按钮（关闭导入失败提示） | 导入失败提示对话框 |
+| Title | list item | 歌曲信息-标题字段 | 歌曲信息对话框弹出时 |
+| Artist | list item | 歌曲信息-艺术家字段 | 歌曲信息对话框弹出时 |
+| Album | list item | 歌曲信息-专辑字段 | 歌曲信息对话框弹出时 |
+| Type | list item | 歌曲信息-文件类型字段 | 歌曲信息对话框弹出时 |
+| Size | list item | 歌曲信息-文件大小字段 | 歌曲信息对话框弹出时 |
+| Duration | list item | 歌曲信息-时长字段 | 歌曲信息对话框弹出时 |
+| Path | list item | 歌曲信息-文件路径字段 | 歌曲信息对话框弹出时 |
+| title | push button | 排序菜单标题项 | 属性项区域 |
+| SettingsDialog_CheckBox | check box | 设置-播放选项复选框1（启动时自动播放） | 设置对话框弹出时 |
+| SettingsDialog_CheckBox_2 | check box | 设置-播放选项复选框2（记住上次播放进度） | 设置对话框弹出时 |
+| SettingsDialog_CheckBox_3 | check box | 设置-播放选项复选框3（开启淡入淡出） | 设置对话框弹出时 |
+| Minimize to system tray | radio button | 最小化到系统托盘单选项 | 设置对话框弹出时 |
+| Exit | radio button | 退出单选项 | 设置对话框弹出时 |
+| Ask me always | radio button | 每次询问单选项（关闭主窗口时弹出确认） | 设置对话框弹出时 |
+| Cancel | push button | 取消按钮（关闭对话框） | 设置对话框弹出时 |
+| Replace | push button | 替换按钮（快捷键替换确认） | 设置对话框弹出时 |
+| Restore Defaults | push button | 恢复默认按钮（恢复快捷键默认设置） | 设置对话框弹出时 |
+| Component_Menu | menu | 系统托盘右键菜单 | 主窗口 |
+| Play/Pause | menu item | 托盘菜单-播放/暂停 | 主窗口 |
+| Previous | menu item | 托盘菜单-上一首 | 主窗口 |
+| Next | menu item | 托盘菜单-下一首 | 主窗口 |
+| Exit | menu item | 退出单选项 | 主窗口 |
+| TabArea | page tab list | 搜索结果标签页区域 | 搜索结果窗口 |
+| Music | page tab | 搜索结果-音乐标签页 | 搜索结果窗口 |
+| Album | page tab | 歌曲信息-专辑字段 | 搜索结果窗口 |
+| Artist | page tab | 歌曲信息-艺术家字段 | 搜索结果窗口 |
+| AllMusicSortMenu | menu | 所有音乐排序菜单 | 搜索结果窗口 |
+| AlbumMusicSortMenu | menu | 专辑音乐排序菜单 | 搜索结果窗口 |
+| ArtistMusicSortMenu | menu | 演唱者音乐排序菜单 | 搜索结果窗口 |
+| MusicSingerGridItem | list item | 搜索结果-歌手网格项 | 搜索结果窗口 |
+| ItemDelegate_2 | list item | 搜索结果-列表项代理 | 搜索结果窗口 |
+| LrcBtn | push button | 歌词按钮（切换歌词界面） | 主窗口工具栏 |
+| VolumeBtn | push button | 音量按钮（打开音量调节） | 主窗口工具栏 |
+| ListBtn | push button | 播放列表按钮（打开播放队列） | 主窗口工具栏 |
+| WindowTitlebar_Menu | menu | 标题栏主菜单按钮 | 标题栏 |
+| Add playlist | menu item | 主菜单-添加播放列表 | 标题栏 |
+| Add music | menu item | 主菜单-添加音乐 | 标题栏 |
+| Settings | menu item | 主菜单-设置 | 标题栏 |
+| Add Songs | push button | 添加音乐文件（点击打开文件对话框选择音乐） | 所有音乐默认页（无音乐时） |
+| Open Folders | push button | 添加音乐文件夹（点击打开文件夹选择对话框） | 所有音乐默认页（无音乐时） |
+| listTitle | push button | 所有音乐列表标题按钮 | 所有音乐列表 |
+| Imagecell_4 | list item | 所有音乐列表项图片 | 所有音乐列表项 |
+| ItemD | list item | 所有音乐列表项 | 所有音乐列表视图 |
+| SidebarItem | list item | 侧边栏列表项 | 侧边栏 |
+| Item | push button | 侧边栏项代理按钮 | 侧边栏项代理 |
+| MoreMenu | menu | 专辑右键更多菜单 | 右键点击专辑时 |
+| View details | menu item | 右键菜单-查看详情 | 右键点击专辑时 |
+| Play all | menu item | 右键菜单-播放全部 | 右键点击专辑时 |
+| Add to | menu | 右键菜单-添加到（子菜单） | 右键点击专辑时 |
+| MoreMenu_3 | menu | 演唱者右键更多菜单 | 右键点击演唱者时 |
+| View details | menu item | 右键菜单-查看详情 | 右键点击演唱者时 |
+| Play all | menu item | 右键菜单-播放全部 | 右键点击演唱者时 |
+| Add to | menu | 右键菜单-添加到（子菜单） | 右键点击演唱者时 |
+| ImportMenu | menu | 导入菜单（添加到播放队列/我的收藏/新建歌单） | 右键菜单-添加到子菜单 |
+| Play queue | menu item | 导入菜单-播放队列 | 右键菜单-添加到子菜单 |
+| My favorites | menu item | 导入菜单-我的收藏 | 右键菜单-添加到子菜单 |
+| Create new playlist | menu item | 导入菜单-新建歌单 | 右键菜单-添加到子菜单 |
+| &lt; | menu item | &lt; (menu item) | 右键菜单-添加到子菜单 |
+| MulitSelectMenu | menu | 多选右键菜单 | 多选时右键菜单 |
+| Add to | menu | 右键菜单-添加到（子菜单） | 多选时右键菜单 |
+| play | menu item | 右键菜单-播放 | 多选时右键菜单 |
+| Delete from local disk | menu item | 右键菜单-从本地磁盘删除 | 多选时右键菜单 |
+| MoreMenu_2 | menu | 音乐右键更多菜单 | 右键点击音乐时 |
+| Pause | menu item | 右键菜单-暂停 | 右键点击音乐时 |
+| Add to | menu | 右键菜单-添加到（子菜单） | 右键点击音乐时 |
+| Open in file manager | menu item | 右键菜单-在文件管理器中打开 | 右键点击音乐时 |
+| play | menu item | 右键菜单-播放 | 右键点击音乐时 |
+| Delete from local disk | menu item | 右键菜单-从本地磁盘删除 | 右键点击音乐时 |
+| Encoding | menu | 右键菜单-编码方式（子菜单） | 右键点击音乐时 |
+| encodings | menu item | 编码方式-选择编码 | 右键点击音乐时 |
+| Song info | menu item | 右键菜单-歌曲信息 | 右键点击音乐时 |
+| PlaylistMenu | menu | 歌单右键菜单 | 右键点击歌单时 |
+| Play | menu item | Play (menu item) | 右键点击歌单时 |
+| Add songs | menu item | 歌单菜单-添加歌曲 | 右键点击歌单时 |
+| Rename | menu item | 歌单菜单-重命名 | 右键点击歌单时 |
+| Delete | menu item | 歌单菜单-删除 | 右键点击歌单时 |
+| ListView_AlbumSublistDelegate_2 | list item | 专辑子列表项代理 | 专辑子列表 |
+| ListView_AlbumSublistDelegate | list item | 专辑子列表项代理 | 专辑子列表视图 |
+| SublistDelegate | push button | 演唱者子列表代理按钮 | 演唱者子列表项 |
+| Imagecell_2 | list item | 演唱者子列表图片 | 演唱者子列表项 |
+| ListView_ArtistSublistDelegate | list item | 演唱者子列表项代理 | 演唱者子列表视图 |
+| TitleButton1 | push button | 音乐子列表标题按钮 | 音乐子列表标题 |
+| Empty | push button | 播放队列空状态删除按钮 | 播放队列 |
+| PlaylistDelegate | list item | 播放队列列表项代理 | 播放队列 |
+| Imagecell_3 | list item | 播放队列列表项图片 | 播放队列项 |
+| Add Songs | push button | 添加音乐文件（点击打开文件对话框选择音乐） | 演唱者默认页（无音乐时） |
+| Open Folders | push button | 添加音乐文件夹（点击打开文件夹选择对话框） | 演唱者默认页（无音乐时） |
+| CircularImg_CircularButton | push button | 演唱者封面圆形播放按钮 | 演唱者网格项 |
+| Morebutton_2 | push button | 演唱者项更多操作按钮 | 演唱者网格项 |
+| Artists | push button | 演唱者视图标题按钮（切换到演唱者视图） | 演唱者视图 |
+| MusicSingerGridItem_2 | list item | 演唱者网格项 | 演唱者视图 |
+| ContentSlider | slider | 音量调节滑块 | 点击音量按钮后 |
+
+## 2. 界面-元素映射
+
+| 界面 | 包含元素 |
+|------|----------|
+| 主窗口-标题栏 | WindowTitlebar_Menu, Add playlist, Add music, Settings |
+| 主窗口-工具栏 | LrcBtn, VolumeBtn, ListBtn, ContentSlider |
+| 主窗口-标签页 | TabArea, Music, Album, Artist |
+| 主窗口-系统托盘菜单 | Component_Menu, Play/Pause, Previous, Next, Exit |
+| 所有音乐-默认页 | Add Songs, Open Folders |
+| 所有音乐-列表 | listTitle, ItemD, Imagecell_4, SortBtn, Play All, DataSort, GridViewButton, ListViewButton |
+| 所有音乐-排序菜单 | AllMusicSortMenu, Menu, title |
+| 专辑-默认页 | Add Songs, Open Folders |
+| 专辑-网格视图 | RoundedImage_CircularButton, Morebutton, CircularButton_Button |
+| 专辑-列表视图 | ItemDelegate, Imagecell, ListView_AlbumListDelegate |
+| 专辑-视图标题 | Albums |
+| 专辑-子列表 | ListView_AlbumSublistDelegate, ListView_AlbumSublistDelegate_2 |
+| 专辑-排序菜单 | AlbumMusicSortMenu |
+| 演唱者-默认页 | Add Songs, Open Folders |
+| 演唱者-网格视图 | CircularImg_CircularButton, Morebutton_2, MusicSingerGridItem_2 |
+| 演唱者-视图标题 | Artists |
+| 演唱者-子列表 | SublistDelegate, Imagecell_2, ListView_ArtistSublistDelegate |
+| 演唱者-排序菜单 | ArtistMusicSortMenu |
+| 音乐右键菜单 | MoreMenu_2, Pause, Add to, Open in file manager, play, Delete from local disk, Encoding, encodings, Song info |
+| 专辑右键菜单 | MoreMenu, View details, Play all, Add to |
+| 演唱者右键菜单 | MoreMenu_3, View details, Play all, Add to |
+| 多选右键菜单 | MulitSelectMenu, Add to, play, Delete from local disk |
+| 导入子菜单 | ImportMenu, Play queue, My favorites, Create new playlist, < |
+| 歌单右键菜单 | PlaylistMenu, Play, Add songs, Rename, Delete |
+| 关闭确认对话框 | Cancel, Minimize to system tray, Exit, Do not ask again, Confirm |
+| 设置对话框 | SettingsDialog_CheckBox, SettingsDialog_CheckBox_2, SettingsDialog_CheckBox_3, Minimize to system tray, Exit, Ask me always, Cancel, Replace, Restore Defaults |
+| 均衡器对话框 | SwitchBtn, SelectComBox, Save, Reset, PreamplifierSlider, DelegateSlider |
+| 歌曲信息对话框 | Title, Artist, Album, Type, Size, Duration, Path |
+| 导入失败对话框 | OK |
+| 播放队列 | Empty, PlaylistDelegate, Imagecell_3 |
+| 侧边栏 | SidebarItem, Item |
+| 搜索结果窗口 | TabArea, Music, Album, Artist, AllMusicSortMenu, AlbumMusicSortMenu, ArtistMusicSortMenu, MusicSingerGridItem, ItemDelegate_2 |
+| 音乐子列表标题 | TitleButton1 |
+| 属性项 | title |
+
+## 3. 功能-操作-断言映射
+
+| 功能 | 操作 | 断言目标 |
+|------|------|----------|
+| 添加音乐文件 | 主菜单 → Add music → 文件对话框选择文件 | ItemD |
+| 添加音乐文件夹 | 主菜单 → Add music → 文件对话框选择文件夹 | ItemD |
+| 添加音乐(默认页按钮) | element_action Add Songs → file_dialog_select | ItemD |
+| 添加音乐文件夹(默认页按钮) | element_action Open Folders → file_dialog_select | ItemD |
+| 新建歌单 | 主菜单 → Add playlist | PlaylistDelegate |
+| 播放全部 | element_action Play All | PlaylistDelegate |
+| 播放/暂停 | element_action Play All (toggle) | PlaylistDelegate |
+| 上一首 | keyboard_hot_key (播放控制) | PlaylistDelegate |
+| 下一首 | keyboard_hot_key (播放控制) | PlaylistDelegate |
+| 打开歌词界面 | element_action LrcBtn | LrcBtn |
+| 关闭歌词界面 | element_action LrcBtn (再次点击) | LrcBtn |
+| 打开音量调节 | element_action VolumeBtn | ContentSlider |
+| 调节音量 | element_action VolumeBtn → element_set_value ContentSlider | ContentSlider |
+| 打开播放队列 | element_action ListBtn | PlaylistDelegate |
+| 切换到所有音乐 | element_action TabArea → Music | listTitle |
+| 切换到专辑视图 | element_action TabArea → Album | Albums |
+| 切换到演唱者视图 | element_action TabArea → Artist | Artists |
+| 专辑网格视图 | element_action GridViewButton | RoundedImage_CircularButton |
+| 专辑列表视图 | element_action ListViewButton | ItemDelegate |
+| 排序音乐 | element_action SortBtn → Menu → title | ItemD |
+| 搜索音乐 | keyboard_type 关键字 → keyboard_press Enter | ItemDelegate_2 |
+| 收藏音乐 | element_action (收藏按钮) | PlaylistDelegate |
+| 右键播放音乐 | mouse_right_click 音乐项 → dtk_context_menu play | PlaylistDelegate |
+| 右键暂停音乐 | mouse_right_click 音乐项 → dtk_context_menu Pause | PlaylistDelegate |
+| 右键删除本地音乐 | mouse_right_click → dtk_context_menu Delete from local disk | ItemD |
+| 右键在文件管理器打开 | mouse_right_click → dtk_context_menu Open in file manager | ItemD |
+| 右键查看歌曲信息 | mouse_right_click → dtk_context_menu Song info | Title |
+| 右键切换编码 | mouse_right_click → dtk_context_menu Encoding → encodings | ItemD |
+| 右键添加到播放队列 | mouse_right_click → dtk_context_menu Add to → Play queue | PlaylistDelegate |
+| 右键添加到我的收藏 | mouse_right_click → dtk_context_menu Add to → My favorites | PlaylistDelegate |
+| 右键添加到新建歌单 | mouse_right_click → dtk_context_menu Add to → Create new playlist | PlaylistDelegate |
+| 专辑右键查看详情 | mouse_right_click 专辑 → dtk_context_menu View details | Imagecell |
+| 专辑右键播放全部 | mouse_right_click 专辑 → dtk_context_menu Play all | PlaylistDelegate |
+| 演唱者右键查看详情 | mouse_right_click 演唱者 → dtk_context_menu View details | MusicSingerGridItem_2 |
+| 演唱者右键播放全部 | mouse_right_click 演唱者 → dtk_context_menu Play all | PlaylistDelegate |
+| 歌单右键播放 | mouse_right_click 歌单 → dtk_context_menu Play | PlaylistDelegate |
+| 歌单右键添加歌曲 | mouse_right_click 歌单 → dtk_context_menu Add songs | PlaylistDelegate |
+| 歌单右键重命名 | mouse_right_click 歌单 → dtk_context_menu Rename | SidebarItem |
+| 歌单右键删除 | mouse_right_click 歌单 → dtk_context_menu Delete | SidebarItem |
+| 多选右键播放 | mouse_right_click 多选 → dtk_context_menu play | PlaylistDelegate |
+| 多选右键删除 | mouse_right_click 多选 → dtk_context_menu Delete from local disk | ItemD |
+| 打开均衡器 | 主菜单 → 均衡器 | SwitchBtn |
+| 开启均衡器 | element_action SwitchBtn | SelectComBox |
+| 选择均衡器模式 | element_action SelectComBox | SelectComBox |
+| 调节前置放大 | element_set_value PreamplifierSlider | PreamplifierSlider |
+| 调节频率波段 | element_set_value DelegateSlider | DelegateSlider |
+| 保存均衡器 | element_action Save | SwitchBtn |
+| 重置均衡器 | element_action Reset | PreamplifierSlider |
+| 打开设置 | 主菜单 → Settings | SettingsDialog_CheckBox |
+| 设置自动播放 | element_action SettingsDialog_CheckBox | SettingsDialog_CheckBox |
+| 设置记住进度 | element_action SettingsDialog_CheckBox_2 | SettingsDialog_CheckBox_2 |
+| 设置淡入淡出 | element_action SettingsDialog_CheckBox_3 | SettingsDialog_CheckBox_3 |
+| 设置关闭行为-最小化 | element_action Minimize to system tray | Minimize to system tray |
+| 设置关闭行为-退出 | element_action Exit | Exit |
+| 设置关闭行为-每次询问 | element_action Ask me always | Ask me always |
+| 恢复默认快捷键 | element_action Restore Defaults | Restore Defaults |
+| 关闭确认-最小化到托盘 | element_action Minimize to system tray | Minimize to system tray |
+| 关闭确认-退出 | element_action Exit | Exit |
+| 关闭确认-不再询问 | element_action Do not ask again | Do not ask again |
+| 关闭确认-取消 | element_action Cancel | CloseConfirmDialog |
+| 关闭确认-确认 | element_action Confirm | CloseConfirmDialog |
+| 查看歌曲信息 | 右键 → Song info (断言信息字段) | Title |
+| 导入失败确认 | element_action OK | ImportFailedDialog |
+| 清空播放队列 | element_action Empty | Empty |
+| 切换主题 | 主菜单 → 主题 → 浅色/深色/系统 | WindowTitlebar_Menu |
+| 查看帮助 | 主菜单 → 帮助 | WindowTitlebar_Menu |
+| 查看关于 | 主菜单 → 关于 | WindowTitlebar_Menu |
+| 退出应用(主菜单) | 主菜单 → 退出 | WindowTitlebar_Menu |
+| 退出应用(托盘) | element_action Component_Menu → Exit | Component_Menu |
+| 快捷键打开快捷键预览 | keyboard_hot_key ctrl+shift+? | WindowTitlebar_Menu |
+| 快捷键打开文件 | keyboard_hot_key ctrl+o → file_dialog_select | ItemD |
+| Tab键切换焦点 | keyboard_press Tab | LrcBtn |
+| Esc关闭对话框 | keyboard_press Escape | SettingsDialog_CheckBox |
+| 方向键导航列表 | keyboard_press Down/Up | ItemD |

--- a/tests/at/yaml/elements.yaml
+++ b/tests/at/yaml/elements.yaml
@@ -1,0 +1,307 @@
+elements:
+  WindowTitlebar_Menu:
+    name: WindowTitlebar_Menu
+    role: menu
+  Component_Menu:
+    name: Component_Menu
+    role: menu
+  Add Songs:
+    name: Add Songs
+    role: push button
+  Play All:
+    name: Play All
+    role: push button
+  PlaylistDelegate:
+    name: PlaylistDelegate
+    role: list item
+  Replace:
+    name: Replace
+    role: push button
+  Ask me always:
+    name: Ask me always
+    role: radio button
+  Cancel:
+    name: Cancel
+    role: push button
+  SwitchBtn:
+    name: SwitchBtn
+    role: toggle button
+  PreamplifierSlider:
+    name: PreamplifierSlider
+    role: slider
+  Reset:
+    name: Reset
+    role: push button
+  PlaylistMenu:
+    name: PlaylistMenu
+    role: menu
+  ListBtn:
+    name: ListBtn
+    role: push button
+  ItemD:
+    name: ItemD
+    role: list item
+  MulitSelectMenu:
+    name: MulitSelectMenu
+    role: menu
+  LrcBtn:
+    name: LrcBtn
+    role: push button
+  VolumeBtn:
+    name: VolumeBtn
+    role: push button
+  ContentSlider:
+    name: ContentSlider
+    role: slider
+  SublistDelegate:
+    name: SublistDelegate
+    role: push button
+  Albums:
+    name: Albums
+    role: push button
+  SidebarItem:
+    name: SidebarItem
+    role: list item
+  ImportMenu:
+    name: ImportMenu
+    role: menu
+  Empty:
+    name: Empty
+    role: push button
+  listTitle:
+    name: listTitle
+    role: push button
+  SortBtn:
+    name: SortBtn
+    role: push button
+  TabArea:
+    name: TabArea
+    role: page tab list
+  ItemDelegate_2:
+    name: ItemDelegate_2
+    role: list item
+  MusicSingerGridItem_2:
+    name: MusicSingerGridItem_2
+    role: list item
+  Artists:
+    name: Artists
+    role: push button
+  Open Folders:
+    name: Open Folders
+    role: push button
+  RoundedImage_CircularButton:
+    name: RoundedImage_CircularButton
+    role: push button
+  Morebutton:
+    name: Morebutton
+    role: push button
+  ItemDelegate:
+    name: ItemDelegate
+    role: list item
+  Imagecell:
+    name: Imagecell
+    role: list item
+  ListView_AlbumListDelegate:
+    name: ListView_AlbumListDelegate
+    role: list item
+  CircularButton_Button:
+    name: CircularButton_Button
+    role: push button
+  Menu:
+    name: Menu
+    role: menu
+  title:
+    name: title
+    role: push button
+  DataSort:
+    name: DataSort
+    role: menu
+  GridViewButton:
+    name: GridViewButton
+    role: push button
+  ListViewButton:
+    name: ListViewButton
+    role: push button
+  Minimize to system tray:
+    name: Minimize to system tray
+    role: radio button
+  Exit:
+    name: Exit
+    role: menu item
+  Do not ask again:
+    name: Do not ask again
+    role: check box
+  Confirm:
+    name: Confirm
+    role: push button
+  SelectComBox:
+    name: SelectComBox
+    role: combo box
+  Save:
+    name: Save
+    role: push button
+  DelegateSlider:
+    name: DelegateSlider
+    role: slider
+  OK:
+    name: OK
+    role: push button
+  Title:
+    name: Title
+    role: list item
+  Artist:
+    name: Artist
+    role: page tab
+  Album:
+    name: Album
+    role: page tab
+  Type:
+    name: Type
+    role: list item
+  Size:
+    name: Size
+    role: list item
+  Duration:
+    name: Duration
+    role: list item
+  Path:
+    name: Path
+    role: list item
+  SettingsDialog_CheckBox:
+    name: SettingsDialog_CheckBox
+    role: check box
+  SettingsDialog_CheckBox_2:
+    name: SettingsDialog_CheckBox_2
+    role: check box
+  SettingsDialog_CheckBox_3:
+    name: SettingsDialog_CheckBox_3
+    role: check box
+  Restore Defaults:
+    name: Restore Defaults
+    role: push button
+  Play/Pause:
+    name: Play/Pause
+    role: menu item
+  Previous:
+    name: Previous
+    role: menu item
+  Next:
+    name: Next
+    role: menu item
+  Music:
+    name: Music
+    role: page tab
+  AllMusicSortMenu:
+    name: AllMusicSortMenu
+    role: menu
+  AlbumMusicSortMenu:
+    name: AlbumMusicSortMenu
+    role: menu
+  ArtistMusicSortMenu:
+    name: ArtistMusicSortMenu
+    role: menu
+  MusicSingerGridItem:
+    name: MusicSingerGridItem
+    role: list item
+  Add playlist:
+    name: Add playlist
+    role: menu item
+  Add music:
+    name: Add music
+    role: menu item
+  Settings:
+    name: Settings
+    role: menu item
+  Imagecell_4:
+    name: Imagecell_4
+    role: list item
+  Item:
+    name: Item
+    role: push button
+  MoreMenu:
+    name: MoreMenu
+    role: menu
+  View details:
+    name: View details
+    role: menu item
+  Play all:
+    name: Play all
+    role: menu item
+  Add to:
+    name: Add to
+    role: menu
+  MoreMenu_3:
+    name: MoreMenu_3
+    role: menu
+  Play queue:
+    name: Play queue
+    role: menu item
+  My favorites:
+    name: My favorites
+    role: menu item
+  Create new playlist:
+    name: Create new playlist
+    role: menu item
+  '&lt;':
+    name: '&lt;'
+    role: menu item
+  play:
+    name: play
+    role: menu item
+  Delete from local disk:
+    name: Delete from local disk
+    role: menu item
+  MoreMenu_2:
+    name: MoreMenu_2
+    role: menu
+  Pause:
+    name: Pause
+    role: menu item
+  Open in file manager:
+    name: Open in file manager
+    role: menu item
+  Encoding:
+    name: Encoding
+    role: menu
+  encodings:
+    name: encodings
+    role: menu item
+  Song info:
+    name: Song info
+    role: menu item
+  Play:
+    name: Play
+    role: menu item
+  Add songs:
+    name: Add songs
+    role: menu item
+  Rename:
+    name: Rename
+    role: menu item
+  Delete:
+    name: Delete
+    role: menu item
+  ListView_AlbumSublistDelegate_2:
+    name: ListView_AlbumSublistDelegate_2
+    role: list item
+  ListView_AlbumSublistDelegate:
+    name: ListView_AlbumSublistDelegate
+    role: list item
+  Imagecell_2:
+    name: Imagecell_2
+    role: list item
+  ListView_ArtistSublistDelegate:
+    name: ListView_ArtistSublistDelegate
+    role: list item
+  TitleButton1:
+    name: TitleButton1
+    role: push button
+  Imagecell_3:
+    name: Imagecell_3
+    role: list item
+  CircularImg_CircularButton:
+    name: CircularImg_CircularButton
+    role: push button
+  Morebutton_2:
+    name: Morebutton_2
+    role: push button

--- a/tests/at/yaml/音乐/音乐.suite.yaml
+++ b/tests/at/yaml/音乐/音乐.suite.yaml
@@ -1,0 +1,53 @@
+name: 音乐_suite
+app: deepin-music
+module: 音乐
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_001_s1
+  name: 主菜单-关于
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 主菜单-关于
+    case_id: case_2003951
+    case_name: 主菜单-关于
+    AT元素引用:
+    - WindowTitlebar_Menu
+- id: suite_音乐_002_s1
+  name: 音乐_窗口菜单hover状态检查
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐主窗口
+    测试功能: 音乐_窗口菜单hover状态检查
+    case_id: case_1992957
+    case_name: 音乐_窗口菜单hover状态检查
+    AT元素引用:
+    - WindowTitlebar_Menu
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_外部交互_任务栏/音乐_外部交互_任务栏.suite.yaml
+++ b/tests/at/yaml/音乐_外部交互_任务栏/音乐_外部交互_任务栏.suite.yaml
@@ -1,0 +1,58 @@
+name: 音乐_外部交互_任务栏_suite
+app: deepin-music
+module: 音乐_外部交互_任务栏
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_外部交互_任务栏_001_s1
+  name: 托盘-删除所有歌曲后检查托盘右键菜单选项状态
+  description: ''
+  steps:
+  - action: mouse_right_click
+    selector:
+      name: Component_Menu
+      role: menu
+  - action: dtk_context_menu
+    selector:
+      name: Component_Menu
+    items:
+    - Play/Pause
+    - Previous
+    - Next
+    - Exit
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: Component_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐-任务栏
+    测试功能: 托盘-删除所有歌曲后检查托盘右键菜单选项状态
+    case_id: case_1676659
+    case_name: 托盘-删除所有歌曲后检查托盘右键菜单选项状态
+    AT元素引用:
+    - Component_Menu
+- id: suite_音乐_外部交互_任务栏_003_s1
+  name: '[302][smoke][acp1]托盘-调起'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Component_Menu
+      role: menu
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: Component_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐-任务栏
+    测试功能: '[302][smoke][acp1]托盘-调起'
+    case_id: case_1676639
+    case_name: '[302][smoke][acp1]托盘-调起'
+    AT元素引用:
+    - Component_Menu
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_打开_关闭/音乐_打开_关闭.suite.yaml
+++ b/tests/at/yaml/音乐_打开_关闭/音乐_打开_关闭.suite.yaml
@@ -1,0 +1,26 @@
+name: 音乐_打开_关闭_suite
+app: deepin-music
+module: 音乐_打开_关闭
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_打开_关闭_002_s1
+  name: '[174][smoke][acp1]打开-右键菜单打开'
+  description: ''
+  steps: []
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  annotation:
+    测试界面: 音乐-关闭
+    测试功能: '[174][smoke][acp1]打开-右键菜单打开'
+    case_id: case_1677785
+    case_name: '[174][smoke][acp1]打开-右键菜单打开'
+    AT元素引用:
+    - WindowTitlebar_Menu
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_用户场景/音乐_用户场景.suite.yaml
+++ b/tests/at/yaml/音乐_用户场景/音乐_用户场景.suite.yaml
@@ -1,0 +1,38 @@
+name: 音乐_用户场景_suite
+app: deepin-music
+module: 音乐_用户场景
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_用户场景_001_s1
+  name: '[acp2][音乐]检查音乐播放功能'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-用户场景
+    测试功能: '[acp2][音乐]检查音乐播放功能'
+    case_id: case_1676597
+    case_name: '[acp2][音乐]检查音乐播放功能'
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - PlaylistDelegate
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_界面操作_主菜单/音乐_界面操作_主菜单.suite.yaml
+++ b/tests/at/yaml/音乐_界面操作_主菜单/音乐_界面操作_主菜单.suite.yaml
@@ -1,0 +1,165 @@
+name: 音乐_界面操作_主菜单_suite
+app: deepin-music
+module: 音乐_界面操作_主菜单
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_界面操作_主菜单_001_s1
+  name: 设置-修改为重复快捷键
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: Replace
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: Replace
+      role: push button
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: 设置-修改为重复快捷键
+    case_id: case_1677101
+    case_name: 设置-修改为重复快捷键
+    AT元素引用:
+    - Replace
+- id: suite_音乐_界面操作_主菜单_002_s1
+  name: '[129][core][acp1]设置-每次询问'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: Ask me always
+      role: radio button
+  - action: mouse_click
+    selector:
+      name: Cancel
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: Ask me always
+      role: radio button
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[129][core][acp1]设置-每次询问'
+    case_id: case_1677097
+    case_name: '[129][core][acp1]设置-每次询问'
+    AT元素引用:
+    - Ask me always
+    - Cancel
+- id: suite_音乐_界面操作_主菜单_006_s1
+  name: '[136]均衡器-调整数值后恢复默认'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: SwitchBtn
+      role: toggle button
+  - action: element_set_value
+    selector:
+      name: PreamplifierSlider
+      role: slider
+    value: '50'
+  - action: mouse_click
+    selector:
+      name: Reset
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PreamplifierSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[136]均衡器-调整数值后恢复默认'
+    case_id: case_1677079
+    case_name: '[136]均衡器-调整数值后恢复默认'
+    AT元素引用:
+    - SwitchBtn
+    - PreamplifierSlider
+    - Reset
+- id: suite_音乐_界面操作_主菜单_007_s1
+  name: '[135][core][acp1]均衡器-自定义调整数值'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Settings
+  - action: mouse_click
+    selector:
+      name: SwitchBtn
+      role: toggle button
+  - action: element_set_value
+    selector:
+      name: PreamplifierSlider
+      role: slider
+    value: '50'
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PreamplifierSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[135][core][acp1]均衡器-自定义调整数值'
+    case_id: case_1677077
+    case_name: '[135][core][acp1]均衡器-自定义调整数值'
+    AT元素引用:
+    - SwitchBtn
+    - PreamplifierSlider
+- id: suite_音乐_界面操作_主菜单_009_s1
+  name: '[005][smoke][acp1]主菜单-添加新歌单选项'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Add playlist
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-主菜单
+    测试功能: '[005][smoke][acp1]主菜单-添加新歌单选项'
+    case_id: case_1677053
+    case_name: '[005][smoke][acp1]主菜单-添加新歌单选项'
+    AT元素引用:
+    - WindowTitlebar_Menu
+    - Add playlist
+    - PlaylistDelegate
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_界面操作_右键菜单/音乐_界面操作_右键菜单.suite.yaml
+++ b/tests/at/yaml/音乐_界面操作_右键菜单/音乐_界面操作_右键菜单.suite.yaml
@@ -1,0 +1,105 @@
+name: 音乐_界面操作_右键菜单_suite
+app: deepin-music
+module: 音乐_界面操作_右键菜单
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_界面操作_右键菜单_001_s1
+  name: '[262]右键菜单-自定义歌单右键菜单检查'
+  description: ''
+  steps:
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Play
+    - Add songs
+    - Rename
+    - Delete
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-右键菜单
+    测试功能: '[262]右键菜单-自定义歌单右键菜单检查'
+    case_id: case_1677191
+    case_name: '[262]右键菜单-自定义歌单右键菜单检查'
+    AT元素引用:
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_界面操作_右键菜单_002_s1
+  name: '[356]右键菜单-播放队列从播放队列删除'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Delete
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-右键菜单
+    测试功能: '[356]右键菜单-播放队列从播放队列删除'
+    case_id: case_1677163
+    case_name: '[356]右键菜单-播放队列从播放队列删除'
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_界面操作_右键菜单_003_s1
+  name: '[352]右键菜单-多选文件右键菜单检查'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_right_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: ItemD
+    items:
+    - play
+    - Add to
+    - Delete from local disk
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: MulitSelectMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-右键菜单
+    测试功能: '[352]右键菜单-多选文件右键菜单检查'
+    case_id: case_1677133
+    case_name: '[352]右键菜单-多选文件右键菜单检查'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+    - MulitSelectMenu
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_界面操作_工具栏/音乐_界面操作_工具栏.suite.yaml
+++ b/tests/at/yaml/音乐_界面操作_工具栏/音乐_界面操作_工具栏.suite.yaml
@@ -1,0 +1,162 @@
+name: 音乐_界面操作_工具栏_suite
+app: deepin-music
+module: 音乐_界面操作_工具栏
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_界面操作_工具栏_001_s1
+  name: 排序-播放队列-使用shift多选歌曲拖拽排序，歌曲按照所选顺序排序
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_drag
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: 排序-播放队列-使用shift多选歌曲拖拽排序，歌曲按照所选顺序排序
+    case_id: case_1677475
+    case_name: 排序-播放队列-使用shift多选歌曲拖拽排序，歌曲按照所选顺序排序
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+- id: suite_音乐_界面操作_工具栏_003_s1
+  name: 排序-播放队列-拖动歌曲至播放队列上滚动区域向上翻页功能
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_scroll
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: 排序-播放队列-拖动歌曲至播放队列上滚动区域向上翻页功能
+    case_id: case_1677461
+    case_name: 排序-播放队列-拖动歌曲至播放队列上滚动区域向上翻页功能
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+- id: suite_音乐_界面操作_工具栏_005_s1
+  name: '[351][core]工具栏-歌词与切换歌曲交互'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: LrcBtn
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: LrcBtn
+      role: push button
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[351][core]工具栏-歌词与切换歌曲交互'
+    case_id: case_1677413
+    case_name: '[351][core]工具栏-歌词与切换歌曲交互'
+    AT元素引用:
+    - LrcBtn
+- id: suite_音乐_界面操作_工具栏_006_s1
+  name: '[032][core][acp1]工具栏-播放歌曲时从播放队列移除当前歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Delete
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[032][core][acp1]工具栏-播放歌曲时从播放队列移除当前歌曲'
+    case_id: case_1677389
+    case_name: '[032][core][acp1]工具栏-播放歌曲时从播放队列移除当前歌曲'
+    AT元素引用:
+    - ListBtn
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_界面操作_工具栏_008_s1
+  name: '[238][core][acp1]工具栏-点击音量条静音按钮解除静'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: VolumeBtn
+      role: push button
+  - action: mouse_click
+    selector:
+      name: ContentSlider
+      role: slider
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ContentSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[238][core][acp1]工具栏-点击音量条静音按钮解除静'
+    case_id: case_1677369
+    case_name: '[238][core][acp1]工具栏-点击音量条静音按钮解除静'
+    AT元素引用:
+    - VolumeBtn
+    - ContentSlider
+- id: suite_音乐_界面操作_工具栏_009_s1
+  name: '[235][core][acp1]工具栏-拖拽放大音量条声'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: VolumeBtn
+      role: push button
+  - action: element_set_value
+    selector:
+      name: ContentSlider
+      role: slider
+    value: '50'
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ContentSlider
+      role: slider
+  annotation:
+    测试界面: 音乐-工具栏
+    测试功能: '[235][core][acp1]工具栏-拖拽放大音量条声'
+    case_id: case_1677363
+    case_name: '[235][core][acp1]工具栏-拖拽放大音量条声'
+    AT元素引用:
+    - VolumeBtn
+    - ContentSlider
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_界面操作_歌曲导入/音乐_界面操作_歌曲导入.suite.yaml
+++ b/tests/at/yaml/音乐_界面操作_歌曲导入/音乐_界面操作_歌曲导入.suite.yaml
@@ -1,0 +1,33 @@
+name: 音乐_界面操作_歌曲导入_suite
+app: deepin-music
+module: 音乐_界面操作_歌曲导入
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_界面操作_歌曲导入_001_s1
+  name: '[314][core][acp1]歌曲导入-自定义歌单页面拖拽添加音乐目录'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-歌曲导入
+    测试功能: '[314][core][acp1]歌曲导入-自定义歌单页面拖拽添加音乐目录'
+    case_id: case_1677709
+    case_name: '[314][core][acp1]歌曲导入-自定义歌单页面拖拽添加音乐目录'
+    AT元素引用:
+    - Add Songs
+    - PlaylistDelegate
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_窗口_专辑/音乐_窗口_专辑.suite.yaml
+++ b/tests/at/yaml/音乐_窗口_专辑/音乐_窗口_专辑.suite.yaml
@@ -1,0 +1,31 @@
+name: 音乐_窗口_专辑_suite
+app: deepin-music
+module: 音乐_窗口_专辑
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_窗口_专辑_001_s1
+  name: '[186][smoke][acp1]专辑-详情页面返回按钮'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: SublistDelegate
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: Albums
+      role: push button
+  annotation:
+    测试界面: 音乐-专辑
+    测试功能: '[186][smoke][acp1]专辑-详情页面返回按钮'
+    case_id: case_1677873
+    case_name: '[186][smoke][acp1]专辑-详情页面返回按钮'
+    AT元素引用:
+    - SublistDelegate
+    - Albums
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_窗口_我的收藏/音乐_窗口_我的收藏.suite.yaml
+++ b/tests/at/yaml/音乐_窗口_我的收藏/音乐_窗口_我的收藏.suite.yaml
@@ -1,0 +1,87 @@
+name: 音乐_窗口_我的收藏_suite
+app: deepin-music
+module: 音乐_窗口_我的收藏
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_窗口_我的收藏_001_s1
+  name: 排序-我的收藏-列表模式使用shift从文管多选歌曲拖拽排序，歌曲按照所选顺序排序
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: SidebarItem
+      role: list item
+  - action: mouse_drag
+    selector:
+      name: ItemD
+      role: list item
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: SidebarItem
+      role: list item
+  annotation:
+    测试界面: 音乐-我的收藏
+    测试功能: 排序-我的收藏-列表模式使用shift从文管多选歌曲拖拽排序，歌曲按照所选顺序排序
+    case_id: case_1678497
+    case_name: 排序-我的收藏-列表模式使用shift从文管多选歌曲拖拽排序，歌曲按照所选顺序排序
+    AT元素引用:
+    - SidebarItem
+    - ItemD
+- id: suite_音乐_窗口_我的收藏_002_s1
+  name: '[329][smoke]排序-我的收藏-列表模式下拖拽多首歌排序'
+  description: ''
+  steps:
+  - action: mouse_right_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: ItemD
+    items:
+    - Add to
+    - My favorites
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ImportMenu
+      role: menu
+  annotation:
+    测试界面: 音乐-我的收藏
+    测试功能: '[329][smoke]排序-我的收藏-列表模式下拖拽多首歌排序'
+    case_id: case_1678367
+    case_name: '[329][smoke]排序-我的收藏-列表模式下拖拽多首歌排序'
+    AT元素引用:
+    - ItemD
+    - ImportMenu
+    - My favorites
+- id: suite_音乐_窗口_我的收藏_003_s1
+  name: '[095]我的收藏-删除所有歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: SidebarItem
+      role: list item
+  - action: keyboard_hot_key
+    key: ctrl+a
+  - action: keyboard_press
+    key: Delete
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: SidebarItem
+      role: list item
+  annotation:
+    测试界面: 音乐-我的收藏
+    测试功能: '[095]我的收藏-删除所有歌曲'
+    case_id: case_1678285
+    case_name: '[095]我的收藏-删除所有歌曲'
+    AT元素引用:
+    - SidebarItem
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_窗口_我的歌单/音乐_窗口_我的歌单.suite.yaml
+++ b/tests/at/yaml/音乐_窗口_我的歌单/音乐_窗口_我的歌单.suite.yaml
@@ -1,0 +1,105 @@
+name: 音乐_窗口_我的歌单_suite
+app: deepin-music
+module: 音乐_窗口_我的歌单
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_窗口_我的歌单_001_s1
+  name: 新建歌单时，输入html标签能正常显示
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Empty
+      role: push button
+  - action: keyboard_type
+    text: test
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: 新建歌单时，输入html标签能正常显示
+    case_id: case_1678697
+    case_name: 新建歌单时，输入html标签能正常显示
+    AT元素引用:
+    - Empty
+    - PlaylistDelegate
+- id: suite_音乐_窗口_我的歌单_002_s1
+  name: 排序-我的歌单-拖拽歌单至音乐库列表
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Empty
+      role: push button
+  - action: mouse_drag
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: 排序-我的歌单-拖拽歌单至音乐库列表
+    case_id: case_1678653
+    case_name: 排序-我的歌单-拖拽歌单至音乐库列表
+    AT元素引用:
+    - Empty
+    - PlaylistDelegate
+- id: suite_音乐_窗口_我的歌单_004_s1
+  name: '[207][smoke][acp1]我的歌单-播放所有按钮播放'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: SidebarItem
+      role: list item
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: '[207][smoke][acp1]我的歌单-播放所有按钮播放'
+    case_id: case_1678563
+    case_name: '[207][smoke][acp1]我的歌单-播放所有按钮播放'
+    AT元素引用:
+    - SidebarItem
+    - Play All
+    - PlaylistDelegate
+- id: suite_音乐_窗口_我的歌单_006_s1
+  name: '[205][smoke][acp1]我的歌单-新建按钮增加歌单'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Empty
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-我的歌单
+    测试功能: '[205][smoke][acp1]我的歌单-新建按钮增加歌单'
+    case_id: case_1678541
+    case_name: '[205][smoke][acp1]我的歌单-新建按钮增加歌单'
+    AT元素引用:
+    - Empty
+    - PlaylistDelegate
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_窗口_所有音乐/音乐_窗口_所有音乐.suite.yaml
+++ b/tests/at/yaml/音乐_窗口_所有音乐/音乐_窗口_所有音乐.suite.yaml
@@ -1,0 +1,356 @@
+name: 音乐_窗口_所有音乐_suite
+app: deepin-music
+module: 音乐_窗口_所有音乐
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_窗口_所有音乐_001_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从本地删除歌曲，播放队列同步减少歌曲
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: ItemD
+    items:
+    - Delete from local disk
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从本地删除歌曲，播放队列同步减少歌曲
+    case_id: case_1678763
+    case_name: 播放队列同步-所有音乐-播放歌曲时从本地删除歌曲，播放队列同步减少歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ItemD
+    - MoreMenu_2
+- id: suite_音乐_窗口_所有音乐_003_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从文管拖拽歌曲增加歌曲，播放队列同步增加歌曲
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_click
+    selector:
+      name: ListBtn
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从文管拖拽歌曲增加歌曲，播放队列同步增加歌曲
+    case_id: case_1678759
+    case_name: 播放队列同步-所有音乐-播放歌曲时从文管拖拽歌曲增加歌曲，播放队列同步增加歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ListBtn
+    - PlaylistDelegate
+- id: suite_音乐_窗口_所有音乐_004_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从主菜单添加选项增加歌曲，播放队列同步增加歌曲
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_click
+    selector:
+      name: WindowTitlebar_Menu
+      role: menu
+  - action: dtk_main_menu
+    items:
+    - Add music
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test2.mp3
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从主菜单添加选项增加歌曲，播放队列同步增加歌曲
+    case_id: case_1678757
+    case_name: 播放队列同步-所有音乐-播放歌曲时从主菜单添加选项增加歌曲，播放队列同步增加歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - WindowTitlebar_Menu
+    - Add music
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_005_s1
+  name: '[322][core]播放队列同步-所有音乐-播放歌曲时从标题栏添加按钮增加歌曲，播放队列同步增加歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test2.mp3
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[322][core]播放队列同步-所有音乐-播放歌曲时从标题栏添加按钮增加歌曲，播放队列同步增加歌曲'
+    case_id: case_1678755
+    case_name: '[322][core]播放队列同步-所有音乐-播放歌曲时从标题栏添加按钮增加歌曲，播放队列同步增加歌曲'
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_006_s1
+  name: 播放队列同步-所有音乐-播放歌曲时从歌单右键菜单增加歌曲，播放队列同步增加歌曲
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: mouse_right_click
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  - action: dtk_context_menu
+    selector:
+      name: PlaylistDelegate
+    items:
+    - Add songs
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test2.mp3
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 播放队列同步-所有音乐-播放歌曲时从歌单右键菜单增加歌曲，播放队列同步增加歌曲
+    case_id: case_1678753
+    case_name: 播放队列同步-所有音乐-播放歌曲时从歌单右键菜单增加歌曲，播放队列同步增加歌曲
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - PlaylistDelegate
+    - PlaylistMenu
+- id: suite_音乐_窗口_所有音乐_007_s1
+  name: '[191][smoke][acp1]所有音乐-歌曲数量展示情况'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: listTitle
+      role: push button
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[191][smoke][acp1]所有音乐-歌曲数量展示情况'
+    case_id: case_1678733
+    case_name: '[191][smoke][acp1]所有音乐-歌曲数量展示情况'
+    AT元素引用:
+    - Add Songs
+    - listTitle
+- id: suite_音乐_窗口_所有音乐_008_s1
+  name: '[374]所有音乐-翻页查看所有歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_scroll
+    selector:
+      name: ItemD
+      role: list item
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[374]所有音乐-翻页查看所有歌曲'
+    case_id: case_1678731
+    case_name: '[374]所有音乐-翻页查看所有歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_009_s1
+  name: '[192][core][acp1]所有音乐-删除所有歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: keyboard_hot_key
+    key: ctrl+a
+  - action: keyboard_press
+    key: Delete
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[192][core][acp1]所有音乐-删除所有歌曲'
+    case_id: case_1678727
+    case_name: '[192][core][acp1]所有音乐-删除所有歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_010_s1
+  name: 所有音乐-歌曲名称反向排序
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: SortBtn
+      role: push button
+  - action: dtk_context_menu
+    selector:
+      name: SortBtn
+    items:
+    - title
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: 所有音乐-歌曲名称反向排序
+    case_id: case_1678717
+    case_name: 所有音乐-歌曲名称反向排序
+    AT元素引用:
+    - SortBtn
+    - ItemD
+- id: suite_音乐_窗口_所有音乐_012_s1
+  name: '[373]所有音乐-Enter键播放歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: ItemD
+      role: list item
+  - action: keyboard_press
+    key: Enter
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[373]所有音乐-Enter键播放歌曲'
+    case_id: case_1678703
+    case_name: '[373]所有音乐-Enter键播放歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+    - PlaylistDelegate
+- id: suite_音乐_窗口_所有音乐_013_s1
+  name: '[190][core][acp1]所有音乐-平铺视图下双击播放歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.mp3
+  - action: mouse_click
+    selector:
+      name: ItemD
+      role: list item
+    do: dblclick
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-所有音乐
+    测试功能: '[190][core][acp1]所有音乐-平铺视图下双击播放歌曲'
+    case_id: case_1678701
+    case_name: '[190][core][acp1]所有音乐-平铺视图下双击播放歌曲'
+    AT元素引用:
+    - Add Songs
+    - ItemD
+    - PlaylistDelegate
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_窗口_搜索/音乐_窗口_搜索.suite.yaml
+++ b/tests/at/yaml/音乐_窗口_搜索/音乐_窗口_搜索.suite.yaml
@@ -1,0 +1,127 @@
+name: 音乐_窗口_搜索_suite
+app: deepin-music
+module: 音乐_窗口_搜索
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_窗口_搜索_001_s1
+  name: '[372]搜索结果-清除搜索关键词'
+  description: ''
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: keyboard_press
+    key: Enter
+  - action: keyboard_press
+    key: Escape
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: TabArea
+      role: page tab list
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: '[372]搜索结果-清除搜索关键词'
+    case_id: case_1678819
+    case_name: '[372]搜索结果-清除搜索关键词'
+    AT元素引用:
+    - TabArea
+- id: suite_音乐_窗口_搜索_002_s1
+  name: '[150]搜索结果-歌曲页面播放所有'
+  description: ''
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: keyboard_press
+    key: Enter
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: PlaylistDelegate
+      role: list item
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: '[150]搜索结果-歌曲页面播放所有'
+    case_id: case_1678815
+    case_name: '[150]搜索结果-歌曲页面播放所有'
+    AT元素引用:
+    - Play All
+    - PlaylistDelegate
+- id: suite_音乐_窗口_搜索_003_s1
+  name: '[219][smoke][acp1]搜索结果-歌曲页面展示'
+  description: ''
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: keyboard_press
+    key: Enter
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: Play All
+      role: push button
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: '[219][smoke][acp1]搜索结果-歌曲页面展示'
+    case_id: case_1678781
+    case_name: '[219][smoke][acp1]搜索结果-歌曲页面展示'
+    AT元素引用:
+    - Play All
+- id: suite_音乐_窗口_搜索_004_s1
+  name: 搜索-搜索列表结果长度限制
+  description: ''
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemDelegate_2
+      role: list item
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: 搜索-搜索列表结果长度限制
+    case_id: case_1678775
+    case_name: 搜索-搜索列表结果长度限制
+    AT元素引用:
+    - ItemDelegate_2
+- id: suite_音乐_窗口_搜索_005_s1
+  name: 搜索-撤销搜索内容
+  description: ''
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+f
+  - action: keyboard_type
+    text: test
+  - action: mouse_right_click
+    selector:
+      name: ItemDelegate_2
+      role: list item
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemDelegate_2
+      role: list item
+  annotation:
+    测试界面: 音乐-搜索
+    测试功能: 搜索-撤销搜索内容
+    case_id: case_1678773
+    case_name: 搜索-撤销搜索内容
+    AT元素引用:
+    - ItemDelegate_2
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_窗口_演唱者/音乐_窗口_演唱者.suite.yaml
+++ b/tests/at/yaml/音乐_窗口_演唱者/音乐_窗口_演唱者.suite.yaml
@@ -1,0 +1,82 @@
+name: 音乐_窗口_演唱者_suite
+app: deepin-music
+module: 音乐_窗口_演唱者
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_窗口_演唱者_001_s1
+  name: '[124]演唱者-暂停时删除当前演唱者的所有歌曲'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  - action: keyboard_hot_key
+    key: ctrl+a
+  - action: keyboard_press
+    key: Delete
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: MusicSingerGridItem_2
+      role: list item
+  annotation:
+    测试界面: 音乐-演唱者
+    测试功能: '[124]演唱者-暂停时删除当前演唱者的所有歌曲'
+    case_id: case_1678093
+    case_name: '[124]演唱者-暂停时删除当前演唱者的所有歌曲'
+    AT元素引用:
+    - Play All
+    - MusicSingerGridItem_2
+- id: suite_音乐_窗口_演唱者_002_s1
+  name: 演唱者-演唱者名称排序
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: SortBtn
+      role: push button
+  - action: dtk_context_menu
+    selector:
+      name: SortBtn
+    items:
+    - title
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: MusicSingerGridItem_2
+      role: list item
+  annotation:
+    测试界面: 音乐-演唱者
+    测试功能: 演唱者-演唱者名称排序
+    case_id: case_1678065
+    case_name: 演唱者-演唱者名称排序
+    AT元素引用:
+    - SortBtn
+    - MusicSingerGridItem_2
+- id: suite_音乐_窗口_演唱者_003_s1
+  name: '[180][smoke][acp1]演唱者-详情页面返回按钮'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: SublistDelegate
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: Artists
+      role: push button
+  annotation:
+    测试界面: 音乐-演唱者
+    测试功能: '[180][smoke][acp1]演唱者-详情页面返回按钮'
+    case_id: case_1678051
+    case_name: '[180][smoke][acp1]演唱者-详情页面返回按钮'
+    AT元素引用:
+    - SublistDelegate
+    - Artists
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_适配_键盘交互/音乐_适配_键盘交互.suite.yaml
+++ b/tests/at/yaml/音乐_适配_键盘交互/音乐_适配_键盘交互.suite.yaml
@@ -1,0 +1,46 @@
+name: 音乐_适配_键盘交互_suite
+app: deepin-music
+module: 音乐_适配_键盘交互
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_适配_键盘交互_001_s1
+  name: 快捷键-下一首Ctrl+Right
+  description: ''
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+right
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: 快捷键-下一首Ctrl+Right
+    case_id: case_1676927
+    case_name: 快捷键-下一首Ctrl+Right
+    AT元素引用:
+    - ItemD
+- id: suite_音乐_适配_键盘交互_006_s1
+  name: '[163]快捷键-重命名歌单F2'
+  description: ''
+  steps:
+  - action: keyboard_press
+    key: F2
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: SidebarItem
+      role: list item
+  annotation:
+    测试界面: 音乐-键盘交互
+    测试功能: '[163]快捷键-重命名歌单F2'
+    case_id: case_1676917
+    case_name: '[163]快捷键-重命名歌单F2'
+    AT元素引用:
+    - SidebarItem
+teardown:
+- action: session_stop

--- a/tests/at/yaml/音乐_音乐格式/音乐_音乐格式.suite.yaml
+++ b/tests/at/yaml/音乐_音乐格式/音乐_音乐格式.suite.yaml
@@ -1,0 +1,38 @@
+name: 音乐_音乐格式_suite
+app: deepin-music
+module: 音乐_音乐格式
+setup:
+- action: session_start
+  command: deepin-music
+  wait: 3.0
+suites:
+- id: suite_音乐_音乐格式_003_s1
+  name: '[318][core][acp1]格式支持-ac3'
+  description: ''
+  steps:
+  - action: mouse_click
+    selector:
+      name: Add Songs
+      role: push button
+  - action: file_dialog_select
+    path: ${TEST_FILES_DIR}/test.ac3
+  - action: mouse_click
+    selector:
+      name: Play All
+      role: push button
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: ItemD
+      role: list item
+  annotation:
+    测试界面: 音乐-音乐格式
+    测试功能: '[318][core][acp1]格式支持-ac3'
+    case_id: case_1676601
+    case_name: '[318][core][acp1]格式支持-ac3'
+    AT元素引用:
+    - Add Songs
+    - Play All
+    - ItemD
+teardown:
+- action: session_stop


### PR DESCRIPTION
## AT-SPI 测试套件 — deepin-music（音乐）

本 PR 为 deepin-music 自动生成 AT-SPI YAML 测试套件。

### 内容概要

- **51 个可自动化用例**，覆盖 16 个模块（主菜单、右键菜单、工具栏、歌曲导入、窗口操作、搜索、演唱者、专辑、我的收藏、我的歌单、所有音乐、键盘交互、音乐格式、任务栏、打开关闭、用户场景）
- **66 个不可自动化用例**（含原因说明）
- 运行时 AT-SPI 元素树：102 元素，29 已覆盖
- context-bundle 元素-功能-接口映射表
- cases_mapped.yaml 含 annotation（测试界面、测试功能、AT元素引用）

### 验证结果

- **Gate 3（映射完整性）**: PASS ✅
- **Gate 5（语义安全）**: PASS ✅

### 图谱说明

MCP 不可用，跳过 UI 图谱推导，仅基于运行时元素表，无源码全集对照。

### 提交范围

- `tests/at/yaml/elements.yaml`
- `tests/at/yaml/**/*.suite.yaml`
- `tests/at/at-tree.yaml` / `at-tree-annotated.yaml`
- `tests/at/context-bundle.md`
- `tests/at/cases_mapped.yaml`

> 中间产物（modules/、report.md）未随本 PR 提交，覆盖率报告通过 issue 附件交付。

## Summary by Sourcery

Establish comprehensive AT-SPI coverage and accessibility mappings for deepin-music.

New Features:
- Add an AT-SPI YAML test suite for deepin-music covering 51 automatable cases across core music-library, playback, search, playlist, toolbar, window, keyboard, format, and user-flow scenarios.
- Add accessibility element inventories and annotated UI trees for deepin-music to support automated test targeting.
- Add mappings between test cases, UI elements, interfaces, and feature contexts, including reasons for unsupported cases.

Enhancements:
- Document the deepin-music accessibility tree and element-to-function relationships for future test maintenance.

Tests:
- Add 51 automatable AT-SPI cases and record 66 cases that cannot be automated with their limitations.