### PR TITLE
fix(lyrics): parse repeated LRC timestamps as separate lines

### DIFF
--- a/src/libdmusic/core/lyricanalysis.cpp
+++ b/src/libdmusic/core/lyricanalysis.cpp
@@ -172,10 +172,8 @@ void LyricAnalysis::parseLyric(const QString &str)
         }
 
         if (timestampCount > 1) {
-            // 逐字歌词格式：[mm:ss.xx]字[mm:ss.xx]字...
-            QVector<LyricWord> words;
+            QVector<QPair<qint64, QString> > parsedWords;
             qint64 firstTime = -1;
-            QString fullText;
             pos = 0;
             while ((pos = wordRx.indexIn(line, pos)) != -1) {
                 auto timeStr = wordRx.capturedTexts()[1];
@@ -183,13 +181,43 @@ void LyricAnalysis::parseLyric(const QString &str)
                 qint64 time = parseTimeStamp(timeStr);
                 if (time >= 0) {
                     if (firstTime < 0) firstTime = time;
-                    words.push_back({time, textStr});
-                    fullText += textStr;
+                    parsedWords.push_back({time, textStr});
                     qCDebug(dmMusic) << "Parsed word - Time:" << timeStr << "ms:" << time << "Text:" << textStr;
                 }
                 pos += wordRx.matchedLength();
             }
-            if (!words.isEmpty() && firstTime >= 0) {
+
+            // Standard LRC allows the same lyric to have multiple timestamps:
+            // [00:01.00][00:02.00]same lyric
+            // Treat the line as word-timed when any intermediate timestamp
+            // is followed by actual lyric text.
+            bool repeatedLine = false;
+            for (int i = 0; i + 1 < parsedWords.size(); ++i) {
+                if (!parsedWords[i].second.trimmed().isEmpty()) {
+                    repeatedLine = false;
+                    break;
+                }
+                repeatedLine = true;
+            }
+
+            if (repeatedLine && parsedWords.size() > 1) {
+                const QString lyricText = parsedWords.last().second.trimmed();
+                if (lyricText.isEmpty()) {
+                    continue;
+                }
+                for (const auto &item : parsedWords) {
+                    tmp.push_back({item.first, lyricText});
+                    tmpWord.push_back(QVector<LyricWord>());
+                }
+            } else if (!parsedWords.isEmpty() && firstTime >= 0) {
+                // Word-timed lyric format: [mm:ss.xx]word[mm:ss.xx]word...
+                QVector<LyricWord> words;
+                QString fullText;
+                words.reserve(parsedWords.size());
+                for (const auto &item : parsedWords) {
+                    words.push_back({item.first, item.second});
+                    fullText += item.second;
+                }
                 tmp.push_back({firstTime, fullText});
                 tmpWord.push_back(words);
                 qCDebug(dmMusic) << "Parsed lyric line with" << words.size() << "words - Time:" << firstTime << "Text:" << fullText;

--- a/tests/libdmusic-test/test_lyricanalysis.cpp
+++ b/tests/libdmusic-test/test_lyricanalysis.cpp
@@ -281,6 +281,46 @@ TEST(LyricAnalysisTest, wordTimingHasCorrectTimes)
     EXPECT_EQ(words[4].text, QStringLiteral(""));
 }
 
+TEST(LyricAnalysisTest, parsesRepeatedTimestampsAsSeparateLines)
+{
+    TempLrcFile tempLrc("[00:01.00][00:02.00]same line\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+
+    ASSERT_EQ(la.getCount(), 2);
+    EXPECT_EQ(la.getPostion(0), 1000);
+    EXPECT_EQ(la.getPostion(1), 2000);
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("same line"));
+    EXPECT_EQ(la.getLineAt(1), QStringLiteral("same line"));
+    EXPECT_FALSE(la.hasWordTiming(0));
+    EXPECT_FALSE(la.hasWordTiming(1));
+}
+
+TEST(LyricAnalysisTest, trimsRepeatedTimestampLyricText)
+{
+    TempLrcFile tempLrc("[00:01.00][00:02.00] same line\r\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+
+    ASSERT_EQ(la.getCount(), 2);
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("same line"));
+    EXPECT_EQ(la.getLineAt(1), QStringLiteral("same line"));
+}
+
+TEST(LyricAnalysisTest, ignoresRepeatedTimestampsWithoutLyricText)
+{
+    TempLrcFile tempLrc(
+        "[00:01.00][00:02.00]\n"
+        "[00:03.00][00:04.00]   \r\n"
+        "[00:05.00]valid line\n");
+    LyricAnalysis la;
+    la.setFromFile(tempLrc.path());
+
+    ASSERT_EQ(la.getCount(), 1);
+    EXPECT_EQ(la.getPostion(0), 5000);
+    EXPECT_EQ(la.getLineAt(0), QStringLiteral("valid line"));
+}
+
 TEST(LyricAnalysisTest, simpleLyricsHaveNoWordTiming)
 {
     TempLrcFile tempLrc("[00:01.20]first line\n[00:03.50]second line\n");


### PR DESCRIPTION
Lines like [00:01.00][00:02.00]same line were misparsed as word-timed lyrics. Now only treat a line as word-timed when each intermediate timestamp is followed by lyric text.

形如 [00:01.00][00:02.00]同一句歌词 的多时间标签行，此前被误判为逐字歌词。
现在只有当每个中间时间标签后都跟有歌词文本时，才按逐字歌词解析。
多个时间标签会生成多条同文本的独立歌词行。

Log: 修复重复时间标签 LRC 行被误判为逐字歌词的问题
Influence: 修复后带多个时间标签的歌词行按多行独立显示，逐字歌词解析不再被误触发，歌词同步更准确。

## Summary by Sourcery

Fix LRC parsing so repeated timestamps produce independent synchronized lyric lines without triggering word timing.

Bug Fixes:
- Correctly parse LRC lines with repeated timestamps as separate lyric lines instead of mistaking them for word-timed lyrics.
- Ignore repeated-timestamp entries that contain no lyric text.

Tests:
- Add coverage for repeated timestamps, whitespace trimming, and empty repeated-timestamp entries.