### PR TITLE
refactor: remove Windows start menu shortcut creation logic

### DIFF
--- a/src/libdmusic/player/winsmtc.cpp
+++ b/src/libdmusic/player/winsmtc.cpp
@@ -7,17 +7,10 @@
 #ifdef Q_OS_WIN
 
 #include <QDebug>
-#include <QUrl>
 #include <QFileInfo>
 #include <QFile>
-#include <QDir>
-#include <QStandardPaths>
 #include <roapi.h>
 #include <windows.storage.streams.h>
-#include <shlobj.h>
-#include <shobjidl.h>
-#include <propkey.h>
-#include <propvarutil.h>
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -89,86 +82,6 @@ private:
     LONG m_ref;
     WinSMTC *m_owner;
 };
-
-void WinSMTC::ensureStartMenuShortcut()
-{
-    wchar_t exePath[MAX_PATH];
-    GetModuleFileNameW(NULL, exePath, MAX_PATH);
-    QString appDir = QFileInfo(QString::fromWCharArray(exePath)).absolutePath();
-
-    PWSTR programsPath = nullptr;
-    if (FAILED(SHGetKnownFolderPath(FOLDERID_Programs, 0, NULL, &programsPath))) {
-        qDebug() << "WinSMTC: Failed to get Programs folder path";
-        return;
-    }
-    QString programsDir = QString::fromWCharArray(programsPath);
-    CoTaskMemFree(programsPath);
-
-    // Remove old English-name shortcuts
-    QDir().remove(programsDir + QStringLiteral("\\Deepin Music\\Deepin Music Player.lnk"));
-    QDir().remove(programsDir + QStringLiteral("\\Deepin Music\\deepin-music.lnk"));
-    QDir().rmdir(programsDir + QStringLiteral("\\Deepin Music"));
-
-    // Create new Chinese-name shortcut
-    QString shortcutDir = programsDir + QStringLiteral("\\深度音乐");
-    QDir().mkpath(shortcutDir);
-    QString shortcutPath = shortcutDir + QStringLiteral("\\深度音乐.lnk");
-
-    // Only pair CoUninitialize when we actually own the initialization
-    HRESULT coInit = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
-    if (FAILED(coInit) && coInit != RPC_E_CHANGED_MODE) {
-        qWarning() << "WinSMTC: CoInitializeEx failed:" << QString::number(coInit, 16);
-        return;
-    }
-    bool coOwned = SUCCEEDED(coInit);
-
-    ComPtr<IShellLinkW> shellLink;
-    HRESULT hr = CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER,
-                                  IID_PPV_ARGS(&shellLink));
-    if (FAILED(hr)) {
-        qDebug() << "WinSMTC: Failed to create IShellLink:" << QString::number(hr, 16);
-        if (coOwned) CoUninitialize();
-        return;
-    }
-
-    shellLink->SetPath(exePath);
-    shellLink->SetDescription(L"深度音乐");
-    shellLink->SetWorkingDirectory(appDir.toStdWString().c_str());
-
-    QString iconPath = appDir + QStringLiteral("\\dsg\\img\\deepin-music.ico");
-    if (QFileInfo::exists(iconPath)) {
-        shellLink->SetIconLocation(iconPath.toStdWString().c_str(), 0);
-    }
-
-    // Set AUMID via IPropertyStore
-    ComPtr<IPropertyStore> propStore;
-    hr = shellLink.As(&propStore);
-    if (SUCCEEDED(hr) && propStore) {
-        PROPVARIANT propVar;
-        PropVariantInit(&propVar);
-        propVar.vt = VT_LPWSTR;
-        // Use a heap-allocated copy since PropVariantClear will free it
-        propVar.pwszVal = static_cast<LPWSTR>(CoTaskMemAlloc(sizeof(WINSMTC_AUMID)));
-        if (propVar.pwszVal) {
-            memcpy(propVar.pwszVal, WINSMTC_AUMID, sizeof(WINSMTC_AUMID));
-            propStore->SetValue(PKEY_AppUserModel_ID, propVar);
-            propStore->Commit();
-            PropVariantClear(&propVar);
-        }
-    }
-
-    // Save the shortcut
-    ComPtr<IPersistFile> persistFile;
-    hr = shellLink.As(&persistFile);
-    if (SUCCEEDED(hr) && persistFile) {
-        hr = persistFile->Save(shortcutPath.toStdWString().c_str(), TRUE);
-        if (FAILED(hr)) {
-            qWarning() << "WinSMTC: Failed to save shortcut:" << QString::number(hr, 16);
-        }
-    }
-
-    if (coOwned) CoUninitialize();
-}
 
 WinSMTC::WinSMTC(QObject *parent) : QObject(parent) {}
 

