### PR TITLE
fix: clean up partial WinSMTC initialization in shutdown

### DIFF
--- a/src/libdmusic/player/winsmtc.cpp
+++ b/src/libdmusic/player/winsmtc.cpp
@@ -235,7 +235,11 @@ bool WinSMTC::initialize(HWND hwnd)
 
 void WinSMTC::shutdown()
 {
-    if (!m_initialized) return;
+    // Keep shutdown idempotent while also cleaning up partial initialization.
+    if (!m_initialized && !m_roInitialized
+            && !m_smtc.Get() && !m_updater.Get() && !m_musicProps.Get()) {
+        return;
+    }
 
     if (m_smtc) {
         // Unregister the ButtonPressed handler first to avoid use-after-free


### PR DESCRIPTION
shutdown() early-returned when m_initialized was false, skipping cleanup of partial state. Now cleanup runs if any of SMTC/updater/props/RO init exist.

shutdown() 在 m_initialized 为 false 时直接返回，跳过了部分初始化状态的清理。 现在只要 SMTC/更新器/属性/RO 初始化任一存在，清理逻辑均会执行。

Log: 修复 WinSMTC 部分初始化时资源未清理的问题
Influence: 修复 Windows 下初始化中途失败时 SMTC 资源泄漏，避免系统媒体控件残留。

## Summary by Sourcery

Clean up WinSMTC state when initialization fails partway through.

Bug Fixes:
- Ensure WinSMTC shutdown cleans up resources left by partial initialization, preventing Windows media-control resource leaks and stale system controls.

Enhancements:
- Preserve idempotent shutdown behavior while recognizing partially initialized state.