### PR TITLE
fix: remove forced poll.h include workaround for VLC headers

### DIFF
--- a/src/libdmusic/CMakeLists.txt
+++ b/src/libdmusic/CMakeLists.txt
@@ -27,8 +27,6 @@ if(VLC_INCLUDE_DIR)
     include_directories(${VLC_INCLUDE_DIR}/vlc)
   endif()
 endif()
-# VLC headers use poll() without including poll.h; force-include it
-add_definitions(-include poll.h)
 if(EXISTS "/runtime/include/vlc")
   include_directories(/runtime/include/vlc)
   include_directories(/runtime/include/vlc/plugins)


### PR DESCRIPTION
The `add_definitions(-include poll.h)` was a workaround because VLC headers call poll() without including poll.h. Drop the workaround from src/libdmusic/CMakeLists.txt along with its explanatory comment.

fix: 移除 VLC 头文件强制包含 poll.h 的 workaround

此前由于 VLC 头文件调用 poll() 但未包含 poll.h，通过
`add_definitions(-include poll.h)` 强制包含以绕过该问题。
现从 src/libdmusic/CMakeLists.txt 中移除该 workaround 及对应注释。

msys2 中 vlc 已经修复了这个问题，现在不需要了

## Summary by Sourcery

Remove the obsolete VLC `poll.h` include workaround from the libdmusic build configuration.

Enhancements:
- Remove the obsolete forced inclusion of `poll.h` from the VLC build configuration now that the dependency provides the required declaration.

Build:
- Simplify the libdmusic CMake configuration by dropping the deprecated VLC header workaround.