--- a/src/libdmusic/player/winsmtc.h
+++ b/src/libdmusic/player/winsmtc.h
@@ -16,8 +16,6 @@
 #include <windows.media.h>
 #include <systemmediatransportcontrolsinterop.h>
 
-#define WINSMTC_AUMID L"Deepin.DeepinMusicPlayer"
-
 class WinSMTC : public QObject
 {
     Q_OBJECT
@@ -27,8 +25,6 @@ public:
 
     bool initialize(HWND hwnd);
     void shutdown();
-
-    static void ensureStartMenuShortcut();
 
     void updateMetadata(const QString &title,
                        const QString &artist,

--- a/src/music-player/main.cpp
+++ b/src/music-player/main.cpp
@@ -91,18 +91,6 @@ int main(int argc, char *argv[])
     wchar_t exePath[MAX_PATH];
     GetModuleFileNameW(NULL, exePath, MAX_PATH);
     QString appDir = QFileInfo(QString::fromWCharArray(exePath)).absolutePath();
-    if (qgetenv("QT_PLUGIN_PATH").isEmpty()) {
-        qputenv("QT_PLUGIN_PATH", (appDir + "/plugins").toUtf8());
-    }
-    if (qgetenv("QT_QPA_PLATFORM_PLUGIN_PATH").isEmpty()) {
-        qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", (appDir + "/plugins/platforms").toUtf8());
-    }
-    if (qgetenv("QML2_IMPORT_PATH").isEmpty()) {
-        qputenv("QML2_IMPORT_PATH", (appDir + "/qml").toUtf8());
-    }
-    if (qgetenv("QT_QML_IMPORT_PATH").isEmpty()) {
-        qputenv("QT_QML_IMPORT_PATH", (appDir + "/qml").toUtf8());
-    }
     if (qgetenv("DSG_DATA_DIRS").isEmpty()) {
         qputenv("DSG_DATA_DIRS", (appDir + "/dsg").toUtf8());
     }
@@ -143,7 +131,6 @@ int main(int argc, char *argv[])
         }
         FreeLibrary(shell32);
     }
-    WinSMTC::ensureStartMenuShortcut();
 #endif
 
     QGuiApplication *app = new QGuiApplication(argc, argv);


### PR DESCRIPTION
Remove ensureStartMenuShortcut() which created a "深度音乐.lnk" shortcut in the Windows Start Menu Programs folder on launch, along with its declaration in winsmtc.h, the call site in main.cpp, the WINSMTC_AUMID macro, and the now-unused includes (QDir, shlobj, shobjidl, propkey, propvarutil).

refactor: 移除 Windows 开始菜单快捷方式创建逻辑

移除 ensureStartMenuShortcut() 函数,该函数原在应用启动时于 Windows 开始菜单 Programs 目录下创建"深度音乐.lnk"快捷方式;同时移除 winsmtc.h 中的声明、
main.cpp 中的调用、WINSMTC_AUMID 宏,以及随之不再使用的头文件包含
(QDir、shlobj、shobjidl、propkey、propvarutil)。

创建开始菜单快捷方式应该交给安装包来做

## Summary by Sourcery

Remove runtime creation of the Windows Start Menu shortcut and the associated unused integration code.

Enhancements:
- Remove application-managed Windows Start Menu shortcut creation and its associated Windows shell integration code.
- Retain Start Menu shortcut ownership with the installer rather than creating shortcuts at application launch.