### PR TITLE
fix: correct search dropdown position offset

### DIFF
--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -338,8 +338,10 @@ TitleBar {
                 id: searchResultComponent
                 SearchResultDialog {
                     width: 360
-                    x: searchEdit.x - (width - searchEdit.width) / 2
-                    y: 50
+                    parent: titleBar
+                    x: searchEdit.mapToItem(titleBar, 0, 0).x
+                       - (width - searchEdit.width) / 2
+                    y: searchEdit.mapToItem(titleBar, 0, searchEdit.height).y + 4
 
                     visible: false
                     onSearchItemTriggered: function(value, type) {


### PR DESCRIPTION
## Root Cause Analysis

The search result dropdown (`SearchResultDialog`, a QML `Popup`) was misaligned with the search box. The root cause is a **coordinate system mismatch**: `searchEdit.x` is a local coordinate relative to `titleRowLayout`, but the `Popup` is rendered in the Overlay layer which uses a different coordinate system. Using `searchEdit.x` directly for the Popup's `x` position — and a hardcoded `y: 50` — caused the dropdown to drift from the search box, especially when window width or title bar layout changed.

**Key evidence:**
- `WindowTitlebar.qml:341` — `x: searchEdit.x - (width - searchEdit.width) / 2` uses local coordinate without conversion
- `WindowTitlebar.qml:342` — `y: 50` hardcoded, doesn't adapt to layout changes
- `searchEdit` is a child of `titleRowLayout`; `SearchResultDialog` is a `Popup` rendered in Overlay — different coordinate systems

## Fix

Set `parent: titleBar` on the Popup and use `mapToItem(titleBar, ...)` to convert `searchEdit`'s coordinates into `titleBar`'s coordinate system before positioning:

```qml
parent: titleBar
x: searchEdit.mapToItem(titleBar, 0, 0).x
   - (width - searchEdit.width) / 2
y: searchEdit.mapToItem(titleBar, 0, searchEdit.height).y + 4
```

## Change Safety Assessment

- **Risk level**: Low
- **Scope**: Only 3 property lines in `WindowTitlebar.qml` (`searchResultComponent`)
- **No business logic changes**: search, data flow, and click handlers unaffected
- `mapToItem` is a standard QML coordinate conversion method; `parent: titleBar` anchors the Popup to the root element with a stable lifecycle

## Business Impact

Affects only the display position of the search result dropdown. Users searching for songs/artists/albums will see the dropdown correctly aligned below the search box regardless of window size.

## Verification Suggestion

1. Open deepin-music with songs in the library
2. Click the search box, type an album name that matches imported songs
3. Verify the dropdown appears directly below and centered on the search box
4. Resize the window and repeat — dropdown should stay aligned

---

## 根因分析

搜索关联栏（`SearchResultDialog`，QML `Popup`）与搜索框位置错位。根本原因是**坐标系不一致**：`searchEdit.x` 是相对于 `titleRowLayout` 的局部坐标，而 `Popup` 显示在 Overlay 层使用不同坐标系。直接使用 `searchEdit.x` 定位 + 硬编码 `y: 50`，导致下拉框偏移，窗口宽度变化时更明显。

**关键证据：**
- `WindowTitlebar.qml:341` — `x: searchEdit.x - ...` 直接使用局部坐标，未做转换
- `WindowTitlebar.qml:342` — `y: 50` 硬编码，不随布局变化
- `searchEdit` 是 `titleRowLayout` 子项，`SearchResultDialog` 是 Overlay 层 Popup，坐标系不同

## 修复方案

将 Popup 的 `parent` 设为 `titleBar`，用 `mapToItem(titleBar, ...)` 将 `searchEdit` 坐标转换到 `titleBar` 坐标系后定位。

## 改动安全评估

- **风险等级**：低
- **范围**：仅 `WindowTitlebar.qml` 中 `searchResultComponent` 的 3 行属性
- **无业务逻辑变更**：搜索、数据流、点击事件不受影响
- `mapToItem` 是 QML 标准坐标转换方法；`parent: titleBar` 锚定到根元素，生命周期稳定

## 业务影响范围

仅影响搜索结果下拉框的显示位置。用户搜索歌曲/歌手/专辑时，下拉框将正确对齐在搜索框下方，不受窗口大小影响。

## 验证建议

1. 打开音乐应用，确保库中有歌曲
2. 点击搜索框，输入已导入歌曲的专辑名
3. 验证下拉框出现在搜索框正下方居中对齐
4. 调整窗口大小后重复验证——下拉框应保持对齐

## Summary by Sourcery

Bug Fixes:
- Correct the search results dropdown positioning so it remains aligned below and centered with the search field across window sizes and title bar layout changes.