### PR TITLE
fix: add keyboard navigation for search dropdown

### DIFF
--- a/src/music-player/dialogs/SearchResultDialog.qml
+++ b/src/music-player/dialogs/SearchResultDialog.qml
@@ -12,11 +12,48 @@ Popup {
     property string pattern: ""
 
     property int itemHeight: 40
+    property int selectedIndex: -1
+    property int resultCount: (songList == null ? 0 : songList.length) + artistModel.count + albumModel.count
 
     signal searchItemTriggered(string value, int type)
 
     id: searchResultRect
     width: 360
+
+    // Moves the keyboard selection by offset, wrapping around available results.
+    function moveSelection(offset) {
+        if (resultCount <= 0)
+            return
+
+        if (selectedIndex < 0) {
+            selectedIndex = offset > 0 ? 0 : resultCount - 1
+            return
+        }
+
+        selectedIndex = (selectedIndex + offset + resultCount) % resultCount
+    }
+
+    // Activates the currently selected result and returns whether activation succeeded.
+    function activateSelection() {
+        if (selectedIndex < 0 || selectedIndex >= resultCount)
+            return false
+
+        var songCount = songList == null ? 0 : songList.length
+        if (selectedIndex < songCount) {
+            searchItemTriggered(songList[selectedIndex], 0)
+            return true
+        }
+
+        var artistIndex = selectedIndex - songCount
+        if (artistIndex < artistModel.count) {
+            searchItemTriggered(artistModel.get(artistIndex).name, 1)
+            return true
+        }
+
+        searchItemTriggered(albumModel.get(artistIndex - artistModel.count).name, 2)
+        return true
+    }
+
     height: (songList == null ? 0 : songList.length + artistModel.count + albumModel.count) * itemHeight + 110
     leftPadding: 8
     rightPadding: 8
@@ -66,10 +103,17 @@ Popup {
         id: resultItemTextDelegate
         Rectangle {
             id: itemRect
+            property int resultIndex: index
             width: parent.width
             height: itemHeight
             radius: 6
             color: "#00000000"
+            Rectangle {
+                anchors.fill: parent
+                radius: parent.radius
+                color: palette.highlight
+                visible: searchResultRect.selectedIndex === itemRect.resultIndex
+            }
             Row {
                 width: parent.width
                 anchors.verticalCenter: parent.verticalCenter
@@ -104,10 +148,20 @@ Popup {
         id: resultItemImgDelegate
         Rectangle {
             id: itemRect
+            property int resultIndex: (model.type === "album"
+                                       ? (searchResultRect.songList == null ? 0 : searchResultRect.songList.length)
+                                         + searchResultRect.artistModel.count
+                                       : (searchResultRect.songList == null ? 0 : searchResultRect.songList.length)) + index
             width: parent.width
             height: itemHeight
             radius: 6
             color: "#00000000"
+            Rectangle {
+                anchors.fill: parent
+                radius: parent.radius
+                color: palette.highlight
+                visible: searchResultRect.selectedIndex === itemRect.resultIndex
+            }
             Row {
                 width: parent.width
                 anchors.verticalCenter: parent.verticalCenter

--- a/src/music-player/mainwindow/WindowTitlebar.qml
+++ b/src/music-player/mainwindow/WindowTitlebar.qml
@@ -272,10 +272,27 @@ TitleBar {
                 Layout.alignment: Qt.AlignCenter
                 placeholder: qsTr("Search")
                 enabled: Presenter.isExistMeta()
+                Keys.onDownPressed: function(event) {
+                    var searchResDlg = searchResultLoader.item
+                    if (!searchResDlg || !searchResDlg.visible)
+                        return
+                    searchResDlg.moveSelection(1)
+                    event.accepted = true
+                }
+                Keys.onUpPressed: function(event) {
+                    var searchResDlg = searchResultLoader.item
+                    if (!searchResDlg || !searchResDlg.visible)
+                        return
+                    searchResDlg.moveSelection(-1)
+                    event.accepted = true
+                }
                 Keys.onReturnPressed: {
                     //console.log("SearchEdit: Keys.onEnterPressed....")
                     var searchResDlg = searchResultLoader.item
                     if (text.length <= 0 || !searchResDlg || searchResDlg.songList == null)
+                        return
+
+                    if (searchResDlg.visible && searchResDlg.activateSelection())
                         return
 
                     var type = -1
@@ -372,6 +389,7 @@ TitleBar {
         }
 
         var searchResDlg = searchResultLoader.item
+        searchResDlg.selectedIndex = -1
         searchResDlg.songList = []
         searchResDlg.artistModel.clear()
         searchResDlg.albumModel.clear()


### PR DESCRIPTION
## Root Cause Analysis

The search result dropdown (`SearchResultDialog.qml`) in deepin-music had no keyboard navigation mechanism at all — no arrow key handlers, no selection index tracking, no focus management. The `SearchEdit` in `WindowTitlebar.qml` only handled the Return key; arrow keys were consumed by the TextField's default cursor movement behavior and never reached the dropdown Popup. As a result, users could only select search results via mouse, with no keyboard support.

Key evidence:
- `SearchResultDialog.qml`: Column + Repeater + MouseArea structure with only hover/click interaction, no `Keys` handlers or `currentIndex` property
- `WindowTitlebar.qml:275-290`: `SearchEdit` had only `Keys.onReturnPressed`, no `Keys.onDownPressed`/`Keys.onUpPressed`

## Fix

Added keyboard navigation directly on the existing Popup + Repeater structure:
- In `SearchResultDialog.qml`: added `selectedIndex` property, `resultCount` binding, `moveSelection(offset)` for arrow key navigation with boundary wrapping, `activateSelection()` to trigger the selected item, and highlight Rectangles in both text and image delegates
- In `WindowTitlebar.qml`: added `Keys.onDownPressed`/`Keys.onUpPressed` on `SearchEdit` to navigate the dropdown when visible (intercepting arrow keys with `event.accepted = true`), extended `Keys.onReturnPressed` to activate the selected item first, and reset `selectedIndex = -1` when search results are refreshed

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Pure additive change (+69 lines, 0 deletions); no existing logic modified or removed
- All new symbols (`selectedIndex`, `moveSelection`, `activateSelection`, `Keys.onDownPressed`/`onUpPressed`) are referenced only within the two changed files — no external callers need updating
- `Keys.onReturnPressed` uses a guard pattern: when no item is selected (`selectedIndex < 0`), behavior falls back to the original logic unchanged

### Business Impact Scope

Affects the music app's search functionality. Users can now use ↑/↓ arrow keys to navigate search result entries (songs, artists, albums) in the dropdown and press Enter to select. Mouse hover and click interactions remain unchanged. No other features or modules are affected.

### Verification Suggestion

Test arrow key navigation (up/down) in the search result dropdown with results containing songs, artists, and albums. Verify Enter activates the highlighted item. Confirm mouse hover/click still works without regression.

---

## 根因分析

deepin-music 的搜索结果下拉列表（`SearchResultDialog.qml`）完全没有键盘导航机制——无方向键处理器、无选中索引追踪、无焦点管理。`WindowTitlebar.qml` 中的 `SearchEdit` 仅处理回车键，方向键被 TextField 默认光标移动行为消费，无法传递到下拉列表 Popup。因此用户只能通过鼠标选择搜索结果，键盘操作完全无效。

关键证据：
- `SearchResultDialog.qml`：使用 Column + Repeater + MouseArea 结构，仅有 hover/click 交互，无 `Keys` 处理器或 `currentIndex` 属性
- `WindowTitlebar.qml:275-290`：`SearchEdit` 仅有 `Keys.onReturnPressed`，无 `Keys.onDownPressed`/`Keys.onUpPressed`

## 修复方案

在现有 Popup + Repeater 结构上直接添加键盘导航：
- `SearchResultDialog.qml`：新增 `selectedIndex` 属性、`resultCount` 绑定、`moveSelection(offset)` 实现方向键导航（含边界环绕）、`activateSelection()` 触发选中项，以及两个 delegate 中的高亮 Rectangle
- `WindowTitlebar.qml`：在 `SearchEdit` 添加 `Keys.onDownPressed`/`Keys.onUpPressed` 在搜索结果可见时拦截方向键并调用 `moveSelection`，扩展 `Keys.onReturnPressed` 前置 `activateSelection()` 检查，并在搜索结果刷新时重置 `selectedIndex = -1`

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 纯增量改动（+69 行，0 行删除），不修改或移除任何现有逻辑
- 所有新增 symbol（`selectedIndex`、`moveSelection`、`activateSelection`、`Keys.onDownPressed`/`onUpPressed`）引用均在两个改动文件内闭合，无外部调用方需同步
- `Keys.onReturnPressed` 采用守卫模式：无选中项时（`selectedIndex < 0`）回退到原有逻辑，行为不变

### 业务影响范围

影响音乐应用的搜索功能。用户现在可以使用 ↑/↓ 方向键在搜索结果下拉列表中导航条目（歌曲、歌手、专辑），按回车键选中。鼠标悬停和点击交互不受影响。不涉及其他功能模块。

### 验证建议

测试搜索结果下拉列表中方向键（上/下）导航，结果包含歌曲、歌手、专辑三类条目。验证回车键激活高亮项。确认鼠标悬停和点击功能无回归。

## Summary by Sourcery

Enable keyboard navigation and selection for the search results dropdown.

New Features:
- Add keyboard navigation for search results with wrapping up/down selection and Enter activation.
- Highlight the currently selected song, artist, or album result in the dropdown.

Bug Fixes:
- Enable keyboard-only selection of search results while preserving existing mouse interactions.