### PR TITLE
refactor: refactor VLC argument handling to use dynamic parameters

### DIFF
--- a/src/libdmusic/player/vlc/Common.cpp
+++ b/src/libdmusic/player/vlc/Common.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,16 +17,14 @@ QStringList VlcCommon::args()
     } else {
         qCDebug(dmMusic) << "VLC args not found, using default args";
         args_list << "--intf=dummy"
-                  << "--no-media-library"
-                  << "--no-stats"
-                  << "--no-osd"
-                  << "--no-loop"
-                  << "--no-video-title-show"
-                  << "--drop-late-frames"
-                  // Disable VLC's TagLib metadata plugin: dmusic parses tags with
-                  // TagLib 2, while this plugin links TagLib 1, causing a
-                  // same-process symbol conflict that crashes on playback.
-                  << "--no-taglib";
+                  << "--no-media-library"     // 禁用媒体库
+                  << "--no-stats"             // 禁用统计信息
+                  << "--no-spu"               // 禁用子画面
+                  << "--no-osd"               // 禁用屏幕显示（OSD）
+                  << "--no-loop"              // 禁止全部循环
+                  << "--no-video-title-show"  // 禁用在视频上显示媒体标题
+                  << "--drop-late-frames"     // 丢弃延迟的帧
+                  << "--no-video";            // 禁用视频输出
     }
 
     qCDebug(dmMusic) << "VLC return args:" << args_list;

--- a/src/libdmusic/player/vlc/Instance.cpp
+++ b/src/libdmusic/player/vlc/Instance.cpp
@@ -85,7 +85,6 @@ VlcInstance::VlcInstance(const QStringList &args,
       _status(false),
       _logLevel(Vlc::ErrorLevel)
 {
-    Q_UNUSED(args)
     vlc_new_function vlc_new = (vlc_new_function)DynamicLibraries::instance()->resolve("libvlc_new");
     vlc_set_user_agent_function vlc_set_user_agent = (vlc_set_user_agent_function)DynamicLibraries::instance()->resolve("libvlc_set_user_agent");
     vlc_set_app_id_function vlc_set_app_id = (vlc_set_app_id_function)DynamicLibraries::instance()->resolve("libvlc_set_app_id");
@@ -99,14 +98,15 @@ VlcInstance::VlcInstance(const QStringList &args,
         qCDebug(dmMusic) << "VLC plugin path set to:" << pluginPath;
     }
 #endif
-
-    // 禁用不需要的模块（音乐播放器不需要视频、字幕等功能）
-    const char *vlcArgs[] = {
-        "--no-video",            // 禁用视频输出
-        "--no-stats",            // 禁用统计信息
-        "--no-spu",              // 禁用字幕处理单元
-    };
-    _vlcInstance = vlc_new(sizeof(vlcArgs) / sizeof(vlcArgs[0]), vlcArgs);
+    QVector<QByteArray> vlcArgData;
+    vlcArgData.reserve(args.size());
+    QVector<const char*> vlcArgs;
+    vlcArgs.reserve(args.size());
+    for (const QString& s : args) {
+        vlcArgData.append(s.toUtf8());
+        vlcArgs.append(vlcArgData.last().constData());
+    }
+    _vlcInstance = vlc_new(static_cast<int>(vlcArgs.size()), vlcArgs.data());
     if (_vlcInstance) {
         qCDebug(dmMusic) << "VLC instance created successfully";
         vlc_set_user_agent(_vlcInstance, DmGlobal::getAppName().toStdString().c_str(), "");//name

--- a/tests/libdmusic-test/test_vlc.cpp
+++ b/tests/libdmusic-test/test_vlc.cpp
@@ -58,7 +58,6 @@ TEST(VlcCommonTest, argsReturnsDefaultArgs)
     const QStringList args = VlcCommon::args();
     EXPECT_FALSE(args.isEmpty());
     EXPECT_TRUE(args.contains("--intf=dummy"));  // 默认参数
-    EXPECT_TRUE(args.contains("--no-taglib"));  // disable VLC TagLib plugin to avoid symbol conflict with dmusic TagLib 2
 }
 
 TEST(VlcEnumsTest, constructs)


### PR DESCRIPTION
- Make VLC parameters configurable instead of hardcoded
- Update copyright year range to 2023-2026
- Improve comments for VLC options
- Remove unused Q_UNUSED macro

refactor: 重构VLC参数处理，使用动态参数

- 使VLC参数可配置而不是硬编码
- 更新版权年份范围为2023-2026
- 改进VLC选项的注释
- 移除未使用的Q_UNUSED宏


之前 `VlcCommon::args()` 传递过去的参数被 `Q_UNUSED(args)`忽略了，并没有被使用，现在修改为使用 `VlcCommon::args()`
@wyu71 我翻了几个版本的 vlc 文档，都没有 `--no-taglib` 这个参数，参考 https://wiki.videolan.org/VLC_command-line_help/

## Summary by Sourcery

Use configurable VLC arguments during instance initialization and align the default playback options with supported VLC parameters.

Bug Fixes:
- Ensure configured VLC arguments are passed through when creating the VLC instance instead of being ignored.

Enhancements:
- Replace hardcoded VLC initialization options with the dynamically supplied argument list and update the default options and related comments.

Tests:
- Update VLC argument tests to reflect the revised default options.

Chores:
- Update the copyright year range to 2023–2026 and remove the unused argument suppression.