### PR TITLE
fix: correct QML signal handler syntax in WindowTitlebar

### DIFF
--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -342,7 +342,7 @@ TitleBar {
                     y: 50
 
                     visible: false
-                    function onSearchItemTriggered(value, type) {
+                    onSearchItemTriggered: function(value, type) {
                         titleBar.searchItemTriggered(value, type)
                         searchEdit.text = value
                         visible = false


### PR DESCRIPTION
Replace the deprecated `function onSignal(...)` form with the proper `onSignal: function(...)` syntax for the searchItemTriggered handler in SearchResultDialog. The old form is not supported by newer QML engines and prevented the handler from being invoked.

fix: 修正 WindowTitlebar 中的 QML 信号处理器语法

将 SearchResultDialog 中 searchItemTriggered 信号处理器由已弃用的 `function onSignal(...)` 形式改为正确的 `onSignal: function(...)` 语法。 旧写法在新版 QML 引擎中不受支持，会导致处理器无法被正常调用。

## Summary by Sourcery

Bug Fixes:
- Correct the QML search item signal handler syntax so it is invoked by newer QML engines.