### PR TITLE
fix: always recalculate position to prevent issues on window resize

### DIFF
--- a/src/music-player/albumlist/AlbumGridDelegate.qml
+++ b/src/music-player/albumlist/AlbumGridDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -121,10 +121,8 @@ Rectangle {
             }
             onHoveredChanged: {
                 if (hovered) {
-                    if (defaultY < 0) {
-                        var p = albumColumn.mapToItem(rootrectangle.parent, albumColumn.x, albumColumn.y)
-                        defaultY = p.y
-                    }
+                    var p = albumColumn.mapToItem(rootrectangle.parent, albumColumn.x, albumColumn.y)
+                    defaultY = p.y
                     albumHoverItemAnimator.start()
                 } else
                     albumExitItemAnimator.start()

--- a/src/music-player/singerlist/ArtistGridDelegate.qml
+++ b/src/music-player/singerlist/ArtistGridDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -120,10 +120,8 @@ Rectangle {
 
             onHoveredChanged: {
                 if (hovered) {
-                    if (defaultY < 0) {
-                        var p = artistColumn.mapToItem(rootrectangle.parent, artistColumn.x, artistColumn.y)
-                        defaultY = p.y
-                    }
+                    var p = artistColumn.mapToItem(rootrectangle.parent, artistColumn.x, artistColumn.y)
+                    defaultY = p.y
                     artistHoverItemAnimator.start()
                 } else {
                     artistExitItemAnimator.start()


### PR DESCRIPTION
Remove the conditional check that only calculated the position when defaultY was negative. Now the position is recalculated every time on hover, preventing layout issues when the window size changes.

fix: 每次都重新计算，防止窗口大小变化时有问题

移除仅在 defaultY 为负值时才计算位置的条件判断。
现在悬停时每次都重新计算位置，防止窗口大小变化时出现布局问题。

## Summary by Sourcery

Recalculate grid delegate positions on every hover to prevent layout issues when the window size changes.

Bug Fixes:
- Recalculate album and artist grid hover positions on every hover event to keep layouts correct after window resizing.

Chores:
- Update SPDX copyright ranges in the affected QML files.